### PR TITLE
Add migration readiness CLI and schema hardening

### DIFF
--- a/mcp_server/storage/migrations/003_schema_hardening.sql
+++ b/mcp_server/storage/migrations/003_schema_hardening.sql
@@ -1,0 +1,60 @@
+-- Migration 003: Schema hardening and manifest backfill
+-- Ensures missing content tracking columns exist, enforces embedding uniqueness,
+-- and records manifest compatibility information.
+
+-- Phase 1: Add missing columns and indexes (idempotent)
+ALTER TABLE files ADD COLUMN IF NOT EXISTS content_hash TEXT;
+ALTER TABLE files ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE;
+ALTER TABLE files ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+CREATE INDEX IF NOT EXISTS idx_files_content_hash ON files(content_hash);
+CREATE INDEX IF NOT EXISTS idx_files_deleted ON files(is_deleted);
+CREATE INDEX IF NOT EXISTS idx_files_relative_path ON files(relative_path);
+CREATE UNIQUE INDEX IF NOT EXISTS files_repository_id_relative_path_key 
+  ON files(repository_id, relative_path);
+
+-- Phase 2: Ensure file_moves table exists with content hash tracking
+CREATE TABLE IF NOT EXISTS file_moves (
+    id INTEGER PRIMARY KEY,
+    repository_id INTEGER NOT NULL,
+    old_relative_path TEXT NOT NULL,
+    new_relative_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    moved_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    move_type TEXT CHECK(move_type IN ('rename', 'relocate', 'restructure')),
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_moves_content_hash ON file_moves(content_hash);
+CREATE INDEX IF NOT EXISTS idx_moves_timestamp ON file_moves(moved_at);
+CREATE INDEX IF NOT EXISTS idx_moves_old_path ON file_moves(old_relative_path);
+CREATE INDEX IF NOT EXISTS idx_moves_new_path ON file_moves(new_relative_path);
+
+-- Phase 3: Backfill newly added columns with safe defaults
+UPDATE files 
+SET content_hash = COALESCE(content_hash, hash, relative_path)
+WHERE content_hash IS NULL OR content_hash = '';
+
+UPDATE files 
+SET is_deleted = COALESCE(is_deleted, FALSE)
+WHERE is_deleted IS NULL;
+
+-- Phase 4: Enforce embedding uniqueness (deduplicate first)
+DELETE FROM embeddings
+WHERE rowid NOT IN (
+    SELECT MIN(rowid)
+    FROM embeddings
+    GROUP BY file_id, symbol_id, chunk_start, chunk_end
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_embeddings_unique_scope 
+  ON embeddings(file_id, symbol_id, chunk_start, chunk_end);
+
+-- Phase 5: Manifest compatibility metadata
+INSERT OR IGNORE INTO index_config (config_key, config_value, description) VALUES
+    ('manifest_version', '1.0', 'Index manifest compatibility version');
+
+-- Phase 6: Update schema version and migration log
+INSERT OR REPLACE INTO schema_version (version, description) 
+VALUES (3, 'Schema hardening and manifest backfill');
+
+INSERT INTO migrations (version_from, version_to, status) 
+VALUES (2, 3, 'completed');

--- a/tests/integration/test_migration_cli.py
+++ b/tests/integration/test_migration_cli.py
@@ -1,0 +1,70 @@
+"""Integration tests for migration maintenance CLI."""
+
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from mcp_server.cli.index_management import index
+from mcp_server.storage.sqlite_store import SQLiteStore
+
+
+def _create_legacy_database(tmp_path: Path) -> Path:
+    """Create a legacy SQLite database without recent migrations."""
+    legacy_root = tmp_path / "legacy_repo" / ".mcp-index"
+    legacy_root.mkdir(parents=True, exist_ok=True)
+    db_path = legacy_root / "code_index.db"
+
+    migration_001 = Path(__file__).parents[2] / "mcp_server" / "storage" / "migrations" / "001_initial_schema.sql"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(migration_001.read_text())
+    conn.execute("INSERT INTO repositories (path, name) VALUES (?, ?)", ("/repo", "legacy"))
+    conn.commit()
+    conn.close()
+
+    return db_path
+
+
+def test_migrate_command_upgrades_legacy_database_and_backfills_manifests(tmp_path):
+    """Ensure migrate command updates schema and creates manifest files."""
+    db_path = _create_legacy_database(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(index, ["migrate", "--db-path", str(db_path)])
+
+    assert result.exit_code == 0
+
+    store = SQLiteStore(str(db_path))
+    health = store.health_check()
+    assert health["status"] == "healthy"
+    assert health["required_migrations"] == []
+
+    with store._get_connection() as conn:  # noqa: SLF001
+        file_columns = {row[1] for row in conn.execute("PRAGMA table_info(files)")}
+        assert {"content_hash", "is_deleted", "deleted_at"}.issubset(file_columns)
+
+        embedding_indexes = {row[1] for row in conn.execute("PRAGMA index_list(embeddings)")}
+        assert "idx_embeddings_unique_scope" in embedding_indexes
+
+    manifest_parent = db_path.parent.parent
+    assert (manifest_parent / ".mcp-index.json").exists()
+    assert (manifest_parent / ".index_metadata.json").exists()
+
+
+def test_migrate_check_only_reports_pending_state(tmp_path):
+    """Check-only mode should not mutate the database but should signal pending migrations."""
+    db_path = _create_legacy_database(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(index, ["migrate", "--db-path", str(db_path), "--check-only"])
+
+    assert result.exit_code == 1
+
+    manifest_parent = db_path.parent.parent
+    assert not (manifest_parent / ".mcp-index.json").exists()
+    assert not (manifest_parent / ".index_metadata.json").exists()
+
+    store = SQLiteStore(str(db_path))
+    health = store.health_check()
+    assert health["required_migrations"]
+    assert health["status"] != "healthy"

--- a/tests/integration/test_phase1_foundation.py
+++ b/tests/integration/test_phase1_foundation.py
@@ -185,8 +185,8 @@ class TestPhase1Foundation:
             )
             assert cursor.fetchone() is not None
 
-    def test_fresh_database_no_migrations_run(self, tmp_path):
-        """Verify fresh database doesn't run migrations."""
+    def test_fresh_database_records_migrations(self, tmp_path):
+        """Verify fresh database runs and records migrations."""
         db_path = tmp_path / "test.db"
 
         # Database doesn't exist yet
@@ -195,13 +195,13 @@ class TestPhase1Foundation:
         # Create store
         store = SQLiteStore(str(db_path))
 
-        # Check that migrations table is empty (no migrations run on fresh DB)
+        # Check that migrations table contains applied migrations
         with store._get_connection() as conn:
             cursor = conn.execute("SELECT COUNT(*) FROM migrations")
             count = cursor.fetchone()[0]
 
-            # Fresh database should have no migration records
-            assert count == 0
+            # Fresh database should record at least one migration
+            assert count >= 1
 
     def test_foreign_key_constraints_enabled(self, tmp_path):
         """Verify foreign key constraints are enabled."""

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -726,6 +726,8 @@ class TestSQLiteStoreHealthCheck:
         assert health["fts5"] is True
         assert health["wal"] is True
         assert health["version"] >= 1
+        assert health["version"] == health["latest_version"]
+        assert health["required_migrations"] == []
         assert health["error"] is None
         # Check all required tables exist
         assert health["tables"]["file_moves"] is True
@@ -834,8 +836,8 @@ class TestSQLiteStoreHealthCheck:
 
         health = store.health_check()
 
-        # Fresh database should have version 1
-        assert health["version"] == 1
+        # Fresh database should match the latest migration version
+        assert health["version"] == health["latest_version"]
 
 
 class TestPerformance:


### PR DESCRIPTION
## Summary
- add schema hardening migration to cover missing content tracking columns, embedding uniqueness, and manifest metadata
- enhance SQLite health checks, migration execution, and manifest backfill helpers for compatibility reporting
- introduce an index CLI migrate command and integration coverage for upgrading legacy databases

## Testing
- pytest tests/test_sqlite_store.py tests/integration/test_phase1_foundation.py tests/integration/test_migration_cli.py *(fails: missing psutil dependency in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b65287b048320ba0fea1bae6d0e33)