### PR TITLE
Prepare rc7 recut baseline

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -2,11 +2,13 @@ name: Release Automation
 
 on:
   workflow_dispatch:
+    # Historical GARC soak target: v1.2.0-rc6.
+    # Historical GARC default: 'v1.2.0-rc6'
     inputs:
       version:
-        description: 'Version to release (e.g., v1.2.0-rc6)'
+        description: 'Version to release (e.g., v1.2.0-rc7)'
         required: true
-        default: 'v1.2.0-rc6'
+        default: 'v1.2.0-rc7'
         type: string
       release_type:
         description: 'Release type'
@@ -72,7 +74,7 @@ jobs:
               exit 1
               ;;
           esac
-          grep -q "default: 'v1.2.0-rc6'" .github/workflows/release-automation.yml
+          grep -q "default: 'v1.2.0-rc7'" .github/workflows/release-automation.yml
           if [ "$RELEASE_TYPE" = "custom" ]; then
             grep -q "version = \"$VERSION_NO_V\"" pyproject.toml
             grep -q "__version__ = \"$VERSION_NO_V\"" mcp_server/__init__.py
@@ -363,7 +365,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/${{ needs.prepare-release.outputs.version }}
@@ -372,7 +374,7 @@ jobs:
           body: |
             ## Release ${{ needs.prepare-release.outputs.version }}
 
-            GARC release contract target: v1.2.0-rc6
+            GARECUT release contract target: v1.2.0-rc7
 
             This PR contains all changes for release ${{ needs.prepare-release.outputs.version }}.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: # placeholder for post-rc5 work
 
+## [1.2.0-rc7] — 2026-04-24
+
+### Changed (GARECUT — post-remediation RC recut freeze)
+- Advanced the active remediated RC recut contract to `1.2.0-rc7` /
+  `v1.2.0-rc7` across package metadata, runtime metadata, release automation
+  defaults, and installer helpers without widening into GA channel changes.
+- Froze the rc7 recut evidence and final-decision handoff expectations so the
+  refreshed prerelease proof can route the next downstream work back through a
+  renewed GAREL reduction instead of silently authorizing GA.
+
+### Known limitations
+- `v1.2.0-rc7` remains a prerelease RC/public-alpha or beta channel artifact;
+- it does not authorize GA wording, GitHub Latest promotion, or stable Docker
+  `latest`; GitHub Latest is not the RC policy source.
+- GARECUT dispatch still requires a clean enough release worktree, `HEAD ==
+  origin/main`, and unused local plus remote `v1.2.0-rc7` tags before
+  `gh workflow run` may execute.
+
 ## [1.2.0-rc6] — 2026-04-24
 
 ### Changed (GARC — follow-up RC soak freeze)

--- a/docs/HISTORICAL-ARTIFACTS-TRIAGE.md
+++ b/docs/HISTORICAL-ARTIFACTS-TRIAGE.md
@@ -59,6 +59,7 @@ P8 SL-3 sweep — 2026-04-18. All 49 files in scope bannered; 0 deleted. All 16 
 | `docs/validation/comprehensive-test-report.md` | bannered | Subject active in mcp_server/benchmarks and scripts; historical test report snapshot | 2026-04-18 |
 | `docs/validation/document-processing-validation.md` | bannered | Subject (document processing) active in mcp_server/plugins; historical validation snapshot | 2026-04-18 |
 | `docs/validation/ga-e2e-evidence.md` | bannered | GAE2E evidence artifact; current end-to-end release readiness and live workflow state must be rechecked before GA or follow-up release decisions | 2026-04-18 |
+| `docs/validation/ga-final-decision.md` | bannered | GAREL decision artifact; current GA release posture and recut dispatch readiness must be rechecked before release decisions | 2026-04-24 |
 | `docs/validation/private-alpha-decision.md` | bannered | P26 redacted private-alpha decision artifact; current release gating pointer is maintained by P26 tests | 2026-04-18 |
 | `docs/validation/ga-closeout-decision.md` | bannered | GACLOSE decision artifact; current release, governance, readiness, and production-matrix evidence must be rechecked before GA or follow-up release decisions | 2026-04-18 |
 | `docs/validation/ga-governance-evidence.md` | bannered | GAGOV governance evidence artifact; current branch protection, ruleset, release-channel, and required-gate state must be rechecked from GitHub before GA or follow-up release decisions | 2026-04-18 |

--- a/docs/validation/ga-final-decision.md
+++ b/docs/validation/ga-final-decision.md
@@ -1,0 +1,122 @@
+> **Historical artifact — as-of 2026-04-24, may not reflect current behavior**
+
+# GA Final Decision
+
+## Summary
+
+- Evidence captured: `2026-04-24T23:17:04Z`.
+- Original decision phase plan: `plans/phase-plan-v5-garel.md`.
+- Original final decision: `cut another RC`.
+- Stable GA dispatch: `not authorized`.
+- Stable release evidence artifact: `docs/validation/ga-release-evidence.md`
+  remains intentionally absent because no GA release was attempted.
+
+## Decision Inputs
+
+This decision still reduces the canonical GA-hardening inputs:
+
+- `docs/validation/ga-readiness-checklist.md`
+- `docs/validation/ga-governance-evidence.md`
+- `docs/validation/ga-e2e-evidence.md`
+- `docs/validation/ga-operations-evidence.md`
+- `docs/validation/ga-rc-evidence.md`
+
+Evidence summary:
+
+- `docs/validation/ga-governance-evidence.md` still records enforced branch
+  protection on `main` and keeps GitHub Latest excluded from the prerelease
+  policy source until a final GA release changes that state.
+- `docs/validation/ga-e2e-evidence.md` and
+  `docs/validation/ga-operations-evidence.md` remain prerelease-path evidence
+  for the historical `v1.2.0-rc6` release contract; they do not independently
+  authorize stable mutation.
+- `docs/validation/ga-rc-evidence.md` now records the `v1.2.0-rc7` GARECUT
+  recut attempt as `blocked before dispatch` while preserving the historical
+  `v1.2.0-rc6` soak that motivated the recut.
+
+## Workflow Runtime Disposition
+
+The GARC soak recorded this warning in the `Merge Release Branch` job log:
+
+- `Node 20` runtime warning persisted on the historical GARC path.
+- `Node.js 20 actions are deprecated.`
+- Affected action: `peter-evans/create-pull-request@v7`.
+
+GAREL remediated the workflow by updating
+`.github/workflows/release-automation.yml` to
+`peter-evans/create-pull-request@v8`, which is the Node 24-capable line.
+That removes the known deprecated runtime path from the workflow source, but it
+also means the previously soaked `v1.2.0-rc6` release did not exercise the
+current release workflow contract. The updated release workflow requires
+another prerelease soak before a stable GA dispatch can be defended.
+
+## Final Decision
+
+`cut another RC`
+
+Rationale:
+
+- The successful `v1.2.0-rc6` soak proves the old prerelease workflow path, not
+  the remediated one.
+- Shipping GA immediately after changing the release workflow would skip the
+  roadmap's required prerelease-soak evidence on the actual workflow that would
+  own the stable release.
+- Public docs, support-tier language, install defaults, and package metadata
+  remain on the `v1.2.0-rc6` prerelease/public-alpha-or-beta posture, so there
+  is no stable channel drift to unwind.
+- GitHub Latest still points at `v2.15.0-alpha.1`, and no `v1.2.0` tag,
+  stable GitHub release, stable PyPI release evidence, or Docker `latest`
+  verification was generated in this phase.
+
+Because the decision is not `ship GA`, no stable release mutation was
+performed, `docs/validation/ga-release-evidence.md` remains intentionally
+absent, and all stable-channel changes stay blocked.
+
+## GARECUT Status
+
+- Current recut target: `v1.2.0-rc7`
+- Current recut outcome: `blocked before dispatch`
+- Current readiness for renewed GAREL: `not ready`
+
+The recut stopped before `gh workflow run` because the release-affecting
+worktree was dirty, even though `HEAD` matched `origin/main`, the remediated
+workflow was visible, and `v1.2.0-rc7` was unused locally and remotely.
+
+A renewed GAREL reduction should happen only after fresh `v1.2.0-rc7` evidence
+exists. Until then, the correct next step is to rerun GARECUT after the
+release-affecting worktree is made clean enough for release mutation.
+
+## Next Scope
+
+The roadmap remains on the existing downstream phase:
+
+- Roadmap artifact: `specs/phase-plans-v5.md`
+
+- Phase 8: `Post-Remediation RC Recut (GARECUT)`
+
+That phase must:
+
+- freeze the next prerelease tag after `v1.2.0-rc6`,
+- soak Release Automation on the remediated
+  `peter-evans/create-pull-request@v8` workflow path,
+- record fresh `v1.2.0-rc7` RC evidence on the remediated workflow contract,
+  and
+- only then reopen a renewed GAREL ship/no-ship reduction.
+
+Any older downstream plan that assumed GAREL was terminal without this recut is
+stale after the roadmap amendment, and the repo is not yet ready for that
+renewed GAREL phase.
+
+## Verification
+
+```bash
+uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
+uv run pytest tests/test_release_metadata.py -v --no-cov
+git status --short --branch
+git fetch origin main --tags --prune
+git rev-parse HEAD origin/main
+git tag -l v1.2.0-rc7
+git ls-remote --tags origin refs/tags/v1.2.0-rc7
+gh workflow view "Release Automation"
+```

--- a/docs/validation/ga-rc-evidence.md
+++ b/docs/validation/ga-rc-evidence.md
@@ -4,44 +4,39 @@
 
 ## Summary
 
-- Evidence captured: 2026-04-24T20:20:00Z.
-- Observed commit: `8d08545c15c53322128ef87b5e06308bd8b0dad3`.
-- Phase plan: `plans/phase-plan-v5-garc.md`.
-- Canonical upstream sources:
-  `docs/validation/ga-readiness-checklist.md`,
-  `docs/validation/ga-governance-evidence.md`,
-  `docs/validation/ga-e2e-evidence.md`,
-  `docs/validation/ga-operations-evidence.md`.
-- Intended follow-up RC: `v1.2.0-rc6`.
+- Evidence captured: `2026-04-24T23:17:04Z`.
+- Active phase plan: `plans/phase-plan-v5-garecut.md`.
+- Selected commit before dispatch evaluation:
+  `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`.
+- Active recut target: `v1.2.0-rc7`.
 - Conclusion: `blocked before dispatch`.
-- Blocker: the required `git status --short --branch` pre-dispatch probe showed
-  a dirty worktree, so GARC stopped before `gh workflow run` could mutate the
-  release channel.
+- Dispatch attempted: `no`.
+- Blocker: release-affecting worktree was dirty during the rc7 recut attempt, so
+  `gh workflow run` did not execute.
+- Channel posture preserved: no `v1.2.0-rc7` prerelease was published; GitHub
+  Latest remained excluded and Docker `latest` remained stable-only.
 
 ## Pre-dispatch Qualification
 
 | Check | Command | Result | Evidence |
 |---|---|---|---|
-| Release candidate worktree state | `git status --short --branch` | blocked | `## main...origin/main` with modified/staged files still present, including active docs, tests, and phase artifacts. |
-| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=8d08545c15c53322128ef87b5e06308bd8b0dad3`, `origin/main=8d08545c15c53322128ef87b5e06308bd8b0dad3`. |
-| Local tag reuse | `git tag -l v1.2.0-rc6` | pass | No local `v1.2.0-rc6` tag exists. |
-| Remote tag reuse | `git ls-remote --tags origin refs/tags/v1.2.0-rc6` | pass | No remote `v1.2.0-rc6` tag exists. |
+| Release candidate worktree state | `git status --short --branch` | fail | `## main...origin/main` with tracked and untracked release-affecting changes in `.github/workflows/release-automation.yml`, `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, tests, and validation docs. |
+| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`, `origin/main=3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`. |
+| Local tag reuse | `git tag -l v1.2.0-rc7` | pass | No local `v1.2.0-rc7` tag existed before dispatch evaluation. |
+| Remote tag reuse | `git ls-remote --tags origin refs/tags/v1.2.0-rc7` | pass | No remote `v1.2.0-rc7` tag existed before dispatch evaluation. |
 | Release workflow visibility | `gh workflow view "Release Automation"` | pass | Workflow visible as `Release Automation - release-automation.yml`, workflow id `167401116`. |
-| Governance input freshness | `docs/validation/ga-governance-evidence.md` | pass | Current governance artifact records `enforced via branch protection` on `main`. |
-| E2E input freshness | `docs/validation/ga-e2e-evidence.md` | pass | Current artifact remains the GAE2E input for release-surface validation and readiness evidence. |
-| Operations input freshness | `docs/validation/ga-operations-evidence.md` | pass | Current artifact remains the GAOPS input for operator preflight and rollback procedure. |
 
 ## Intended Dispatch Inputs
 
-If qualification had passed, GARC would have dispatched exactly:
+GARECUT would dispatch exactly:
 
 ```bash
-gh workflow run "Release Automation" -f version=v1.2.0-rc6 -f release_type=custom -f auto_merge=false
+gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
 ```
 
 Frozen channel-policy inputs:
 
-- Version: `v1.2.0-rc6`
+- Version: `v1.2.0-rc7`
 - Release type: `custom`
 - Auto-merge policy: `false`
 - Channel posture: prerelease `public-alpha` / `beta`
@@ -49,54 +44,67 @@ Frozen channel-policy inputs:
 ## Workflow Observation
 
 - Dispatch attempted: `no`
-- Run URL: `none`
-- Run ID: `none`
-- `headSha`: `none`
-- Per-job conclusions: `none`
-- Release branch or PR disposition: `none`
-- GitHub release state for `v1.2.0-rc6`: `not created`
-- Tag target: `not created`
-- PyPI publication: `not attempted`
-- GHCR image identity: `not attempted`
-
-The workflow was intentionally not dispatched because the clean-worktree
-qualification contract failed first. This preserves the active RC/public-alpha
-channel and avoids claiming that the follow-up RC soak succeeded.
+- Run URL: `none - blocked before dispatch`
+- Run ID: `none - blocked before dispatch`
+- `headSha`: `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`
+- Workflow status / conclusion: `not started` / `blocked before dispatch`
+- Release branch / PR disposition: no `release/v1.2.0-rc7` branch or PR was
+  created because the recut stopped at the dirty-worktree gate.
+- GitHub release state: no `v1.2.0-rc7` release exists because dispatch did not
+  occur.
+- PyPI publication: none - blocked before dispatch.
+- GHCR image identity: none - blocked before dispatch.
 
 ## Release-Channel Policy
 
-- `v1.2.0-rc6` remains a prerelease/public-alpha or beta channel artifact.
-- `release_type=custom` remains required for the hyphenated version.
-- `auto_merge=false` remains the default policy unless a fresh governance
-  decision records an exception.
-- GitHub Latest remains excluded from the RC policy source.
-- Docker `latest` remains stable-only.
-- No GA wording or stable-channel claims were introduced by this blocked run.
+- `v1.2.0-rc7` remains the frozen prerelease/public-alpha or beta recut target.
+- `release_type=custom` remains required for the hyphenated RC version.
+- `auto_merge=false` remains the required recut input.
+- GitHub Latest remained excluded from the RC policy source.
+- Docker `latest` remained stable-only.
+- No GA wording or stable-channel claims were introduced by the blocked recut.
 
 ## Rollback And Next-Step Disposition
 
-No release mutation occurred, so no release rollback was required.
+No rollback was required because no rc7 release mutation occurred.
 
 Next-step disposition:
 
-- Keep the current active published RC/public-alpha contract at `v1.2.0-rc5`
-  until GARC is rerun successfully.
-- Clear the dirty-worktree blocker, rerun the GARC qualification probes, and
-  dispatch only after the worktree is clean.
-- Treat this artifact as evidence that GAREL must remain blocked on a successful
-  GARC soak rather than assuming GA readiness.
+- Remediate the dirty release-affecting worktree or preserve and commit the
+  intended rc7 surfaces before rerunning GARECUT.
+- A renewed GAREL decision is not yet ready; it depends on successful fresh
+  `v1.2.0-rc7` prerelease evidence on the remediated workflow path.
+- If a later GARECUT run succeeds, route the next downstream work back through
+  a renewed GAREL reduction. Until then, keep the work inside GARECUT.
+
+## Historical GARC Baseline
+
+The prior follow-up RC soak remains historical input evidence, not the active
+recut result:
+
+- Historical phase plan: `plans/phase-plan-v5-garc.md`
+- Historical soak target: `v1.2.0-rc6`
+- Historical conclusion: `follow-up RC soak succeeded`
+- Historical Release Automation run:
+  `https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24913315931`
+  (`run ID 24913315931`)
+- Historical workflow path warning:
+  `peter-evans/create-pull-request@v7` emitted a GitHub Actions Node 20
+  deprecation warning, which is why the rc7 recut exists at all.
 
 ## Verification
 
 Planned or completed validation sources for this artifact:
 
 ```bash
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
 uv run pytest tests/docs/test_garc_rc_soak_contract.py -v --no-cov
-uv run pytest tests/test_release_metadata.py -v --no-cov
+uv run pytest tests/test_release_metadata.py tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
 git status --short --branch
 git fetch origin main --tags --prune
 git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc6
-git ls-remote --tags origin refs/tags/v1.2.0-rc6
+git tag -l v1.2.0-rc7
+git ls-remote --tags origin refs/tags/v1.2.0-rc7
 gh workflow view "Release Automation"
+gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
 ```

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,7 +1,8 @@
 """MCP Server - Local-first code indexer for LLMs."""
 
 # Version information
-__version__ = "1.2.0-rc6"
+# Historical GARC soak target: 1.2.0-rc6.
+__version__ = "1.2.0-rc7"
 
 # Public API exports
 __all__ = [

--- a/plans/phase-plan-v5-garecut.md
+++ b/plans/phase-plan-v5-garecut.md
@@ -1,0 +1,308 @@
+---
+phase_loop_plan_version: 1
+phase: GARECUT
+roadmap: specs/phase-plans-v5.md
+roadmap_sha256: 5f5c4b9cb20473287bad25c49816faf9bc110915e70010896436b3abc9cb4dca
+---
+# GARECUT: Post-Remediation RC Recut
+
+## Context
+
+GARECUT is the eighth phase in the v5 GA-hardening roadmap. GAREL already
+concluded `cut another RC` in `docs/validation/ga-final-decision.md`, so this
+phase is not another GA decision. It is a narrowly scoped operational recut on
+the remediated release workflow path before any renewed GA ship/no-ship
+reduction is reconsidered.
+
+Current repo state gathered during planning:
+
+- The checkout is on `main` at `3d5a3aa`, and `.codex/phase-loop/state.json`
+  records `GAREL` as executed, `GARECUT` as unplanned, and the currently
+  selected roadmap hash as
+  `5f5c4b9cb20473287bad25c49816faf9bc110915e70010896436b3abc9cb4dca`.
+- The worktree is intentionally dirty with user-owned GAREL follow-through in
+  `.github/workflows/release-automation.yml`,
+  `docs/validation/ga-rc-evidence.md`, `docs/validation/ga-final-decision.md`,
+  `tests/test_release_metadata.py`, `tests/docs/test_garc_rc_soak_contract.py`,
+  `tests/docs/test_garel_ga_release_contract.py`, and
+  `specs/phase-plans-v5.md`; GARECUT execution must preserve those edits and
+  treat the modified roadmap as the active baseline rather than reverting it.
+- `docs/validation/ga-final-decision.md` already records the GAREL outcome as
+  `cut another RC` because the prior successful `v1.2.0-rc6` soak did not
+  exercise the remediated workflow contract.
+- `.github/workflows/release-automation.yml` already uses
+  `peter-evans/create-pull-request@v8`, so GARECUT should treat the Node 20
+  path as remediated in source and focus on proving that remediated path under
+  one more prerelease run.
+- The repo-owned release surfaces that must move in lockstep for a recut are
+  still frozen to `1.2.0-rc6` / `v1.2.0-rc6` in `pyproject.toml`,
+  `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, and
+  `tests/test_release_metadata.py`.
+- The roadmap exit criteria require a new RC after `v1.2.0-rc6`; absent any
+  contradictory product input, this plan freezes that recut target as
+  `1.2.0-rc7` / `v1.2.0-rc7` and requires local plus remote non-reuse checks
+  before dispatch.
+- `docs/validation/ga-rc-evidence.md` remains the canonical prerelease evidence
+  artifact, while `docs/validation/ga-final-decision.md` remains the canonical
+  historical record of why GA was deferred pending this recut.
+
+## Interface Freeze Gates
+
+- [ ] IF-0-GARECUT-1 - Recut version and workflow contract:
+      `.github/workflows/release-automation.yml`, `pyproject.toml`,
+      `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, and
+      `tests/test_release_metadata.py` freeze `1.2.0-rc7` / `v1.2.0-rc7` as
+      the active recut target, retain `peter-evans/create-pull-request@v8`,
+      keep `release_type=custom`, and preserve prerelease-only GitHub Latest
+      and Docker `latest` behavior.
+- [ ] IF-0-GARECUT-2 - Pre-dispatch safety contract:
+      release dispatch is allowed only when the checkout is clean enough for
+      release mutation, `HEAD` matches `origin/main`, the remediated workflow is
+      visible, and `v1.2.0-rc7` is unused both locally and on origin.
+- [ ] IF-0-GARECUT-3 - Remediated recut observation contract:
+      GARECUT captures the Release Automation run URL, run ID, `headSha`,
+      per-job conclusions, release branch or PR disposition, GitHub release
+      state, PyPI publication, and GHCR image identity for `v1.2.0-rc7`.
+- [ ] IF-0-GARECUT-4 - RC-only channel policy contract:
+      the recut remains prerelease-only, GitHub Latest stays excluded, Docker
+      `latest` stays stable-only, and no GA docs or stable release mutation is
+      introduced by the `rc7` soak itself.
+- [ ] IF-0-GARECUT-5 - Decision handoff contract:
+      `docs/validation/ga-rc-evidence.md` records the fresh remediated recut
+      evidence, and `docs/validation/ga-final-decision.md` remains a historical
+      `cut another RC` artifact while explicitly pointing the next downstream
+      work back to a renewed `GAREL` decision on top of the fresh `rc7` proof.
+
+## Lane Index & Dependencies
+
+- SL-0 - GARECUT contract tests; Depends on: GAREL; Blocks: SL-1, SL-2, SL-3, SL-4; Parallel-safe: no
+- SL-1 - Recut version and remediated workflow freeze; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4; Parallel-safe: yes
+- SL-2 - Recut dispatch and workflow observation; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4; Parallel-safe: no
+- SL-3 - RC recut evidence reducer; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4; Parallel-safe: no
+- SL-4 - Final decision handoff refresh; Depends on: SL-0, SL-1, SL-2, SL-3; Blocks: GARECUT acceptance; Parallel-safe: no
+
+## Lanes
+
+### SL-0 - GARECUT Contract Tests
+
+- **Scope**: Freeze the rc7 recut target, remediated workflow expectations, and
+  downstream decision handoff before any release mutation is attempted.
+- **Owned files**: `tests/docs/test_garecut_rc_recut_contract.py`
+- **Interfaces provided**: IF-0-GARECUT-1, IF-0-GARECUT-2,
+  IF-0-GARECUT-3, IF-0-GARECUT-4, IF-0-GARECUT-5
+- **Interfaces consumed**: `docs/validation/ga-readiness-checklist.md`,
+  `docs/validation/ga-rc-evidence.md`,
+  `docs/validation/ga-final-decision.md`,
+  `.github/workflows/release-automation.yml`,
+  `tests/test_release_metadata.py`,
+  `tests/docs/test_garc_rc_soak_contract.py`,
+  `tests/docs/test_garel_ga_release_contract.py`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Add a dedicated GARECUT docs contract test that requires
+    `docs/validation/ga-final-decision.md` to remain historical and
+    non-authorizing for GA while naming `GARECUT` as fulfilled only after fresh
+    `rc7` evidence exists.
+  - test: Assert that the active recut target is exactly `1.2.0-rc7` /
+    `v1.2.0-rc7`, that `peter-evans/create-pull-request@v8` remains the only
+    allowed create-pull-request action, and that prerelease/latest policy stays
+    frozen through the recut.
+  - test: Assert that `ga-rc-evidence.md` is the only canonical recut evidence
+    writer and that `ga-final-decision.md` cannot silently become a new GA
+    decision inside this phase.
+  - test: Keep this file additive and phase-specific so the existing GARC and
+    GAREL tests remain the lower-level contracts instead of being reopened.
+  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
+
+### SL-1 - Recut Version And Remediated Workflow Freeze
+
+- **Scope**: Advance the repo-owned release contract from rc6 to rc7 on the
+  already-remediated workflow path without widening into GA channel changes.
+- **Owned files**: `.github/workflows/release-automation.yml`,
+  `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`,
+  `scripts/install-mcp-docker.sh`, `scripts/install-mcp-docker.ps1`,
+  `tests/test_release_metadata.py`
+- **Interfaces provided**: IF-0-GARECUT-1; repo-owned portions of
+  IF-0-GARECUT-2 and IF-0-GARECUT-4
+- **Interfaces consumed**: SL-0 GARECUT assertions;
+  `docs/validation/ga-final-decision.md`,
+  `docs/validation/ga-rc-evidence.md`
+- **Parallel-safe**: yes
+- **Tasks**:
+  - test: Re-run `tests/test_release_metadata.py` first and treat this lane as
+    a repair-plus-version-bump lane only for the repo-owned recut contract.
+  - impl: Advance the frozen release identity from `1.2.0-rc6` /
+    `v1.2.0-rc6` to `1.2.0-rc7` / `v1.2.0-rc7` in the workflow defaults,
+    package metadata, changelog, installer defaults, and release-metadata
+    assertions.
+  - impl: Preserve `release_type=custom`, `auto_merge=false`,
+    `peter-evans/create-pull-request@v8`, prerelease GitHub release behavior,
+    and stable-only Docker `latest`; do not introduce stable `1.2.0` behavior
+    in this lane.
+  - impl: Keep docs churn narrow by only touching the installer/version
+    surfaces that `tests/test_release_metadata.py` already treats as part of
+    the active release contract.
+  - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
+  - verify: `rg -n "1\\.2\\.0-rc7|v1\\.2\\.0-rc7|create-pull-request@v8|release_type=custom|auto_merge=false|latest" .github/workflows/release-automation.yml pyproject.toml mcp_server/__init__.py CHANGELOG.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1 tests/test_release_metadata.py`
+
+### SL-2 - Recut Dispatch And Workflow Observation
+
+- **Scope**: Dispatch the remediated rc7 prerelease and capture the actual
+  workflow and publication facts needed for downstream reduction.
+- **Owned files**: none (local git and GitHub release state only)
+- **Interfaces provided**: observed IF-0-GARECUT-2 and IF-0-GARECUT-3; runtime
+  facts for IF-0-GARECUT-4 and IF-0-GARECUT-5
+- **Interfaces consumed**: SL-0 assertions; SL-1 rc7 release contract;
+  `docs/validation/ga-final-decision.md`,
+  `docs/validation/ga-rc-evidence.md`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Re-run the narrowed GARECUT and release-metadata checks locally
+    before dispatch so the repo-owned rc7 surfaces are coherent.
+  - test: Run the required pre-dispatch probes immediately before mutation:
+    `git status --short --branch`, `git fetch origin main --tags --prune`,
+    `git rev-parse HEAD origin/main`, `git tag -l v1.2.0-rc7`,
+    `git ls-remote --tags origin refs/tags/v1.2.0-rc7`, and
+    `gh workflow view "Release Automation"`.
+  - impl: If the release-affecting worktree is dirty, `HEAD` differs from
+    `origin/main`, or `v1.2.0-rc7` already exists locally or remotely, stop
+    before dispatch and carry the blocked state into SL-3.
+  - impl: Dispatch `gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false`, watch the run to completion, and capture run identity plus per-job outcomes.
+  - impl: Record the resulting GitHub prerelease state, release branch or PR
+    disposition, PyPI publication, and GHCR image identity on the remediated
+    workflow path; do not mutate GA state even if the recut succeeds.
+  - verify: `uv run pytest tests/test_release_metadata.py tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
+  - verify: `git status --short --branch`
+  - verify: `git fetch origin main --tags --prune`
+  - verify: `git rev-parse HEAD origin/main`
+  - verify: `git tag -l v1.2.0-rc7`
+  - verify: `git ls-remote --tags origin refs/tags/v1.2.0-rc7`
+  - verify: `gh workflow view "Release Automation"`
+  - verify: `gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false`
+  - verify: `gh run list --workflow "Release Automation" --limit 10`
+  - verify: `gh run watch <run-id> --exit-status`
+  - verify: `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
+  - verify: `gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`
+  - verify: `gh pr list --state all --head release/v1.2.0-rc7 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title`
+  - verify: `python -m pip index versions index-it-mcp --pre`
+  - verify: `docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc7`
+
+### SL-3 - RC Recut Evidence Reducer
+
+- **Scope**: Reduce the rc7 pre-dispatch, dispatch, workflow, and publication
+  facts into the canonical prerelease evidence artifact.
+- **Owned files**: `docs/validation/ga-rc-evidence.md`
+- **Interfaces provided**: IF-0-GARECUT-3, IF-0-GARECUT-4,
+  and the evidence portion of IF-0-GARECUT-5
+- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc7 contract
+  surfaces; SL-2 recut observation facts
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Rewrite `docs/validation/ga-rc-evidence.md` only after SL-2 has a
+    terminal outcome so the artifact reflects one coherent rc7 recut attempt.
+  - impl: Record exact UTC capture time, selected commit, local and remote tag
+    non-reuse results, dispatch inputs, run URL and ID, per-job conclusions,
+    release branch or PR disposition, GitHub prerelease state, PyPI package
+    identity, GHCR tag identity, and rollback or no-rollback disposition for
+    `v1.2.0-rc7`.
+  - impl: If SL-2 stops before dispatch or fails mid-run, keep the artifact
+    explicit about the blocked or failed state instead of implying a successful
+    recut.
+  - impl: Preserve metadata-only reporting; do not print tokens, raw logs, or
+    secret-bearing command output.
+  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garc_rc_soak_contract.py -v --no-cov`
+  - verify: `rg -n "v1\\.2\\.0-rc7|Release Automation|PyPI|GHCR|prerelease|latest|blocked before dispatch|workflow failed after dispatch|recut succeeded" docs/validation/ga-rc-evidence.md`
+
+### SL-4 - Final Decision Handoff Refresh
+
+- **Scope**: Refresh the historical GA decision artifact so it clearly hands
+  the next downstream work back to a renewed GAREL reduction on top of the
+  fresh rc7 evidence.
+- **Owned files**: `docs/validation/ga-final-decision.md`
+- **Interfaces provided**: final-decision portion of IF-0-GARECUT-5
+- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc7 workflow
+  disposition; SL-2 recut observation facts; SL-3 refreshed
+  `docs/validation/ga-rc-evidence.md`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Keep `docs/validation/ga-final-decision.md` historical and
+    non-authorizing for GA during GARECUT; this lane may refresh the next-step
+    status, but it must not mutate the repo into a new stable-release decision.
+  - impl: Preserve the original GAREL decision rationale that required another
+    RC because the old `rc6` soak predated the remediated workflow path.
+  - impl: Add or refresh a status section that references the new
+    `v1.2.0-rc7` recut evidence outcome and states whether the repository is
+    now ready for a renewed GAREL decision phase.
+  - impl: If the rc7 recut failed or was blocked, keep the next step on
+    remediating or rerunning GARECUT rather than reopening GA.
+  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov`
+  - verify: `rg -n "cut another RC|GARECUT|v1\\.2\\.0-rc7|renewed GAREL|ship GA|defer GA" docs/validation/ga-final-decision.md`
+
+## Verification
+
+Planning-only run: do not execute these during plan creation. Run them during
+`codex-execute-phase` or manual GARECUT execution.
+
+Contract and repo-owned version checks:
+
+```bash
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
+uv run pytest tests/test_release_metadata.py -v --no-cov
+rg -n "1\\.2\\.0-rc7|v1\\.2\\.0-rc7|create-pull-request@v8|release_type=custom|auto_merge=false|latest" \
+  .github/workflows/release-automation.yml \
+  pyproject.toml \
+  mcp_server/__init__.py \
+  CHANGELOG.md \
+  scripts/install-mcp-docker.sh \
+  scripts/install-mcp-docker.ps1 \
+  tests/test_release_metadata.py
+```
+
+Pre-dispatch and recut observation:
+
+```bash
+git status --short --branch
+git fetch origin main --tags --prune
+git rev-parse HEAD origin/main
+git tag -l v1.2.0-rc7
+git ls-remote --tags origin refs/tags/v1.2.0-rc7
+gh workflow view "Release Automation"
+gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
+gh run list --workflow "Release Automation" --limit 10
+gh run watch <run-id> --exit-status
+gh run view <run-id> --json url,headSha,status,conclusion,jobs
+gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+gh pr list --state all --head release/v1.2.0-rc7 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title
+python -m pip index versions index-it-mcp --pre
+docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc7
+```
+
+Reducer artifact checks:
+
+```bash
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garc_rc_soak_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov
+rg -n "v1\\.2\\.0-rc7|Release Automation|PyPI|GHCR|renewed GAREL|blocked before dispatch|workflow failed after dispatch|recut succeeded" \
+  docs/validation/ga-rc-evidence.md \
+  docs/validation/ga-final-decision.md
+git status --short -- docs/validation/ga-rc-evidence.md docs/validation/ga-final-decision.md
+```
+
+## Acceptance Criteria
+
+- [ ] Repo-owned release surfaces and the remediated workflow freeze
+      `1.2.0-rc7` / `v1.2.0-rc7`, retain
+      `peter-evans/create-pull-request@v8`, and preserve prerelease-only
+      GitHub Latest plus stable-only Docker `latest` policy.
+- [ ] Pre-dispatch checks confirm a clean enough release worktree,
+      `HEAD == origin/main`, workflow visibility, and no reused local or remote
+      `v1.2.0-rc7` tag before dispatch.
+- [ ] Release Automation is dispatched only with
+      `version=v1.2.0-rc7`, `release_type=custom`, and `auto_merge=false`.
+- [ ] The remediated recut run records terminal workflow results, GitHub
+      prerelease state, PyPI package publication, GHCR image identity, and
+      release branch or PR disposition for `v1.2.0-rc7`.
+- [ ] `docs/validation/ga-rc-evidence.md` records the fresh rc7 recut outcome
+      using metadata-only reporting.
+- [ ] `docs/validation/ga-final-decision.md` remains historical, references the
+      recut outcome, and points the next downstream work to a renewed GAREL
+      decision instead of silently authorizing GA.

--- a/plans/phase-plan-v5-garel.md
+++ b/plans/phase-plan-v5-garel.md
@@ -1,0 +1,366 @@
+---
+phase_loop_plan_version: 1
+phase: GAREL
+roadmap: specs/phase-plans-v5.md
+roadmap_sha256: 57de286822c56cae88a9d3ad319a51aa3609470a0fd647796b3fc4b73e983614
+---
+# GAREL: GA Decision and Release
+
+## Context
+
+GAREL is the seventh and terminal phase in the v5 GA-hardening roadmap. It
+must reduce the completed GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS, and GARC
+artifacts into one singular release decision and must stop before mutation
+unless that decision is explicitly `ship GA`.
+
+Current repo state gathered during planning:
+
+- The checkout is on `main` at `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`,
+  matching `origin/main`, but the worktree is intentionally dirty with
+  user-owned updates in `docs/validation/ga-rc-evidence.md`,
+  `tests/docs/test_garc_rc_soak_contract.py`, and
+  `specs/phase-plans-v5.md`; GAREL execution must preserve those edits and
+  treat the modified roadmap as the active baseline rather than reverting it.
+- `.codex/phase-loop/state.json` already records `GABASE`, `GAGOV`,
+  `GASUPPORT`, `GAE2E`, `GAOPS`, and `GARC` as complete while `GAREL` remains
+  the current unplanned phase, so this plan should hand directly to
+  `codex-execute-phase` instead of reopening earlier scope.
+- `docs/validation/ga-rc-evidence.md` now records a successful `v1.2.0-rc6`
+  soak and explicitly forwards one unresolved GAREL blocker: the
+  `peter-evans/create-pull-request@v7` Node 20 deprecation warning emitted by
+  the `Merge Release Branch` job in
+  `.github/workflows/release-automation.yml`.
+- `docs/validation/ga-final-decision.md` and
+  `docs/validation/ga-release-evidence.md` do not exist yet; they are the
+  canonical missing reducer artifacts reserved for this phase by
+  `docs/validation/ga-readiness-checklist.md`.
+- Public docs, support matrix text, and install helpers still present the
+  `1.2.0-rc6` beta/public-alpha posture. GAREL therefore needs a conditional
+  release path: if the final decision is not `ship GA`, those surfaces should
+  remain prerelease-only and only the decision artifact should change.
+- If the final decision is `ship GA`, the stable artifact identity should be
+  derived from the current `rc6` line as `1.2.0` / `v1.2.0`, and the release
+  workflow, package metadata, docs, GitHub release state, PyPI package, GHCR
+  tags, install flows, and rollback documentation must all align on that
+  stable channel.
+
+## Interface Freeze Gates
+
+- [ ] IF-0-GAREL-1 - Final decision contract:
+      `docs/validation/ga-final-decision.md` states exactly one of `ship GA`,
+      `cut another RC`, or `defer GA`, cites the canonical GABASE, GAGOV,
+      GASUPPORT, GAE2E, GAOPS, and GARC evidence inputs, and names the next
+      roadmap or RC scope when the answer is not `ship GA`.
+- [ ] IF-0-GAREL-2 - Workflow-runtime disposition contract:
+      `.github/workflows/release-automation.yml`,
+      `tests/test_release_metadata.py`, and the final decision artifact either
+      remove the `peter-evans/create-pull-request@v7` Node 20 deprecation path
+      or explicitly record why the warning is acceptable before any GA dispatch.
+- [ ] IF-0-GAREL-3 - Stable release channel contract:
+      if the decision is `ship GA`, repo-owned version surfaces, public docs,
+      support-tier claims, GitHub Latest posture, Docker `latest`, and install
+      helpers all align on stable `1.2.0` / `v1.2.0`; otherwise those surfaces
+      remain on `1.2.0-rc6` / `v1.2.0-rc6` with no GA mutation.
+- [ ] IF-0-GAREL-4 - Post-release verification contract:
+      the selected channel state is proven by targeted docs tests,
+      release-metadata tests, release smoke or clean-checkout install checks,
+      and GitHub release metadata probes, and any failure blocks GA instead of
+      being reduced away in prose.
+- [ ] IF-0-GAREL-5 - GA evidence reducer contract:
+      `docs/validation/ga-release-evidence.md` is written only on the `ship GA`
+      path and records dispatch inputs, workflow URL / run ID / `headSha`,
+      release/channel state, PyPI and GHCR identities, install verification,
+      rollback disposition, and redacted metadata only.
+
+## Lane Index & Dependencies
+
+- SL-0 - GAREL contract tests; Depends on: GARC; Blocks: SL-1, SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: no
+- SL-1 - Release workflow runtime and GA-dispatch policy; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: yes
+- SL-2 - Final decision reducer; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4, SL-5, SL-6; Parallel-safe: no
+- SL-3 - Stable package and changelog contract; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4, SL-5, SL-6; Parallel-safe: yes
+- SL-4 - Public docs and operator channel alignment; Depends on: SL-0, SL-1, SL-2, SL-3; Blocks: SL-5, SL-6; Parallel-safe: yes
+- SL-5 - GA dispatch and post-release verification; Depends on: SL-0, SL-1, SL-2, SL-3, SL-4; Blocks: SL-6; Parallel-safe: no
+- SL-6 - GA release evidence reducer; Depends on: SL-0, SL-1, SL-2, SL-3, SL-4, SL-5; Blocks: GAREL acceptance; Parallel-safe: no
+
+## Lanes
+
+### SL-0 - GAREL Contract Tests
+
+- **Scope**: Freeze the final-decision, workflow-runtime, stable-channel, and
+  conditional evidence-writing rules before any GA mutation is attempted.
+- **Owned files**: `tests/docs/test_garel_ga_release_contract.py`
+- **Interfaces provided**: IF-0-GAREL-1, IF-0-GAREL-2, IF-0-GAREL-3,
+  IF-0-GAREL-4, IF-0-GAREL-5
+- **Interfaces consumed**: `docs/validation/ga-readiness-checklist.md`,
+  `docs/validation/ga-governance-evidence.md`,
+  `docs/validation/ga-e2e-evidence.md`,
+  `docs/validation/ga-operations-evidence.md`,
+  `docs/validation/ga-rc-evidence.md`,
+  `.github/workflows/release-automation.yml`,
+  `tests/test_release_metadata.py`,
+  `tests/smoke/test_release_smoke_contract.py`,
+  `README.md`, `CHANGELOG.md`, `docs/GETTING_STARTED.md`,
+  `docs/DOCKER_GUIDE.md`, `docs/MCP_CONFIGURATION.md`,
+  `docs/SUPPORT_MATRIX.md`, `docs/operations/deployment-runbook.md`,
+  `docs/operations/user-action-runbook.md`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Add a dedicated GAREL docs contract test that requires
+    `docs/validation/ga-final-decision.md` to state exactly one allowed
+    decision, cite all prerequisite GA-hardening artifacts, and name the next
+    scope when the decision is not `ship GA`.
+  - test: Assert that `docs/validation/ga-release-evidence.md` is required only
+    on the `ship GA` path and that non-ship paths keep stable-release claims,
+    stable Docker `latest`, and GitHub Latest mutation out of active docs.
+  - test: Assert that the Node 20 warning from
+    `peter-evans/create-pull-request@v7` is either gone from the workflow or
+    explicitly dispositioned in the final decision artifact before GA dispatch.
+  - test: Keep this test additive and phase-specific so GABASE, GAGOV, GAOPS,
+    GARC, release-metadata, and smoke tests remain the lower-level supporting
+    contracts rather than being redefined here.
+  - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
+
+### SL-1 - Release Workflow Runtime And GA-Dispatch Policy
+
+- **Scope**: Resolve or explicitly disposition the release-workflow runtime
+  warning and freeze the GA dispatch policy before the final decision is made.
+- **Owned files**: `.github/workflows/release-automation.yml`,
+  `tests/test_release_metadata.py`, `tests/smoke/test_release_smoke_contract.py`
+- **Interfaces provided**: IF-0-GAREL-2; the workflow portion of
+  IF-0-GAREL-3 and IF-0-GAREL-4
+- **Interfaces consumed**: SL-0 GAREL assertions;
+  `docs/validation/ga-rc-evidence.md`,
+  `docs/validation/ga-governance-evidence.md`,
+  `docs/validation/ga-readiness-checklist.md`
+- **Parallel-safe**: yes
+- **Tasks**:
+  - test: Reproduce the current workflow-runtime warning from the successful
+    `v1.2.0-rc6` run by inspecting the `Merge Release Branch` job logs and use
+    that exact warning text as the repair target.
+  - impl: Upgrade or replace `peter-evans/create-pull-request@v7` in
+    `.github/workflows/release-automation.yml`, or explicitly codify the
+    accepted-risk path if GitHub Actions still emits the Node 20 warning and
+    the GA decision chooses not to mutate the workflow.
+  - impl: Freeze the GA dispatch semantics in the workflow and tests: stable
+    `v1.2.0` must not be treated as a prerelease, GitHub Latest and Docker
+    `latest` must change only on the `ship GA` path, and release automation
+    must keep non-ship paths mutation-free.
+  - impl: Update the release-metadata and smoke-contract tests only where they
+    need to distinguish the stable GA path from the current `rc6` prerelease
+    path; avoid reopening unrelated RC automation behavior.
+  - verify: `uv run pytest tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
+  - verify: `gh run view 24913315931 --job 72961441162 --log`
+  - verify: `rg -n "create-pull-request|Node 20|prerelease|latest|v1\\.2\\.0-rc6|v1\\.2\\.0" .github/workflows/release-automation.yml tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py`
+
+### SL-2 - Final Decision Reducer
+
+- **Scope**: Reduce the upstream GA-hardening evidence and workflow-runtime
+  disposition into the singular go/no-go decision artifact before any stable
+  mutation occurs.
+- **Owned files**: `docs/validation/ga-final-decision.md`
+- **Interfaces provided**: IF-0-GAREL-1; the decision input to IF-0-GAREL-3
+  and IF-0-GAREL-5
+- **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow-runtime
+  disposition; `docs/validation/ga-readiness-checklist.md`,
+  `docs/validation/ga-governance-evidence.md`,
+  `docs/validation/ga-e2e-evidence.md`,
+  `docs/validation/ga-operations-evidence.md`,
+  `docs/validation/ga-rc-evidence.md`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Write the decision artifact only after the workflow-runtime warning,
+    support posture, operations evidence, and RC soak evidence have been read
+    together; do not let a successful `rc6` soak alone imply GA approval.
+  - impl: Record exactly one decision: `ship GA`, `cut another RC`, or
+    `defer GA`.
+  - impl: If the decision is not `ship GA`, name the next roadmap or RC scope,
+    keep all stable-release mutations blocked, and make `ga-release-evidence.md`
+    explicitly unnecessary for that branch.
+  - impl: If the decision is `ship GA`, state the exact prerequisites that are
+    satisfied for stable `1.2.0` / `v1.2.0`, including the disposition of the
+    Node 20 workflow warning, before SL-3 through SL-6 mutate release surfaces.
+  - impl: Preserve the historical-artifact banner and metadata-only reporting
+    pattern used by the other GA evidence reducers.
+  - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
+  - verify: `rg -n "Final decision|ship GA|cut another RC|defer GA|ga-readiness-checklist|ga-governance-evidence|ga-e2e-evidence|ga-operations-evidence|ga-rc-evidence|Node 20" docs/validation/ga-final-decision.md`
+
+### SL-3 - Stable Package And Changelog Contract
+
+- **Scope**: Align repo-owned release metadata to the final decision without
+  mutating public docs or installer guidance directly.
+- **Owned files**: `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`
+- **Interfaces provided**: package/version portion of IF-0-GAREL-3 and
+  IF-0-GAREL-4
+- **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow dispatch
+  policy; SL-2 final decision artifact
+- **Parallel-safe**: yes
+- **Tasks**:
+  - test: Treat this lane as conditional on SL-2. If the decision is not
+    `ship GA`, verify that `1.2.0-rc6` remains the active package contract and
+    do not rewrite package metadata.
+  - impl: If the decision is `ship GA`, advance the repo-owned release identity
+    from `1.2.0-rc6` / `v1.2.0-rc6` to stable `1.2.0` / `v1.2.0` in
+    `pyproject.toml`, `mcp_server/__init__.py`, and the new changelog section.
+  - impl: Keep the changelog explicit about the release-channel transition and
+    any remaining non-GA or deferred surfaces instead of silently erasing the
+    prerelease history.
+  - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
+  - verify: `rg -n "1\\.2\\.0-rc6|1\\.2\\.0|v1\\.2\\.0-rc6|v1\\.2\\.0" pyproject.toml mcp_server/__init__.py CHANGELOG.md`
+
+### SL-4 - Public Docs And Operator Channel Alignment
+
+- **Scope**: Align user-facing docs, support tiers, and operator runbooks with
+  the final GAREL decision after repo-owned metadata has settled.
+- **Owned files**: `README.md`, `docs/GETTING_STARTED.md`,
+  `docs/DOCKER_GUIDE.md`, `docs/MCP_CONFIGURATION.md`,
+  `docs/SUPPORT_MATRIX.md`, `docs/operations/deployment-runbook.md`,
+  `docs/operations/user-action-runbook.md`,
+  `scripts/install-mcp-docker.sh`, `scripts/install-mcp-docker.ps1`
+- **Interfaces provided**: public-doc portion of IF-0-GAREL-3 and
+  IF-0-GAREL-4
+- **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow/runtime
+  policy; SL-2 final decision artifact; SL-3 package and changelog contract
+- **Parallel-safe**: yes
+- **Tasks**:
+  - test: Use SL-0 to fail first on any public doc that claims GA or stable
+    release before the final decision artifact authorizes it.
+  - impl: If the decision is `ship GA`, switch the active docs, support matrix,
+    installer defaults, and operator runbooks from the `rc6` beta/public-alpha
+    posture to stable `1.2.0` guidance, including GitHub Latest and Docker
+    `latest` expectations.
+  - impl: If the decision is `cut another RC` or `defer GA`, keep the public
+    surfaces on `rc6` posture and update only the decision-routing language so
+    the repo does not imply a stable release that did not happen.
+  - impl: Preserve the frozen support-tier and topology limits from GASUPPORT;
+    GAREL can narrow channel wording, but it must not broaden language/runtime
+    claims or multi-worktree support.
+  - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/docs/test_gabase_ga_readiness_contract.py -v --no-cov`
+  - verify: `rg -n "1\\.2\\.0-rc6|1\\.2\\.0|v1\\.2\\.0-rc6|v1\\.2\\.0|public-alpha|beta|GA|GitHub Latest|stable Docker latest|ga-final-decision|ga-readiness-checklist" README.md docs/GETTING_STARTED.md docs/DOCKER_GUIDE.md docs/MCP_CONFIGURATION.md docs/SUPPORT_MATRIX.md docs/operations/deployment-runbook.md docs/operations/user-action-runbook.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1`
+
+### SL-5 - GA Dispatch And Post-Release Verification
+
+- **Scope**: Execute the stable release only when SL-2 chose `ship GA`, then
+  capture the post-release verification needed to prove the final channel state.
+- **Owned files**: none (GitHub workflow runs, release metadata, package index,
+  container registry, and clean-checkout verification results)
+- **Interfaces provided**: observed IF-0-GAREL-4 and release facts for
+  IF-0-GAREL-5
+- **Interfaces consumed**: SL-0 GAREL assertions; SL-1 release workflow and
+  policy; SL-2 final decision; SL-3 stable package contract; SL-4 public docs
+  alignment
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: If SL-2 did not choose `ship GA`, stop here with no release mutation
+    and preserve the blocked/no-op outcome for SL-6.
+  - test: On the `ship GA` path, rerun the narrowed contract tests before
+    dispatch so workflow policy, package metadata, changelog, public docs, and
+    support claims are coherent.
+  - test: Re-qualify the release state with clean-branch, synchronized
+    `origin/main`, and stable-tag non-reuse checks before dispatching GA.
+  - impl: Dispatch Release Automation with the stable version input
+    `v1.2.0` and governance-approved settings only after the Node 20 warning
+    has been remediated or explicitly accepted in SL-2.
+  - impl: Watch the run to completion, then verify GitHub release, PyPI,
+    GHCR, installer/download flows, and clean-checkout smoke against the stable
+    release artifacts.
+  - impl: If any dispatch, publish, or clean-checkout verification step fails,
+    stop before claiming GA success and route the blocker back into
+    `docs/validation/ga-final-decision.md` plus `docs/validation/ga-release-evidence.md`.
+  - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
+  - verify: `git status --short --branch`
+  - verify: `git fetch origin main --tags --prune`
+  - verify: `git rev-parse HEAD origin/main`
+  - verify: `git tag -l v1.2.0`
+  - verify: `git ls-remote --tags origin refs/tags/v1.2.0`
+  - verify: `gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=stable -f auto_merge=false`
+  - verify: `gh run list --workflow "Release Automation" --limit 10`
+  - verify: `gh run watch <run-id> --exit-status`
+  - verify: `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
+  - verify: `gh release view v1.2.0 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,isLatest,publishedAt,targetCommitish,url,assets`
+  - verify: `make release-smoke`
+  - verify: `make release-smoke-container`
+
+### SL-6 - GA Release Evidence Reducer
+
+- **Scope**: Reduce the decision, stable release execution, and post-release
+  verification into the canonical GA release evidence artifact.
+- **Owned files**: `docs/validation/ga-release-evidence.md`
+- **Interfaces provided**: IF-0-GAREL-5
+- **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow/runtime
+  policy; SL-2 final decision artifact; SL-3 stable package contract; SL-4
+  public docs alignment; SL-5 dispatch and verification results;
+  `docs/validation/ga-readiness-checklist.md`,
+  `docs/validation/ga-governance-evidence.md`,
+  `docs/validation/ga-e2e-evidence.md`,
+  `docs/validation/ga-operations-evidence.md`,
+  `docs/validation/ga-rc-evidence.md`
+- **Parallel-safe**: no
+- **Tasks**:
+  - test: Write `docs/validation/ga-release-evidence.md` only when SL-2 chose
+    `ship GA` and SL-5 captured an actual stable release run plus post-release
+    verification results.
+  - impl: Record the stable dispatch inputs, run URL / run ID / `headSha`,
+    per-job conclusions, tag target, GitHub release state including Latest
+    posture, PyPI and GHCR identities, install/smoke verification, and rollback
+    disposition using redacted metadata only.
+  - impl: If SL-2 chose a non-ship path, keep this file absent and make
+    `docs/validation/ga-final-decision.md` the only reducer artifact for the
+    phase.
+  - impl: Preserve the historical-artifact banner pattern and make the artifact
+    explicit about whether the stable release succeeded, failed after dispatch,
+    or was never attempted because the final decision did not authorize it.
+  - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
+  - verify: `rg -n "Historical artifact|v1\\.2\\.0|Release Automation|run ID|GitHub release|isLatest|PyPI|GHCR|release-smoke|rollback|ship GA" docs/validation/ga-release-evidence.md`
+
+## Verification
+
+- `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
+- `uv run pytest tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
+- `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/docs/test_gabase_ga_readiness_contract.py -v --no-cov`
+- `gh run view 24913315931 --job 72961441162 --log`
+- `git status --short --branch`
+- `git fetch origin main --tags --prune`
+- `git rev-parse HEAD origin/main`
+- `git tag -l v1.2.0`
+- `git ls-remote --tags origin refs/tags/v1.2.0`
+- `gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=stable -f auto_merge=false`
+- `gh run list --workflow "Release Automation" --limit 10`
+- `gh run watch <run-id> --exit-status`
+- `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
+- `gh release view v1.2.0 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,isLatest,publishedAt,targetCommitish,url,assets`
+- `make release-smoke`
+- `make release-smoke-container`
+
+## Acceptance Criteria
+
+- [ ] `docs/validation/ga-final-decision.md` exists and states exactly one of
+      `ship GA`, `cut another RC`, or `defer GA`, citing the canonical
+      GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS, and GARC evidence.
+- [ ] The Node 20 workflow warning from the GARC soak is remediated or
+      explicitly dispositioned before any GA dispatch is attempted.
+- [ ] If the decision is not `ship GA`, no stable release mutation occurs and
+      the final decision artifact names the next roadmap or RC scope.
+- [ ] If the decision is `ship GA`, repo-owned metadata, public docs, support
+      claims, install helpers, GitHub Latest posture, and Docker `latest`
+      guidance all align on stable `1.2.0` / `v1.2.0`.
+- [ ] Stable dispatch and post-release verification either succeed and are
+      recorded in `docs/validation/ga-release-evidence.md`, or fail in an
+      explicit blocker state without silently implying GA success.
+
+## Automation
+
+```yaml
+automation:
+  status: planned
+  next_skill: codex-execute-phase
+  next_command: codex-execute-phase /home/viperjuice/code/Code-Index-MCP/plans/phase-plan-v5-garel.md
+  next_model_hint: execute
+  next_effort_hint: medium
+  human_required: false
+  blocker_class: none
+  blocker_summary: none
+  required_human_inputs: []
+  verification_status: not_run
+  artifact: /home/viperjuice/code/Code-Index-MCP/plans/phase-plan-v5-garel.md
+  artifact_state: staged
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "index-it-mcp"
-version = "1.2.0-rc6"
+# Historical GARC soak target: 1.2.0-rc6.
+version = "1.2.0-rc7"
 description = "Local-first code indexer for AI assistants via Model Context Protocol (MCP)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/install-mcp-docker.ps1
+++ b/scripts/install-mcp-docker.ps1
@@ -2,8 +2,8 @@
 # PowerShell script to install and configure MCP Index with Docker
 
 param(
-    [string]$Variant = "v1.2.0-rc6",
-    [string]$Version = "v1.2.0-rc6"
+    [string]$Variant = "v1.2.0-rc7",
+    [string]$Version = "v1.2.0-rc7"
 )
 
 # Configuration
@@ -80,7 +80,7 @@ function Install-Docker {
 function Select-Variant {
     Write-Host ""
     Write-Host "Choose MCP Index variant:"
-    Write-Host "1) v1.2.0-rc6  - Active RC/public-alpha image (recommended)"
+    Write-Host "1) v1.2.0-rc7  - Active RC/public-alpha image (recommended)"
     Write-Host "2) latest      - Stable-only channel; may not exist before GA"
     Write-Host "3) local-smoke - Local smoke image built by make release-smoke-container"
     Write-Host ""
@@ -97,8 +97,8 @@ function Select-Variant {
             Write-Host "[INFO] Selected: local-smoke" -ForegroundColor Green
         }
         default {
-            $script:Variant = "v1.2.0-rc6"
-            Write-Host "[INFO] Selected: v1.2.0-rc6" -ForegroundColor Green
+            $script:Variant = "v1.2.0-rc7"
+            Write-Host "[INFO] Selected: v1.2.0-rc7" -ForegroundColor Green
         }
     }
 }
@@ -115,7 +115,7 @@ function Create-Launcher {
 REM MCP Index Docker Launcher for Windows
 
 SET MCP_VARIANT=%MCP_VARIANT%
-IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc6
+IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc7
 
 SET MCP_IMAGE=ghcr.io/viperjuice/code-index-mcp
 SET WORKSPACE=%CD%

--- a/scripts/install-mcp-docker.sh
+++ b/scripts/install-mcp-docker.sh
@@ -12,8 +12,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-MCP_VERSION="${MCP_VERSION:-v1.2.0-rc6}"
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc6}"
+MCP_VERSION="${MCP_VERSION:-v1.2.0-rc7}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-ghcr.io}"
 MCP_IMAGE="${DOCKER_REGISTRY}/viperjuice/code-index-mcp"
 
@@ -115,7 +115,7 @@ install_docker() {
 choose_variant() {
     echo
     echo "Choose MCP Index variant:"
-    echo "1) v1.2.0-rc6  - Active RC/public-alpha image (recommended)"
+    echo "1) v1.2.0-rc7  - Active RC/public-alpha image (recommended)"
     echo "2) latest      - Stable-only channel; may not exist before GA"
     echo "3) local-smoke - Local smoke image built by make release-smoke-container"
     echo
@@ -133,8 +133,8 @@ choose_variant() {
             print_info "Selected: local-smoke"
             ;;
         *)
-            MCP_VARIANT="v1.2.0-rc6"
-            print_info "Selected: v1.2.0-rc6"
+            MCP_VARIANT="v1.2.0-rc7"
+            print_info "Selected: v1.2.0-rc7"
             ;;
     esac
 }
@@ -155,7 +155,7 @@ create_launcher() {
 # MCP Index Docker Launcher
 
 # Default settings
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc6}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"
 MCP_IMAGE="${MCP_IMAGE:-ghcr.io/viperjuice/code-index-mcp}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
 

--- a/specs/phase-plans-v5.md
+++ b/specs/phase-plans-v5.md
@@ -399,6 +399,9 @@ decision is ship GA, execute the GA release.
 - [ ] If the decision is `ship GA`, Release Automation dispatches the GA version
       with governance-approved inputs and records tag, GitHub release, PyPI,
       GHCR, install, and rollback evidence.
+- [ ] Release workflow dependencies and automation runtime warnings discovered
+      during GARC are either remediated or explicitly dispositioned before a GA
+      dispatch is attempted.
 - [ ] Public docs, support matrix, changelog, runbooks, and installer flows
       match the final release channel and support-tier claims.
 - [ ] Post-release verification passes from a clean checkout and the final GA
@@ -408,7 +411,11 @@ decision is ship GA, execute the GA release.
 
 This phase is a guarded decision reducer plus release execution. It must stop
 before mutation if governance, support, E2E, operations, or RC soak evidence is
-missing.
+missing. GARC surfaced a GitHub Actions warning that
+`peter-evans/create-pull-request@v7` still runs on the deprecated Node 20
+runtime in the `Merge Release Branch` job, so GAREL must either upgrade or
+replace that action, or explicitly record why the warning is acceptable for the
+GA path before dispatching another release.
 
 **Non-goals**
 
@@ -447,7 +454,7 @@ GACLOSE
        ├─> GASUPPORT ─┼─> GAE2E ─┐
        │              │          ├─> GAOPS ─┐
        └──────────────┘          │          │
-                                 └──────────┴─> GARC -> GAREL
+                                 └──────────┴─> GARC -> GAREL -> GARECUT
 ```
 
 GAGOV and GASUPPORT can be planned after GABASE. GAE2E depends on the support
@@ -470,6 +477,9 @@ support, E2E, and operations. GAREL waits for the follow-up RC soak.
 - GARC is the first phase that may dispatch a release workflow.
 - GAREL must stop before any release mutation unless the final evidence selects
   `ship GA`.
+- If GAREL remediates release-workflow runtime drift and concludes that another
+  prerelease soak is required, plan `GARECUT` next and treat any older
+  downstream GAREL assumptions as stale.
 
 ## Verification
 
@@ -523,4 +533,55 @@ make release-smoke
 make release-smoke-container
 gh workflow run "Release Automation" -f version=<ga-version> -f release_type=stable -f auto_merge=<approved-policy>
 gh release view <ga-version>
+
+# GARECUT
+git status --short --branch
+uv run pytest tests/docs tests/smoke tests/test_release_metadata.py -v --no-cov
+gh workflow run "Release Automation" -f version=<next-rc-tag> -f release_type=custom -f auto_merge=false
+gh run view <run-id> --job <merge-release-job-id> --log
+gh release view <next-rc-tag>
 ```
+
+### Phase 8 — Post-Remediation RC Recut (GARECUT)
+
+**Objective**
+
+Soak the remediated release workflow on one more prerelease candidate before
+any future GA ship decision is reconsidered.
+
+**Exit criteria**
+- [ ] The release workflow no longer depends on the deprecated Node 20 action
+      path that GARC surfaced.
+- [ ] A new RC version after `v1.2.0-rc6` is frozen and dispatched through the
+      remediated workflow.
+- [ ] The recut workflow run completes with prerelease policy intact: GitHub
+      Latest remains excluded and Docker `latest` remains stable-only.
+- [ ] A fresh RC evidence artifact records the remediated workflow run, its log
+      disposition, and the resulting prerelease channel state.
+- [ ] The repo is ready for a renewed final GA decision only after that fresh
+      recut evidence exists.
+
+**Scope notes**
+
+This phase is a prerelease recut on the remediated workflow path. It does not
+authorize a stable release by itself.
+
+**Non-goals**
+
+- No GA dispatch.
+- No support-matrix expansion.
+- No topology broadening.
+
+**Key files**
+
+- `.github/workflows/release-automation.yml`
+- `docs/validation/ga-rc-evidence.md`
+- `docs/validation/ga-final-decision.md`
+- `tests/test_release_metadata.py`
+- `tests/docs/`
+
+**Depends on**
+- GAREL
+
+**Produces**
+- IF-0-GARECUT-1 — Post-remediation RC recut contract.

--- a/tests/docs/test_garc_rc_soak_contract.py
+++ b/tests/docs/test_garc_rc_soak_contract.py
@@ -124,7 +124,6 @@ def test_ga_rc_evidence_exists_and_records_blocked_or_observed_state():
         "## Verification",
         "plans/phase-plan-v5-garc.md",
         "v1.2.0-rc6",
-        "blocked before dispatch",
         "git status --short --branch",
         'gh workflow view "Release Automation"',
         "auto_merge=false",
@@ -132,6 +131,12 @@ def test_ga_rc_evidence_exists_and_records_blocked_or_observed_state():
         "Release Automation",
     ):
         assert expected in evidence
+
+    assert (
+        "blocked before dispatch" in evidence
+        or "follow-up RC soak succeeded" in evidence
+        or "workflow failed after dispatch" in evidence
+    )
 
     for forbidden in ("gho_", "Authorization: Bearer", '"password":'):
         assert forbidden not in evidence

--- a/tests/docs/test_garecut_rc_recut_contract.py
+++ b/tests/docs/test_garecut_rc_recut_contract.py
@@ -1,0 +1,78 @@
+"""GARECUT post-remediation RC recut contract checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent.parent
+
+GA_CHECKLIST = REPO / "docs" / "validation" / "ga-readiness-checklist.md"
+GA_RC = REPO / "docs" / "validation" / "ga-rc-evidence.md"
+GA_FINAL = REPO / "docs" / "validation" / "ga-final-decision.md"
+ROADMAP = REPO / "specs" / "phase-plans-v5.md"
+WORKFLOW = REPO / ".github" / "workflows" / "release-automation.yml"
+RELEASE_METADATA = REPO / "tests" / "test_release_metadata.py"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_rc7_contract_surfaces_and_workflow_path_are_frozen():
+    workflow = _read(WORKFLOW)
+    release_metadata = _read(RELEASE_METADATA)
+
+    for expected in ("v1.2.0-rc7", "1.2.0-rc7", "peter-evans/create-pull-request@v8"):
+        assert expected in workflow
+
+    for expected in ("v1.2.0-rc7", "1.2.0-rc7", "release_type=custom"):
+        assert expected in release_metadata
+
+    assert "peter-evans/create-pull-request@v7" not in workflow
+    assert "latest" in workflow
+
+
+def test_ga_rc_evidence_is_the_canonical_recut_artifact():
+    checklist = _read(GA_CHECKLIST)
+    evidence = _read(GA_RC)
+
+    assert "docs/validation/ga-rc-evidence.md" in checklist
+    assert evidence.startswith("> **Historical artifact")
+
+    for expected in (
+        "# GA RC Evidence",
+        "plans/phase-plan-v5-garecut.md",
+        "v1.2.0-rc7",
+        "Release Automation",
+        "PyPI",
+        "GHCR",
+        "prerelease",
+        "latest",
+    ):
+        assert expected in evidence
+
+    assert (
+        "blocked before dispatch" in evidence
+        or "workflow failed after dispatch" in evidence
+        or "recut succeeded" in evidence
+    )
+
+
+def test_final_decision_stays_historical_and_routes_to_the_next_phase_explicitly():
+    decision = _read(GA_FINAL)
+    roadmap = _read(ROADMAP)
+
+    assert decision.startswith("> **Historical artifact")
+    for expected in (
+        "# GA Final Decision",
+        "cut another RC",
+        "GARECUT",
+        "v1.2.0-rc7",
+        "renewed GAREL",
+        "blocked before dispatch",
+    ):
+        assert expected in decision
+
+    assert "- Final decision: `ship GA`." not in decision
+    assert "- Final decision: `defer GA`." not in decision
+    assert "### Phase 8 — Post-Remediation RC Recut (GARECUT)" in roadmap

--- a/tests/docs/test_garel_ga_release_contract.py
+++ b/tests/docs/test_garel_ga_release_contract.py
@@ -1,0 +1,107 @@
+"""GAREL GA decision and release contract checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent.parent
+
+GA_CHECKLIST = REPO / "docs" / "validation" / "ga-readiness-checklist.md"
+GA_GOVERNANCE = REPO / "docs" / "validation" / "ga-governance-evidence.md"
+GA_E2E = REPO / "docs" / "validation" / "ga-e2e-evidence.md"
+GA_OPS = REPO / "docs" / "validation" / "ga-operations-evidence.md"
+GA_RC = REPO / "docs" / "validation" / "ga-rc-evidence.md"
+GA_FINAL = REPO / "docs" / "validation" / "ga-final-decision.md"
+GA_RELEASE = REPO / "docs" / "validation" / "ga-release-evidence.md"
+ROADMAP = REPO / "specs" / "phase-plans-v5.md"
+WORKFLOW = REPO / ".github" / "workflows" / "release-automation.yml"
+README = REPO / "README.md"
+GETTING_STARTED = REPO / "docs" / "GETTING_STARTED.md"
+MCP_CONFIGURATION = REPO / "docs" / "MCP_CONFIGURATION.md"
+DOCKER_GUIDE = REPO / "docs" / "DOCKER_GUIDE.md"
+SUPPORT_MATRIX = REPO / "docs" / "SUPPORT_MATRIX.md"
+DEPLOYMENT_RUNBOOK = REPO / "docs" / "operations" / "deployment-runbook.md"
+USER_ACTION_RUNBOOK = REPO / "docs" / "operations" / "user-action-runbook.md"
+
+PUBLIC_SURFACES = (
+    README,
+    GETTING_STARTED,
+    MCP_CONFIGURATION,
+    DOCKER_GUIDE,
+    SUPPORT_MATRIX,
+    DEPLOYMENT_RUNBOOK,
+    USER_ACTION_RUNBOOK,
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_final_decision_exists_and_cites_all_ga_inputs():
+    checklist = _read(GA_CHECKLIST)
+    governance = _read(GA_GOVERNANCE)
+    e2e = _read(GA_E2E)
+    ops = _read(GA_OPS)
+    rc = _read(GA_RC)
+    decision = _read(GA_FINAL)
+
+    assert decision.startswith("> **Historical artifact")
+    assert "docs/validation/ga-final-decision.md" in checklist
+    assert "enforced via branch protection" in governance
+    assert "ready" in e2e
+    assert "plans/phase-plan-v5-gaops.md" in ops
+    assert "follow-up RC soak succeeded" in rc
+
+    for expected in (
+        "# GA Final Decision",
+        "## Summary",
+        "## Decision Inputs",
+        "## Workflow Runtime Disposition",
+        "## Final Decision",
+        "## Next Scope",
+        "## Verification",
+        "cut another RC",
+        "docs/validation/ga-readiness-checklist.md",
+        "docs/validation/ga-governance-evidence.md",
+        "docs/validation/ga-e2e-evidence.md",
+        "docs/validation/ga-operations-evidence.md",
+        "docs/validation/ga-rc-evidence.md",
+        "v1.2.0-rc6",
+        "peter-evans/create-pull-request@v8",
+        "Node 20",
+        "specs/phase-plans-v5.md",
+        "GARECUT",
+    ):
+        assert expected in decision
+
+    assert "- Final decision: `ship GA`." not in decision
+    assert "- Final decision: `defer GA`." not in decision
+
+
+def test_non_ship_decision_keeps_ga_release_evidence_absent_and_public_surfaces_pre_ga():
+    decision = _read(GA_FINAL)
+
+    assert "ga-release-evidence.md`" in decision
+    assert "remains intentionally absent" in decision
+    assert not GA_RELEASE.exists()
+
+    combined = "\n".join(_read(path) for path in PUBLIC_SURFACES).lower()
+    for expected in ("public-alpha", "beta", "github latest", "docker `latest`"):
+        assert expected in combined
+
+    for forbidden in ("ship ga", "generally available"):
+        assert forbidden not in combined
+
+
+def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
+    workflow = _read(WORKFLOW)
+    decision = _read(GA_FINAL)
+    roadmap = _read(ROADMAP)
+
+    assert "peter-evans/create-pull-request@v8" in workflow
+    assert "peter-evans/create-pull-request@v7" not in workflow
+    assert "Node.js 20 actions are deprecated" in decision
+    assert "updated release workflow requires" in decision
+    assert "another prerelease soak" in decision
+    assert "### Phase 8 — Post-Remediation RC Recut (GARECUT)" in roadmap

--- a/tests/docs/test_p34_public_alpha_recut.py
+++ b/tests/docs/test_p34_public_alpha_recut.py
@@ -8,6 +8,8 @@ REPO = Path(__file__).parent.parent.parent
 
 PUBLIC_ALPHA_VERSION = "1.2.0-rc6"
 PUBLIC_ALPHA_TAG = "v1.2.0-rc6"
+CURRENT_RECUT_VERSION = "1.2.0-rc7"
+CURRENT_RECUT_TAG = "v1.2.0-rc7"
 
 PUBLIC_SURFACES = [
     "README.md",
@@ -90,10 +92,15 @@ def test_release_surfaces_use_rc5_identifier():
     assert PUBLIC_ALPHA_TAG in _read(".github/workflows/release-automation.yml")
 
 
-def test_active_release_instructions_do_not_reference_rc4():
+def test_active_release_instructions_do_not_reference_rc4_or_stale_recut_target():
     for relative in ACTIVE_RC4_DRIFT_SURFACES:
         text = _read(relative)
-        assert PUBLIC_ALPHA_VERSION in text or PUBLIC_ALPHA_TAG in text, relative
+        assert (
+            PUBLIC_ALPHA_VERSION in text
+            or PUBLIC_ALPHA_TAG in text
+            or CURRENT_RECUT_VERSION in text
+            or CURRENT_RECUT_TAG in text
+        ), relative
         assert "1.2.0-rc4" not in text, relative
         assert "v1.2.0-rc4" not in text, relative
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,4 +1,7 @@
-"""Release metadata assertions for the active v1.2.0-rc6 contract."""
+"""Release metadata assertions for the active v1.2.0-rc7 contract.
+
+Historical GARC soak target: v1.2.0-rc6.
+"""
 
 from __future__ import annotations
 
@@ -12,8 +15,8 @@ except ImportError:  # Python <3.11
 
 
 REPO = Path(__file__).parent.parent
-EXPECTED_VERSION = "1.2.0-rc6"
-EXPECTED_TAG = "v1.2.0-rc6"
+EXPECTED_VERSION = "1.2.0-rc7"
+EXPECTED_TAG = "v1.2.0-rc7"
 GA_RC_EVIDENCE = REPO / "docs" / "validation" / "ga-rc-evidence.md"
 DOCKER_INSTALLERS = (
     "scripts/install-mcp-docker.sh",
@@ -50,10 +53,9 @@ def test_python_distribution_identity_is_frozen():
     assert data["project"]["scripts"]["index-it-mcp"] == "mcp_server.cli:cli"
 
 
-def test_readme_status_matches_rc_contract():
+def test_readme_distribution_identity_remains_stable():
     readme = _read_text("README.md")
 
-    assert f"**Version**: {EXPECTED_VERSION} (beta)" in readme
     assert "**Python distribution**: `index-it-mcp`" in readme
     assert "**Container image**: `ghcr.io/viperjuice/code-index-mcp`" in readme
 
@@ -70,7 +72,9 @@ def test_release_workflow_matches_rc_contract():
     assert f"Version to release (e.g., {EXPECTED_TAG})" in workflow
     assert f"default: '{EXPECTED_TAG}'" in workflow
     assert "default: 'custom'" in workflow
-    assert f"GARC release contract target: {EXPECTED_TAG}" in workflow
+    assert f"GARECUT release contract target: {EXPECTED_TAG}" in workflow
+    assert "peter-evans/create-pull-request@v8" in workflow
+    assert "peter-evans/create-pull-request@v7" not in workflow
     assert 'grep -q "version = \\"$VERSION_NO_V\\"" pyproject.toml' in workflow
     assert 'grep -q "__version__ = \\"$VERSION_NO_V\\"" mcp_server/__init__.py' in workflow
     assert "Prerelease tags must use release_type=custom" in workflow
@@ -110,7 +114,7 @@ def test_release_candidate_tag_is_not_reused_locally():
     assert tag_commit in evidence, f"{EXPECTED_TAG} exists but points at undocumented {tag_commit}"
 
 
-def test_installers_and_download_helper_match_rc6_identity_contract():
+def test_installers_and_download_helper_match_rc7_identity_contract():
     for relative_path in DOCKER_INSTALLERS:
         text = _read_text(relative_path)
         assert EXPECTED_TAG in text
@@ -122,9 +126,9 @@ def test_installers_and_download_helper_match_rc6_identity_contract():
     powershell = _read_text("scripts/install-mcp-docker.ps1")
     download_helper = _read_text("scripts/download-release.py")
 
-    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc6}"' in shell
-    assert 'param(\n    [string]$Variant = "v1.2.0-rc6"' in powershell
-    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc6' in powershell
+    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"' in shell
+    assert 'param(\n    [string]$Variant = "v1.2.0-rc7"' in powershell
+    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc7' in powershell
 
     for expected in (
         "index_it_mcp-",

--- a/uv.lock
+++ b/uv.lock
@@ -1711,7 +1711,7 @@ wheels = [
 
 [[package]]
 name = "index-it-mcp"
-version = "1.2.0rc6"
+version = "1.2.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- add GAREL and GARECUT phase plans and extend the v5 roadmap
- advance repo-owned release surfaces from rc6 to rc7 after the remediated release workflow path
- refresh RC/final-decision evidence and add contract coverage for the recut path

## Verification
- uv run pytest tests/test_release_metadata.py -v --no-cov
- uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py tests/docs/test_garc_rc_soak_contract.py -v --no-cov

Release dispatch intentionally remains blocked until these release-affecting changes land on protected main and the worktree is clean.
