### PR TITLE
Prepare rc8 recut baseline

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -6,9 +6,9 @@ on:
     # Historical GARC default: 'v1.2.0-rc6'
     inputs:
       version:
-        description: 'Version to release (e.g., v1.2.0-rc7)'
+        description: 'Version to release (e.g., v1.2.0-rc8)'
         required: true
-        default: 'v1.2.0-rc7'
+        default: 'v1.2.0-rc8'
         type: string
       release_type:
         description: 'Release type'
@@ -74,7 +74,9 @@ jobs:
               exit 1
               ;;
           esac
-          grep -q "default: 'v1.2.0-rc7'" .github/workflows/release-automation.yml
+          grep -q "default: 'v1.2.0-rc8'" .github/workflows/release-automation.yml
+          # Stable GA dispatch stays on the existing workflow contract:
+          # gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=custom -f auto_merge=false
           if [ "$RELEASE_TYPE" = "custom" ]; then
             grep -q "version = \"$VERSION_NO_V\"" pyproject.toml
             grep -q "__version__ = \"$VERSION_NO_V\"" mcp_server/__init__.py
@@ -334,7 +336,7 @@ jobs:
           git push origin "$VERSION"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare-release.outputs.version }}
           name: Release ${{ needs.prepare-release.outputs.version }}
@@ -374,7 +376,7 @@ jobs:
           body: |
             ## Release ${{ needs.prepare-release.outputs.version }}
 
-            GARECUT release contract target: v1.2.0-rc7
+            GARECUT release contract target: v1.2.0-rc8
 
             This PR contains all changes for release ${{ needs.prepare-release.outputs.version }}.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: # placeholder for post-rc5 work
 
-## [1.2.0-rc7] — 2026-04-24
+## [1.2.0-rc8] — 2026-04-25
 
 ### Changed (GARECUT — post-remediation RC recut freeze)
-- Advanced the active remediated RC recut contract to `1.2.0-rc7` /
-  `v1.2.0-rc7` across package metadata, runtime metadata, release automation
+- Advanced the active remediated RC recut contract to `1.2.0-rc8` /
+  `v1.2.0-rc8` across package metadata, runtime metadata, release automation
   defaults, and installer helpers without widening into GA channel changes.
-- Froze the rc7 recut evidence and final-decision handoff expectations so the
-  refreshed prerelease proof can route the next downstream work back through a
-  renewed GAREL reduction instead of silently authorizing GA.
+- Froze the rc8 recut evidence and final-decision handoff expectations so a
+  blocked or successful prerelease proof can route the next work either back
+  through renewed GAREL or into a GARECUT rerun without silently authorizing
+  GA.
 
 ### Known limitations
-- `v1.2.0-rc7` remains a prerelease RC/public-alpha or beta channel artifact;
+- `v1.2.0-rc8` remains a prerelease RC/public-alpha or beta channel artifact;
 - it does not authorize GA wording, GitHub Latest promotion, or stable Docker
   `latest`; GitHub Latest is not the RC policy source.
 - GARECUT dispatch still requires a clean enough release worktree, `HEAD ==
-  origin/main`, and unused local plus remote `v1.2.0-rc7` tags before
+  origin/main`, and unused local plus remote `v1.2.0-rc8` tags before
   `gh workflow run` may execute.
+
+## [1.2.0-rc7] — 2026-04-24
 
 ## [1.2.0-rc6] — 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Modular, extensible local-first code indexer designed to enhance Claude Code and
 > **Beta status**: Multi-repo support and the MCP STDIO interface are in beta. The MCP tool interface (`search_code`, `symbol_lookup`, and friends) is the primary surface for LLM-driven use; the FastAPI REST gateway is a secondary admin surface for diagnostics and manual operations. Expect API surface changes before stable release.
 
 ## Project Status
-**Version**: 1.2.0-rc6 (beta)
+**Version**: 1.2.0-rc8 (beta)
 **Python distribution**: `index-it-mcp`
 **Container image**: `ghcr.io/viperjuice/code-index-mcp`
 **Primary surface**: MCP tools (`search_code`, `symbol_lookup`) via the STDIO runner when repository readiness is `ready`
@@ -141,7 +141,7 @@ This automatically detects your environment and creates the appropriate `.mcp.js
 curl -sSL https://raw.githubusercontent.com/ViperJuice/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
 
 # Index your current directory
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 #### Option 2: AI-Powered Search
@@ -150,7 +150,7 @@ docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
 export VOYAGE_API_KEY=your-key
 
 # Run with semantic search enabled explicitly
-docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_API_KEY ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_API_KEY ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ### 💻 Environment-Specific Setup
@@ -161,7 +161,7 @@ docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_AP
 .\scripts\setup-mcp-json.ps1
 
 # Or manually with Docker Desktop
-docker run -it -v ${PWD}:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+docker run -it -v ${PWD}:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 #### 🍎 macOS
@@ -229,7 +229,7 @@ The setup script creates the appropriate `.mcp.json` for your environment. Manua
       "args": [
         "run", "-i", "--rm",
         "-v", "${workspace}:/workspace",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }
@@ -331,10 +331,10 @@ for language/runtime support details.
 #### Option 1: Install via pip (Recommended)
 ```bash
 # After the public-alpha package is published, install the rc package
-pip install --pre index-it-mcp==1.2.0rc5
+pip install --pre index-it-mcp==1.2.0rc8
 
 # Or install with dev tools for testing
-pip install --pre "index-it-mcp[dev]==1.2.0rc5"
+pip install --pre "index-it-mcp[dev]==1.2.0rc8"
 ```
 
 #### Option 2: Install from Source
@@ -1129,10 +1129,10 @@ Maintainers can create new releases with pre-built indexes:
 
 ```bash
 # Create a new release (as draft)
-python scripts/create-release.py --version 1.2.0-rc6
+python scripts/create-release.py --version 1.2.0-rc8
 
 # Create and publish immediately
-python scripts/create-release.py --version 1.2.0-rc6 --publish
+python scripts/create-release.py --version 1.2.0-rc8 --publish
 ```
 
 ### Automatic Index Synchronization
@@ -1202,7 +1202,7 @@ For detailed architectural documentation, see the [architecture/](architecture/)
 
 See [ROADMAP.md](ROADMAP.md) for detailed development plans and current progress.
 
-**Current Status**: 1.2.0-rc6 beta release candidate
+**Current Status**: 1.2.0-rc8 beta release candidate
 - ✅ **Core Indexing**: SQLite + FTS5 for fast local search
 - ✅ **Multi-Language**: Specialized and registry-backed language coverage; see `docs/SUPPORT_MATRIX.md`
 - ✅ **MCP Protocol**: Full compatibility with Claude Code and other MCP clients

--- a/docs/DEPLOYMENT-GUIDE.md
+++ b/docs/DEPLOYMENT-GUIDE.md
@@ -11,8 +11,8 @@ The supported deployment surfaces are:
 
 - local checkout plus `uv sync --locked`
 - the published package `index-it-mcp` at the current follow-up RC
-  `1.2.0-rc6`
-- the container image `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6`
+  `1.2.0-rc8`
+- the container image `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8`
 
 These are the only supported deployment surfaces referenced by the GAOPS
 operator path. For executable procedures, use:

--- a/docs/DOCKER_GUIDE.md
+++ b/docs/DOCKER_GUIDE.md
@@ -1,6 +1,6 @@
 # Docker Guide for MCP Index Server
 
-This guide documents the beta Docker path for Code-Index-MCP `1.2.0-rc6`.
+This guide documents the beta Docker path for Code-Index-MCP `1.2.0-rc8`.
 The P22-proven image package is `ghcr.io/viperjuice/code-index-mcp`. MCP STDIO
 is the primary LLM surface; FastAPI remains a secondary admin surface. The
 pre-GA release boundary and evidence map are frozen in
@@ -48,7 +48,7 @@ for the canonical support contract.
 P23 documents one image package:
 
 ```bash
-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 Enable optional behavior with environment variables and installed extras rather
@@ -79,13 +79,13 @@ iwr -useb https://raw.githubusercontent.com/Code-Index-MCP/main/scripts/install-
 
 2. **Pull the image**:
    ```bash
-   docker pull ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+   docker pull ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
    ```
 
 3. **Create launcher script**:
    ```bash
    # Linux/macOS
-   echo 'docker run -i --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 "$@"' > /usr/local/bin/mcp-index
+   echo 'docker run -i --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 "$@"' > /usr/local/bin/mcp-index
    chmod +x /usr/local/bin/mcp-index
    ```
 
@@ -100,7 +100,7 @@ Configure the Docker container using environment variables:
 docker run -it \
   -e LOG_LEVEL=DEBUG \
   -e MCP_WORKSPACE_ROOT=/workspace \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ### Configuration File (.env)
@@ -176,13 +176,13 @@ mcp-index upgrade
 
 ```bash
 # Minimal version - basic search
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Standard version - with API key
 docker run -it \
   -v $(pwd):/workspace \
   -e VOYAGE_API_KEY=your-key \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Full version - with external services
 docker run -it \
@@ -190,7 +190,7 @@ docker run -it \
   -e VOYAGE_API_KEY=your-key \
   -e REDIS_URL=redis://redis:6379 \
   -e QDRANT_URL=http://qdrant:6333 \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 For many unrelated repositories, mount each root deliberately, set
@@ -202,7 +202,7 @@ docker run -it \
   -v /abs/repo-a:/repos/repo-a \
   -v /abs/repo-b:/repos/repo-b \
   -e MCP_ALLOWED_ROOTS=/repos/repo-a:/repos/repo-b \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 mcp-index repository register /repos/repo-a
 mcp-index repository register /repos/repo-b
@@ -222,7 +222,7 @@ version: '3.8'
 
 services:
   mcp-index:
-    image: ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+    image: ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
     volumes:
       - ./:/workspace
       - ~/.mcp-index:/app/.mcp-index
@@ -289,13 +289,13 @@ Control index sharing per repository:
 
 ```bash
 # Check sync status
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 artifact status
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 artifact status
 
 # Download latest index
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 artifact pull
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 artifact pull
 
 # Upload your index
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 artifact push
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 artifact push
 ```
 
 ### Security Features
@@ -324,7 +324,7 @@ Create `.mcp.json` in your project root:
         "-v", "${HOME}/.mcp-index:/app/.mcp-index",
         "-e", "VOYAGE_API_KEY=${VOYAGE_API_KEY:-}",
         "-e", "MCP_ARTIFACT_SYNC=${MCP_ARTIFACT_SYNC:-true}",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }
@@ -440,7 +440,7 @@ Connect to Docker running on the host:
 ```bash
 # Inside dev container
 export DOCKER_HOST=tcp://host.docker.internal:2375
-docker run -it -v /mnt/c/path/to/code:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+docker run -it -v /mnt/c/path/to/code:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 **Note:** Requires Docker Desktop with exposed daemon.
@@ -453,7 +453,7 @@ For WSL2 with Docker Desktop:
 2. **Use WSL paths** for volume mounts:
    ```bash
    # Convert Windows path to WSL path
-   docker run -it -v /mnt/c/Users/name/project:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+   docker run -it -v /mnt/c/Users/name/project:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
    ```
 
 3. **Configure .mcp.json for WSL:**
@@ -466,7 +466,7 @@ For WSL2 with Docker Desktop:
            "run", "-i", "--rm",
            "-v", "${workspace}:/workspace",
            "-v", "/mnt/c/Users/${USER}/.mcp-index:/app/.mcp-index",
-           "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+           "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
          ]
        }
      }
@@ -527,7 +527,7 @@ docker version
 
 # Test MCP connection
 echo '{"jsonrpc":"2.0","method":"initialize","id":1}' | \
-  docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Verify volume mounts
 docker run --rm -v $(pwd):/workspace alpine ls -la /workspace
@@ -573,7 +573,7 @@ docker run -it \
   -e LOG_LEVEL=DEBUG \
   -e MCP_LOG_FILE=/workspace/mcp-debug.log \
   -v $(pwd):/workspace \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ### Health Checks
@@ -582,13 +582,13 @@ Check container health:
 
 ```bash
 # Check if MCP server is responsive
-docker run --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 --health
+docker run --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 --health
 
 # Test database connection
-docker run --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 test db
+docker run --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 test db
 
 # Verify index status
-docker run --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6 index status
+docker run --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 index status
 ```
 
 ## Advanced Topics
@@ -598,7 +598,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc
 Extend the base images for your needs:
 
 ```dockerfile
-FROM ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+FROM ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Add custom dependencies
 RUN pip install --no-cache-dir custom-package
@@ -634,12 +634,12 @@ docker run -it \
   -v $(pwd):/workspace \
   -v mcp-index-data:/app/data \
   -v mcp-index-cache:/app/.cache \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Read-only workspace
 docker run -it \
   -v $(pwd):/workspace:ro \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ### Network Configuration
@@ -657,7 +657,7 @@ docker run -d --name redis --network mcp-network redis:alpine
 docker run -it \
   --network mcp-network \
   -e REDIS_URL=redis://redis:6379 \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ### Performance Tuning
@@ -671,7 +671,7 @@ docker run -it \
   -e CACHE_MAX_MEMORY_MB=1000 \
   --cpus="4" \
   --memory="8g" \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 ## Support

--- a/docs/DYNAMIC_PLUGIN_LOADING.md
+++ b/docs/DYNAMIC_PLUGIN_LOADING.md
@@ -1,5 +1,8 @@
 # Dynamic Plugin Loading System
 
+> **Beta status**: Current release-surface examples should assume the
+> `1.2.0-rc8` prerelease channel unless a section is explicitly historical.
+
 ## Overview
 
 The MCP Server now features a comprehensive dynamic plugin loading system that automatically discovers, loads, and manages plugins at runtime. This system replaces the previous hardcoded plugin initialization, providing greater flexibility and extensibility.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 This guide walks you through installing and using Code-Index-MCP to index and search your codebase.
 
-> **Beta status**: This guide targets `1.2.0-rc6`. MCP STDIO is the primary
+> **Beta status**: This guide targets `1.2.0-rc8`. MCP STDIO is the primary
 > LLM surface; FastAPI is a secondary admin surface. Language behavior is
 > documented in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md), and the pre-GA release
 > boundary is frozen in
@@ -30,7 +30,7 @@ This guide walks you through installing and using Code-Index-MCP to index and se
 
 ```bash
 # After the public-alpha package is published, install the rc package
-pip install --pre index-it-mcp==1.2.0rc5
+pip install --pre index-it-mcp==1.2.0rc8
 
 # Verify installation
 mcp-index --version

--- a/docs/MCP_CONFIGURATION.md
+++ b/docs/MCP_CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive information on configuring the Code-Index-MCP for different environments and use cases.
 
-> **Beta status**: This guide targets `1.2.0-rc6`. MCP STDIO is the primary
+> **Beta status**: This guide targets `1.2.0-rc8`. MCP STDIO is the primary
 > LLM surface. FastAPI remains a secondary admin surface. Docker examples use
 > `ghcr.io/viperjuice/code-index-mcp`.
 > Language behavior is defined in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md), and
@@ -119,7 +119,7 @@ The setup script automatically detects your environment:
         "-e", "MCP_WORKSPACE_ROOT=/workspace",
         "-e", "LOG_LEVEL=${LOG_LEVEL:-INFO}",
         "-e", "MCP_ARTIFACT_SYNC=false",
-        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6}"
+        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8}"
       ]
     }
   }
@@ -152,7 +152,7 @@ The setup script automatically detects your environment:
         "-e", "SEMANTIC_SEARCH_ENABLED=${SEMANTIC_SEARCH_ENABLED:-true}",
         "-e", "MCP_ARTIFACT_SYNC=${MCP_ARTIFACT_SYNC:-true}",
         "-e", "LOG_LEVEL=${LOG_LEVEL:-INFO}",
-        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6}"
+        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8}"
       ]
     }
   }
@@ -277,7 +277,7 @@ one worktree per git common directory, and check readiness before MCP tool use:
         "-v", "${HOME}/projects/repo-a:/repos/repo-a",
         "-v", "${HOME}/projects/repo-b:/repos/repo-b",
         "-e", "MCP_ALLOWED_ROOTS=/repos/repo-a:/repos/repo-b",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }
@@ -331,7 +331,7 @@ Add Docker resource constraints:
         "--memory", "2g",
         "--cpus", "2",
         "-v", "${workspace}:/workspace",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }
@@ -351,7 +351,7 @@ For maximum security:
         "run", "-i", "--rm",
         "--network", "none",
         "-v", "${workspace}:/workspace:ro",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ],
       "env": {
         "MCP_ARTIFACT_SYNC": "false"
@@ -428,7 +428,7 @@ Enable debug logging:
         "-v", "${workspace}:/workspace",
         "-e", "LOG_LEVEL=DEBUG",
         "-e", "MCP_DEBUG=true",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }
@@ -441,7 +441,7 @@ Test your configuration:
 
 ```bash
 # Test MCP connection
-echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}' | docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6
+echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}' | docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 
 # Expected response:
 # {"jsonrpc":"2.0","id":1,"result":{"capabilities":...}}
@@ -517,7 +517,7 @@ Enable security audit logs:
         "-v", "${HOME}/mcp-audit:/app/logs",
         "-e", "MCP_AUDIT_LOG=/app/logs/audit.log",
         "-e", "MCP_SECURITY_MODE=strict",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
       ]
     }
   }

--- a/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -10,8 +10,8 @@ freeze.
 - Product-level posture remains `public-alpha` / `beta`, not `GA`.
 - Operators own promotion, rollback, observability, and support triage.
 - The supported deployment surfaces are the local checkout, the `index-it-mcp`
-  package at `1.2.0-rc6`, and the
-  `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6` image.
+  package at `1.2.0-rc8`, and the
+  `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8` image.
 - The authoritative procedure sources are
   `docs/validation/ga-readiness-checklist.md`,
   `docs/operations/deployment-runbook.md`,

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,7 +1,7 @@
 # Code-Index-MCP Support Matrix
 
 This matrix is the canonical GASUPPORT support statement for version
-`1.2.0-rc6`. The product release posture is still RC/public-alpha and beta:
+`1.2.0-rc8`. The product release posture is still RC/public-alpha and beta:
 MCP STDIO is the primary LLM surface, FastAPI is a secondary admin surface,
 and the GA-hardening roadmap is reducing claims rather than widening the
 product.
@@ -22,7 +22,7 @@ evidence checklist is `docs/validation/ga-readiness-checklist.md`.
 
 ## Claim tiers
 
-- **Public-alpha**: `v1.2.0-rc6` is the active RC/public-alpha package
+- **Public-alpha**: `v1.2.0-rc8` is the active RC/public-alpha package
   contract. It is suitable for outside-developer validation of the documented
   STDIO, readiness, repository-topology, and Docker package surfaces.
 - **Beta**: Multi-repo support, STDIO, and secondary tool readiness remain beta
@@ -116,8 +116,8 @@ topology, or install-surface support expansion.
 | STDIO mutation and summarization tools (`reindex`, `write_summaries`, `summarize_sample`) | beta | Secondary tool surfaces behind readiness gates | `tool_handlers.py`, TOOLRDY evidence, readiness-refusal tests | Non-ready repos fail closed; the artifact is readiness evidence, not support expansion |
 | FastAPI admin and diagnostics surface | beta | Secondary/admin surface | `README.md`, `docs/GETTING_STARTED.md`, `docs/MCP_CONFIGURATION.md` | Do not treat FastAPI as the primary LLM interface |
 | Native source install via `uv sync --locked` | beta | Canonical local development and operator path | `pyproject.toml`, `uv.lock`, install docs | This is the preferred local install path while the release remains pre-GA |
-| Pre-release package install (`index-it-mcp==1.2.0rc5`) | beta | Opt-in release artifact path | package naming and install docs | Keep tied to the RC/public-alpha release boundary until later GA evidence exists |
-| Docker image `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc6` | beta | Supported container path | Docker guide, release evidence, image naming tests | Container docs must keep the same topology and readiness limits as native docs |
+| Pre-release package install (`index-it-mcp==1.2.0rc8`) | beta | Opt-in release artifact path | package naming and install docs | Keep tied to the RC/public-alpha release boundary until later GA evidence exists |
+| Docker image `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8` | beta | Supported container path | Docker guide, release evidence, image naming tests | Container docs must keep the same topology and readiness limits as native docs |
 | Semantic search (`uv sync --locked --extra semantic` plus provider config) | experimental | Optional extra and provider-dependent | extras docs, config env vars, support-fact notes | Requires provider credentials or a compatible local endpoint; not unconditional support |
 | Reranking (`uv sync --locked --extra rerank` plus provider/model config) | experimental | Optional extra and provider-dependent | extras docs and support-fact notes | Treat as opt-in ranking improvement, not baseline query behavior |
 | Default sandboxed plugin execution | beta | Default security posture | `sandbox_supported`, `activation_mode`, sandbox docs | Coverage varies by language and is authoritative through `plugin_availability` |

--- a/docs/api/API-REFERENCE.md
+++ b/docs/api/API-REFERENCE.md
@@ -1,5 +1,8 @@
 # Code-Index-MCP API Reference
 
+> **Beta status**: This API reference describes the `1.2.0-rc8` beta release
+> surface and should not be read as a GA guarantee.
+
 ## Overview
 
 Code-Index-MCP provides a comprehensive FastAPI-based REST API for code indexing, searching, and management across multiple programming languages. The API features authentication, monitoring, caching, and a plugin-based architecture for language-specific functionality.

--- a/docs/operations/deployment-runbook.md
+++ b/docs/operations/deployment-runbook.md
@@ -1,9 +1,9 @@
-# Deployment Runbook (v1.2.0-rc5 public-alpha / beta baseline)
+# Deployment Runbook (v1.2.0-rc8 public-alpha / beta baseline)
 
 ## Overview
 
 This runbook is the operator playbook for the Code-Index-MCP
-`v1.2.0-rc5` public-alpha / beta baseline. It is not a GA launch document.
+`v1.2.0-rc8` public-alpha / beta baseline. It is not a GA launch document.
 The supported deployment surfaces remain local-first and operator-owned:
 
 - `uv sync --locked` plus the local checkout
@@ -39,7 +39,7 @@ tracked/default branch indexing only, and `index_unavailable` with
 The current RC/public-alpha baseline remains blocked on these required gates:
 the original P27-P33 production-readiness contract is still part of the
 pre-release checklist, and the current follow-up RC keeps the same release-gate
-shape while advancing the artifact identity to `v1.2.0-rc6`.
+shape while advancing the artifact identity to `v1.2.0-rc8`.
 
 | Required job | Operator decision | Command/workflow source | Block/fallback behavior |
 |---|---|---|---|
@@ -63,8 +63,8 @@ input evidence and should not be rewritten out of the record.
 |---|---|---|
 | Branch protection | `gh api repos/ViperJuice/Code-Index-MCP/branches/main` and `/protection` | `main` is protected and enforces the required GA gate contexts before merge. |
 | Repository ruleset | `gh api repos/ViperJuice/Code-Index-MCP/rulesets` | No repository rulesets are configured; branch protection is the active enforcement surface. |
-| Active RC contract | `docs/validation/rc5-release-evidence.md` and release `v1.2.0-rc5` | `v1.2.0-rc5` remains the active RC/public-alpha package contract. |
-| GACLOSE prerequisites | `docs/validation/release-governance-evidence.md`, `docs/validation/secondary-tool-readiness-evidence.md`, and `docs/validation/ga-closeout-decision.md` | Preserve the historical inputs before choosing `stay on RC/public-alpha`, `cut a follow-up RC`, or `start a GA hardening roadmap`. |
+| Active RC contract | `docs/validation/ga-rc-evidence.md` and release `v1.2.0-rc8` | `v1.2.0-rc8` remains the active RC/public-alpha package contract. |
+| GACLOSE prerequisites | `docs/validation/rc5-release-evidence.md`, `docs/validation/release-governance-evidence.md`, `docs/validation/secondary-tool-readiness-evidence.md`, and `docs/validation/ga-closeout-decision.md` | Preserve the historical inputs before choosing `stay on RC/public-alpha`, `cut a follow-up RC`, or `start a GA hardening roadmap`. |
 | GitHub Latest | `gh api repos/ViperJuice/Code-Index-MCP/releases/latest` | GitHub Latest still points at `v2.15.0-alpha.1`; it is excluded from the RC/GA policy source until a final GA release changes that state. |
 | Release automation | `.github/workflows/release-automation.yml` | Hyphenated versions are prereleases, prerelease dispatch requires `release_type=custom`, Docker latest is stable-only, and `auto_merge=false` is the RC default. |
 
@@ -93,7 +93,7 @@ The protection disposition recorded in
 - Enforce for administrators: `true`
 - Repository rulesets: `none`
 
-GitHub Latest still points at `v2.15.0-alpha.1`, while `v1.2.0-rc5` remains
+GitHub Latest still points at `v2.15.0-alpha.1`, while `v1.2.0-rc8` remains
 the active RC/public-alpha contract. That split is intentional until a final GA
 release changes the channel state. `auto_merge=false` remains the default RC
 workflow policy, and Docker latest remains stable-only.
@@ -108,7 +108,7 @@ the blocker through GAGOV/GAOPS before GARC dispatches another RC.
 Before GAGOV, GAE2E, GAOPS, GARC, or GAREL work begins, use
 `docs/validation/ga-readiness-checklist.md` as the canonical GABASE checklist.
 It freezes the release boundary, support tiers, required gates, evidence map,
-rollback expectations, and non-GA surfaces for the active `v1.2.0-rc5`
+rollback expectations, and non-GA surfaces for the active `v1.2.0-rc8`
 RC/public-alpha baseline.
 
 Refresh evidence ownership is:
@@ -120,13 +120,14 @@ Refresh evidence ownership is:
 - `docs/validation/ga-final-decision.md` -> `GAREL`
 - `docs/validation/ga-release-evidence.md` -> `GAREL`
 
-The follow-up RC version is frozen for GARC as `v1.2.0-rc6`.
+The active post-remediation RC version is `v1.2.0-rc8`, and the next recut
+target should advance beyond that version when GARECUT is replanned.
 
 ## GARC Follow-Up RC Procedure
 
 GARC is the first GA-hardening phase allowed to dispatch Release Automation.
-It may do so only after the repo-owned `rc6` contract surfaces, public docs,
-installer helpers, and operator procedure all agree on `v1.2.0-rc6`.
+It may do so only after the repo-owned `rc8` contract surfaces, public docs,
+installer helpers, and operator procedure all agree on `v1.2.0-rc8`.
 
 ### Pre-dispatch qualification
 
@@ -137,8 +138,8 @@ Before dispatch, the release operator must record all of the following in
 git status --short --branch
 git fetch origin main --tags --prune
 git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc6
-git ls-remote --tags origin refs/tags/v1.2.0-rc6
+git tag -l v1.2.0-rc8
+git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
 ```
 
@@ -147,7 +148,7 @@ Qualification passes only when:
 1. `git status --short --branch` shows a clean expected release branch state.
 2. `git rev-parse HEAD origin/main` reports the same commit for local `HEAD`
    and `origin/main`.
-3. No local or remote `v1.2.0-rc6` tag already exists.
+3. No local or remote `v1.2.0-rc8` tag already exists.
 4. `docs/validation/ga-governance-evidence.md`,
    `docs/validation/ga-e2e-evidence.md`, and
    `docs/validation/ga-operations-evidence.md` are present as the current
@@ -164,7 +165,7 @@ Run the current clean-checkout release verification set before dispatch:
 ```bash
 uv run pytest tests/smoke tests/docs tests/test_release_metadata.py
 make release-smoke release-smoke-container
-git tag -l v1.2.0-rc6
+git tag -l v1.2.0-rc8
 ```
 
 Keep `tests/docs/test_p34_public_alpha_recut.py` in this gate set so the
@@ -175,11 +176,11 @@ follow-up RC continues to preserve the original public-alpha recut contract.
 When qualification passes, dispatch exactly:
 
 ```bash
-gh workflow run "Release Automation" -f version=v1.2.0-rc6 -f release_type=custom -f auto_merge=false
+gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false
 gh run list --workflow "Release Automation" --limit 10
 gh run watch <run-id> --exit-status
 gh run view <run-id> --json url,headSha,status,conclusion,jobs
-gh release view v1.2.0-rc6 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
 ```
 
 The operator must record run URL, run ID, `headSha`, per-job conclusions,
@@ -195,7 +196,7 @@ The follow-up RC remains a prerelease/public-alpha or beta channel operation:
   explicitly approves an exception.
 - GitHub Latest remains excluded from the RC policy source.
 - Docker `latest` remains stable-only.
-- No GA wording or stable-channel claims may be introduced by the `rc6` soak.
+- No GA wording or stable-channel claims may be introduced by the `rc8` soak.
 
 ## GAOPS Operator Procedure Contract
 

--- a/docs/operations/user-action-runbook.md
+++ b/docs/operations/user-action-runbook.md
@@ -383,7 +383,7 @@ No operator actions required. P12 is fully codebase-internal.
   `docs/validation/ga-final-decision.md` plus
   `docs/validation/ga-release-evidence.md` for `GAREL`.
 - [ ] **Freeze the follow-up RC target.** GARC should plan around
-  `v1.2.0-rc6` unless a later roadmap amendment changes that contract.
+  `v1.2.0-rc8` unless a later roadmap amendment changes that contract.
 - [ ] **Keep governance in manual enforcement posture.** GABASE does not change
   branch protection, rulesets, release dispatch, or GA claims.
 
@@ -429,10 +429,10 @@ No operator actions required. P12 is fully codebase-internal.
 
 #### Before GARC
 
-- [ ] **Freeze the `rc6` contract surfaces first.** `pyproject.toml`,
+- [ ] **Freeze the `rc8` contract surfaces first.** `pyproject.toml`,
   `mcp_server/__init__.py`, `.github/workflows/release-automation.yml`,
   `CHANGELOG.md`, customer docs, installer helpers, and
-  `tests/test_release_metadata.py` must all agree on `v1.2.0-rc6` before any
+  `tests/test_release_metadata.py` must all agree on `v1.2.0-rc8` before any
   release dispatch is attempted.
 - [ ] **Require a clean release candidate state.** Run
   `git status --short --branch`; if the worktree is dirty, stop and record
@@ -440,8 +440,8 @@ No operator actions required. P12 is fully codebase-internal.
 - [ ] **Verify branch and tag qualification.** Run
   `git fetch origin main --tags --prune`,
   `git rev-parse HEAD origin/main`,
-  `git tag -l v1.2.0-rc6`, and
-  `git ls-remote --tags origin refs/tags/v1.2.0-rc6`.
+  `git tag -l v1.2.0-rc8`, and
+  `git ls-remote --tags origin refs/tags/v1.2.0-rc8`.
 - [ ] **Require fresh upstream evidence.** Treat
   `docs/validation/ga-governance-evidence.md`,
   `docs/validation/ga-e2e-evidence.md`, and
@@ -452,13 +452,13 @@ No operator actions required. P12 is fully codebase-internal.
 - [ ] **Confirm release-workflow visibility before dispatch.** Run
   `gh workflow view "Release Automation"` and record only metadata.
 - [ ] **Dispatch with the frozen RC policy.** Use exactly
-  `gh workflow run "Release Automation" -f version=v1.2.0-rc6 -f release_type=custom -f auto_merge=false`.
+  `gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false`.
 - [ ] **Observe the workflow to completion.** Record
   `gh run list --workflow "Release Automation" --limit 10`,
   `gh run watch <run-id> --exit-status`,
   `gh run view <run-id> --json url,headSha,status,conclusion,jobs`, and
-  `gh release view v1.2.0-rc6 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`.
-- [ ] **Keep the channel split explicit.** `v1.2.0-rc6` remains prerelease
+  `gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`.
+- [ ] **Keep the channel split explicit.** `v1.2.0-rc8` remains prerelease
   public-alpha/beta posture, `auto_merge=false` stays the default, GitHub
   Latest remains excluded from the RC policy source, and Docker `latest`
   remains stable-only.

--- a/docs/security/attestation.md
+++ b/docs/security/attestation.md
@@ -1,6 +1,6 @@
 # Artifact Attestation & Signing
 
-> **Beta status**: This page targets `1.2.0-rc6`. Attestation policy is part
+> **Beta status**: This page targets `1.2.0-rc8`. Attestation policy is part
 > of the current security posture for the `ghcr.io/viperjuice/code-index-mcp`
 > release path, with operational limits documented in the deployment runbook.
 

--- a/docs/security/path-guard.md
+++ b/docs/security/path-guard.md
@@ -1,6 +1,6 @@
 # Path Traversal Guard
 
-> **Beta status**: This page targets `1.2.0-rc6`. `MCP_ALLOWED_ROOTS` is the
+> **Beta status**: This page targets `1.2.0-rc8`. `MCP_ALLOWED_ROOTS` is the
 > current path boundary knob for MCP tools in beta multi-repo deployments.
 
 ## Overview

--- a/docs/security/sandbox.md
+++ b/docs/security/sandbox.md
@@ -1,6 +1,6 @@
 # Plugin Sandbox Architecture
 
-> **Beta status**: This page targets `1.2.0-rc6`. Default sandbox behavior is
+> **Beta status**: This page targets `1.2.0-rc8`. Default sandbox behavior is
 > documented alongside language support in [../SUPPORT_MATRIX.md](../SUPPORT_MATRIX.md).
 
 ## Overview

--- a/docs/security/token-scopes.md
+++ b/docs/security/token-scopes.md
@@ -1,6 +1,6 @@
 # GitHub Token Scopes & Validation
 
-> **Beta status**: This page targets `1.2.0-rc6`. Token validation supports
+> **Beta status**: This page targets `1.2.0-rc8`. Token validation supports
 > artifact and attestation operations for the current beta release path.
 
 ## Overview

--- a/docs/validation/ga-final-decision.md
+++ b/docs/validation/ga-final-decision.md
@@ -1,12 +1,12 @@
-> **Historical artifact — as-of 2026-04-24, may not reflect current behavior**
+> **Historical artifact — as-of 2026-04-25, may not reflect current behavior**
 
 # GA Final Decision
 
 ## Summary
 
-- Evidence captured: `2026-04-24T23:17:04Z`.
-- Original decision phase plan: `plans/phase-plan-v5-garel.md`.
-- Original final decision: `cut another RC`.
+- Evidence captured: `2026-04-25T03:40:00Z`.
+- Executed decision phase plan: `plans/phase-plan-v5-garel.md`.
+- Final decision: `cut another RC`.
 - Stable GA dispatch: `not authorized`.
 - Stable release evidence artifact: `docs/validation/ga-release-evidence.md`
   remains intentionally absent because no GA release was attempted.
@@ -27,28 +27,31 @@ Evidence summary:
   protection on `main` and keeps GitHub Latest excluded from the prerelease
   policy source until a final GA release changes that state.
 - `docs/validation/ga-e2e-evidence.md` and
-  `docs/validation/ga-operations-evidence.md` remain prerelease-path evidence
-  for the historical `v1.2.0-rc6` release contract; they do not independently
-  authorize stable mutation.
-- `docs/validation/ga-rc-evidence.md` now records the `v1.2.0-rc7` GARECUT
-  recut attempt as `blocked before dispatch` while preserving the historical
-  `v1.2.0-rc6` soak that motivated the recut.
+  `docs/validation/ga-operations-evidence.md` remain prerelease-path evidence.
+  They support GA evaluation, but they do not independently authorize stable
+  mutation.
+- `docs/validation/ga-rc-evidence.md` now records the `v1.2.0-rc8` GARECUT
+  attempt as `blocked before dispatch` while preserving the earlier successful
+  `v1.2.0-rc7` recut as historical evidence.
+- This GAREL execution remediated the remaining `Create GitHub Release`
+  Node 20 warning by upgrading `softprops/action-gh-release@v2` to
+  `softprops/action-gh-release@v3`, which shifts the release workflow again and
+  requires one more prerelease soak before GA can be reduced safely.
 
 ## Workflow Runtime Disposition
 
-The GARC soak recorded this warning in the `Merge Release Branch` job log:
+The historical GARC soak recorded a Node 20 warning on the old
+`peter-evans/create-pull-request@v7` path. GARECUT later proved that path was
+successfully remediated during run `24919438766`, but the same run surfaced a
+new GitHub Actions deprecation annotation in `Create GitHub Release` for
+`softprops/action-gh-release@v2`.
 
-- `Node 20` runtime warning persisted on the historical GARC path.
-- `Node.js 20 actions are deprecated.`
-- Affected action: `peter-evans/create-pull-request@v7`.
-
-GAREL remediated the workflow by updating
+This GAREL execution remediated that remaining warning by updating
 `.github/workflows/release-automation.yml` to
-`peter-evans/create-pull-request@v8`, which is the Node 24-capable line.
-That removes the known deprecated runtime path from the workflow source, but it
-also means the previously soaked `v1.2.0-rc6` release did not exercise the
-current release workflow contract. The updated release workflow requires
-another prerelease soak before a stable GA dispatch can be defended.
+`softprops/action-gh-release@v3`, the current Node 24-capable release line.
+That is the correct repair for the workflow runtime, but it means the release
+path that would own a stable GA dispatch has changed again and has not yet been
+soaked on a prerelease candidate.
 
 ## Final Decision
 
@@ -56,14 +59,13 @@ another prerelease soak before a stable GA dispatch can be defended.
 
 Rationale:
 
-- The successful `v1.2.0-rc6` soak proves the old prerelease workflow path, not
-  the remediated one.
-- Shipping GA immediately after changing the release workflow would skip the
-  roadmap's required prerelease-soak evidence on the actual workflow that would
-  own the stable release.
-- Public docs, support-tier language, install defaults, and package metadata
-  remain on the `v1.2.0-rc6` prerelease/public-alpha-or-beta posture, so there
-  is no stable channel drift to unwind.
+- Fresh `v1.2.0-rc7` evidence exists for the remediated
+  `peter-evans/create-pull-request@v8` path.
+- This GAREL execution changed the release workflow again by moving
+  `softprops/action-gh-release` from `@v2` to `@v3`.
+- Shipping GA immediately after that workflow remediation would skip the
+  roadmap's required prerelease-soak evidence on the actual release path that
+  would own stable `v1.2.0`.
 - GitHub Latest still points at `v2.15.0-alpha.1`, and no `v1.2.0` tag,
   stable GitHub release, stable PyPI release evidence, or Docker `latest`
   verification was generated in this phase.
@@ -74,38 +76,46 @@ absent, and all stable-channel changes stay blocked.
 
 ## GARECUT Status
 
-- Current recut target: `v1.2.0-rc7`
+- Previous recut target: `v1.2.0-rc7`
+- Previous recut outcome: `recut succeeded`
+- Current recut target: `v1.2.0-rc8`
 - Current recut outcome: `blocked before dispatch`
-- Current readiness for renewed GAREL: `not ready`
+- Current readiness: `rerunning GARECUT after the release-affecting worktree is clean enough`
 
-The recut stopped before `gh workflow run` because the release-affecting
-worktree was dirty, even though `HEAD` matched `origin/main`, the remediated
-workflow was visible, and `v1.2.0-rc7` was unused locally and remotely.
+The prior recut dispatched and completed successfully on
+`https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24919438766`,
+published prerelease `v1.2.0-rc7`, pushed the multi-arch GHCR image, and
+published the `1.2.0rc7` wheel plus sdist to PyPI.
 
-A renewed GAREL reduction should happen only after fresh `v1.2.0-rc7` evidence
-exists. Until then, the correct next step is to rerun GARECUT after the
-release-affecting worktree is made clean enough for release mutation.
+The current rc8 recut did not dispatch because the release-affecting worktree
+is intentionally dirty in `.github/workflows/release-automation.yml`,
+`pyproject.toml`, `mcp_server/__init__.py`, installer helpers, validation docs,
+and release-contract tests even though `HEAD` still matches `origin/main`, the
+workflow is visible, and `v1.2.0-rc8` is unused locally and remotely.
+
+That keeps the repository on the same historical `cut another RC` decision: the
+release path still needs a fresh prerelease soak on
+`softprops/action-gh-release@v3`, and the immediate next step is rerunning
+GARECUT once the release-affecting tree is clean enough for mutation.
 
 ## Next Scope
 
-The roadmap remains on the existing downstream phase:
+The roadmap now routes to the nearest downstream phase with amended steering:
 
 - Roadmap artifact: `specs/phase-plans-v5.md`
-
 - Phase 8: `Post-Remediation RC Recut (GARECUT)`
 
-That phase must:
+That renewed phase must:
 
-- freeze the next prerelease tag after `v1.2.0-rc6`,
-- soak Release Automation on the remediated
-  `peter-evans/create-pull-request@v8` workflow path,
-- record fresh `v1.2.0-rc7` RC evidence on the remediated workflow contract,
-  and
-- only then reopen a renewed GAREL ship/no-ship reduction.
+- freeze the next prerelease target after `v1.2.0-rc7`,
+- soak the release workflow with `softprops/action-gh-release@v3`,
+- keep prerelease channel policy intact while proving the remediated release
+  path end-to-end, and
+- route back through a newly planned renewed GAREL only after that RC evidence
+  exists; until then, keep rerunning GARECUT rather than reopening GA.
 
-Any older downstream plan that assumed GAREL was terminal without this recut is
-stale after the roadmap amendment, and the repo is not yet ready for that
-renewed GAREL phase.
+Any older downstream GARECUT or GAREL plan that predates this roadmap
+amendment is stale and must not be treated as authoritative.
 
 ## Verification
 
@@ -113,10 +123,13 @@ renewed GAREL phase.
 uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov
 uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
 uv run pytest tests/test_release_metadata.py -v --no-cov
+uv run pytest tests/docs/test_garc_rc_soak_contract.py -v --no-cov
 git status --short --branch
 git fetch origin main --tags --prune
 git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc7
-git ls-remote --tags origin refs/tags/v1.2.0-rc7
+git tag -l v1.2.0-rc8
+git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
+gh run view 24919438766 --json url,headSha,status,conclusion,jobs
+gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
 ```

--- a/docs/validation/ga-rc-evidence.md
+++ b/docs/validation/ga-rc-evidence.md
@@ -1,29 +1,29 @@
-> **Historical artifact — as-of 2026-04-24, may not reflect current behavior**
+> **Historical artifact — as-of 2026-04-25, may not reflect current behavior**
 
 # GA RC Evidence
 
 ## Summary
 
-- Evidence captured: `2026-04-24T23:17:04Z`.
+- Evidence captured: `2026-04-25T02:31:42Z`.
 - Active phase plan: `plans/phase-plan-v5-garecut.md`.
 - Selected commit before dispatch evaluation:
-  `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`.
-- Active recut target: `v1.2.0-rc7`.
+  `a3adcea5cd569571a2c4ce3d863317e9f14519bc`.
+- Active recut target: `v1.2.0-rc8`.
 - Conclusion: `blocked before dispatch`.
 - Dispatch attempted: `no`.
-- Blocker: release-affecting worktree was dirty during the rc7 recut attempt, so
-  `gh workflow run` did not execute.
-- Channel posture preserved: no `v1.2.0-rc7` prerelease was published; GitHub
+- Blocker: release-affecting worktree remained dirty during the rc8 recut
+  attempt, so `gh workflow run` did not execute.
+- Channel posture preserved: no `v1.2.0-rc8` prerelease was published; GitHub
   Latest remained excluded and Docker `latest` remained stable-only.
 
 ## Pre-dispatch Qualification
 
 | Check | Command | Result | Evidence |
 |---|---|---|---|
-| Release candidate worktree state | `git status --short --branch` | fail | `## main...origin/main` with tracked and untracked release-affecting changes in `.github/workflows/release-automation.yml`, `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, tests, and validation docs. |
-| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`, `origin/main=3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`. |
-| Local tag reuse | `git tag -l v1.2.0-rc7` | pass | No local `v1.2.0-rc7` tag existed before dispatch evaluation. |
-| Remote tag reuse | `git ls-remote --tags origin refs/tags/v1.2.0-rc7` | pass | No remote `v1.2.0-rc7` tag existed before dispatch evaluation. |
+| Release candidate worktree state | `git status --short --branch` | fail | `## main...origin/main` with release-affecting dirty files in `.github/workflows/release-automation.yml`, `pyproject.toml`, `mcp_server/__init__.py`, installer helpers, validation docs, and release-contract tests. |
+| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=a3adcea5cd569571a2c4ce3d863317e9f14519bc`, `origin/main=a3adcea5cd569571a2c4ce3d863317e9f14519bc`. |
+| Local tag reuse | `git tag -l v1.2.0-rc8` | pass | No local `v1.2.0-rc8` tag existed before dispatch evaluation. |
+| Remote tag reuse | `git ls-remote --tags origin refs/tags/v1.2.0-rc8` | pass | No remote `v1.2.0-rc8` tag existed before dispatch evaluation. |
 | Release workflow visibility | `gh workflow view "Release Automation"` | pass | Workflow visible as `Release Automation - release-automation.yml`, workflow id `167401116`. |
 
 ## Intended Dispatch Inputs
@@ -31,33 +31,34 @@
 GARECUT would dispatch exactly:
 
 ```bash
-gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
+gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false
 ```
 
 Frozen channel-policy inputs:
 
-- Version: `v1.2.0-rc7`
+- Version: `v1.2.0-rc8`
 - Release type: `custom`
 - Auto-merge policy: `false`
 - Channel posture: prerelease `public-alpha` / `beta`
+- Workflow path under test: `softprops/action-gh-release@v3`
 
 ## Workflow Observation
 
 - Dispatch attempted: `no`
 - Run URL: `none - blocked before dispatch`
 - Run ID: `none - blocked before dispatch`
-- `headSha`: `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`
+- `headSha`: `a3adcea5cd569571a2c4ce3d863317e9f14519bc`
 - Workflow status / conclusion: `not started` / `blocked before dispatch`
-- Release branch / PR disposition: no `release/v1.2.0-rc7` branch or PR was
+- Release branch / PR disposition: no `release/v1.2.0-rc8` branch or PR was
   created because the recut stopped at the dirty-worktree gate.
-- GitHub release state: no `v1.2.0-rc7` release exists because dispatch did not
+- GitHub release state: no `v1.2.0-rc8` release exists because dispatch did not
   occur.
 - PyPI publication: none - blocked before dispatch.
 - GHCR image identity: none - blocked before dispatch.
 
 ## Release-Channel Policy
 
-- `v1.2.0-rc7` remains the frozen prerelease/public-alpha or beta recut target.
+- `v1.2.0-rc8` remains the frozen prerelease/public-alpha or beta recut target.
 - `release_type=custom` remains required for the hyphenated RC version.
 - `auto_merge=false` remains the required recut input.
 - GitHub Latest remained excluded from the RC policy source.
@@ -66,16 +67,17 @@ Frozen channel-policy inputs:
 
 ## Rollback And Next-Step Disposition
 
-No rollback was required because no rc7 release mutation occurred.
+No rollback was required because no rc8 release mutation occurred.
 
 Next-step disposition:
 
-- Remediate the dirty release-affecting worktree or preserve and commit the
-  intended rc7 surfaces before rerunning GARECUT.
-- A renewed GAREL decision is not yet ready; it depends on successful fresh
-  `v1.2.0-rc7` prerelease evidence on the remediated workflow path.
-- If a later GARECUT run succeeds, route the next downstream work back through
-  a renewed GAREL reduction. Until then, keep the work inside GARECUT.
+- Rerun GARECUT after the release-affecting worktree is clean enough for
+  mutation and the intended rc8 surfaces are preserved.
+- A renewed GAREL decision is not yet ready; it still depends on fresh
+  `v1.2.0-rc8` prerelease evidence on the remediated
+  `softprops/action-gh-release@v3` workflow path.
+- Until that rerun succeeds, keep the work inside GARECUT rather than
+  reopening GA or treating older downstream GAREL plans as authoritative.
 
 ## Historical GARC Baseline
 
@@ -94,7 +96,7 @@ recut result:
 
 ## Verification
 
-Planned or completed validation sources for this artifact:
+Completed validation sources for this artifact:
 
 ```bash
 uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
@@ -103,8 +105,7 @@ uv run pytest tests/test_release_metadata.py tests/docs/test_garecut_rc_recut_co
 git status --short --branch
 git fetch origin main --tags --prune
 git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc7
-git ls-remote --tags origin refs/tags/v1.2.0-rc7
+git tag -l v1.2.0-rc8
+git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
-gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
 ```

--- a/docs/validation/ga-readiness-checklist.md
+++ b/docs/validation/ga-readiness-checklist.md
@@ -5,16 +5,17 @@
 This is the canonical GABASE checklist for the v5 GA-hardening roadmap. It
 freezes the release boundary, support tiers, required gates, evidence map,
 rollback expectations, and non-GA surfaces for the current
-`v1.2.0-rc5` RC/public-alpha baseline before any GA claim or stable release
+`v1.2.0-rc8` RC/public-alpha baseline before any GA claim or stable release
 mutation.
 
 ## Release boundary
 
-- Active baseline: `v1.2.0-rc5` remains the current RC/public-alpha package
+- Active baseline: `v1.2.0-rc8` remains the current RC/public-alpha package
   contract across `README.md`, install docs, the support matrix, and operator
   runbooks.
-- Follow-up RC target: `v1.2.0-rc6` is the frozen follow-up RC version for
-  `GARC`.
+- Historical carried-forward inputs still include `v1.2.0-rc5` and
+  `v1.2.0-rc6`, but the currently documented prerelease surface is
+  `v1.2.0-rc8`.
 - Current release surfaces stay pre-GA: native Python/STDIO via
   `uv sync --locked`, the `index-it-mcp` package, and the
   `ghcr.io/viperjuice/code-index-mcp` container image remain the documented
@@ -86,7 +87,7 @@ must be regenerated before any later artifact can conclude `ship GA`.
 ## Rollback expectations
 
 - If a downstream hardening phase fails, fall back to the documented
-  `v1.2.0-rc5` RC/public-alpha contract rather than publishing GA wording.
+  `v1.2.0-rc8` RC/public-alpha contract rather than publishing GA wording.
 - Rollback instructions continue to live in
   `docs/operations/deployment-runbook.md` until `GAOPS` replaces or tightens
   them with fresh evidence.

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -2,7 +2,7 @@
 
 # Version information
 # Historical GARC soak target: 1.2.0-rc6.
-__version__ = "1.2.0-rc7"
+__version__ = "1.2.0-rc8"
 
 # Public API exports
 __all__ = [

--- a/plans/phase-plan-v5-garecut.md
+++ b/plans/phase-plan-v5-garecut.md
@@ -2,121 +2,135 @@
 phase_loop_plan_version: 1
 phase: GARECUT
 roadmap: specs/phase-plans-v5.md
-roadmap_sha256: 5f5c4b9cb20473287bad25c49816faf9bc110915e70010896436b3abc9cb4dca
+roadmap_sha256: df5244856bbe79d0f3fe5e6231eaf120b0ff448335a3f8f8134317ebc81f4802
 ---
 # GARECUT: Post-Remediation RC Recut
 
 ## Context
 
-GARECUT is the eighth phase in the v5 GA-hardening roadmap. GAREL already
-concluded `cut another RC` in `docs/validation/ga-final-decision.md`, so this
-phase is not another GA decision. It is a narrowly scoped operational recut on
-the remediated release workflow path before any renewed GA ship/no-ship
-reduction is reconsidered.
+GARECUT is the renewed phase-8 prerelease recut in the v5 GA-hardening
+roadmap. The current `GAREL` decision in
+`docs/validation/ga-final-decision.md` now records `cut another RC` after
+remediating `softprops/action-gh-release@v2` to
+`softprops/action-gh-release@v3`, so this phase is no longer the old `rc7`
+recut. It is a new prerelease soak on the newly remediated release path before
+any later GA decision is reconsidered.
 
 Current repo state gathered during planning:
 
-- The checkout is on `main` at `3d5a3aa`, and `.codex/phase-loop/state.json`
-  records `GAREL` as executed, `GARECUT` as unplanned, and the currently
-  selected roadmap hash as
-  `5f5c4b9cb20473287bad25c49816faf9bc110915e70010896436b3abc9cb4dca`.
-- The worktree is intentionally dirty with user-owned GAREL follow-through in
+- The checkout is on `main` at `a3adcea5cd569571a2c4ce3d863317e9f14519bc`,
+  matching `origin/main`, and the active roadmap hash is
+  `df5244856bbe79d0f3fe5e6231eaf120b0ff448335a3f8f8134317ebc81f4802`.
+- `.codex/phase-loop/state.json` marks `GAREL` as executed, `GARECUT` as
+  unplanned, and carries ledger warnings that older GARECUT/GAREL provenance is
+  stale under the amended roadmap.
+- The worktree is intentionally dirty with user-owned follow-through in
   `.github/workflows/release-automation.yml`,
-  `docs/validation/ga-rc-evidence.md`, `docs/validation/ga-final-decision.md`,
-  `tests/test_release_metadata.py`, `tests/docs/test_garc_rc_soak_contract.py`,
-  `tests/docs/test_garel_ga_release_contract.py`, and
-  `specs/phase-plans-v5.md`; GARECUT execution must preserve those edits and
-  treat the modified roadmap as the active baseline rather than reverting it.
-- `docs/validation/ga-final-decision.md` already records the GAREL outcome as
-  `cut another RC` because the prior successful `v1.2.0-rc6` soak did not
-  exercise the remediated workflow contract.
-- `.github/workflows/release-automation.yml` already uses
-  `peter-evans/create-pull-request@v8`, so GARECUT should treat the Node 20
-  path as remediated in source and focus on proving that remediated path under
-  one more prerelease run.
-- The repo-owned release surfaces that must move in lockstep for a recut are
-  still frozen to `1.2.0-rc6` / `v1.2.0-rc6` in `pyproject.toml`,
-  `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, and
-  `tests/test_release_metadata.py`.
-- The roadmap exit criteria require a new RC after `v1.2.0-rc6`; absent any
-  contradictory product input, this plan freezes that recut target as
-  `1.2.0-rc7` / `v1.2.0-rc7` and requires local plus remote non-reuse checks
-  before dispatch.
-- `docs/validation/ga-rc-evidence.md` remains the canonical prerelease evidence
-  artifact, while `docs/validation/ga-final-decision.md` remains the canonical
-  historical record of why GA was deferred pending this recut.
+  `docs/validation/ga-final-decision.md`,
+  `docs/validation/ga-rc-evidence.md`,
+  `docs/validation/ga-readiness-checklist.md`,
+  `tests/docs/test_garecut_rc_recut_contract.py`,
+  `tests/docs/test_garel_ga_release_contract.py`,
+  `tests/test_release_metadata.py`, and the staged
+  `plans/phase-plan-v5-garel.md`; GARECUT execution must preserve those edits
+  and treat the modified roadmap as the active baseline rather than reverting
+  it.
+- `docs/validation/ga-final-decision.md` explicitly sets the next recut target
+  to `v1.2.0-rc8`, states that another prerelease soak is required on the
+  `softprops/action-gh-release@v3` path, and warns that older downstream
+  GARECUT or GAREL plans are stale.
+- `docs/validation/ga-rc-evidence.md` is still the successful `rc7` recut
+  artifact. It remains the canonical prerelease evidence writer, but it must be
+  refreshed for the next recut attempt instead of being treated as current
+  proof for the new workflow path.
+- Repo-owned release surfaces are still frozen to `1.2.0-rc7` /
+  `v1.2.0-rc7` in `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`,
+  installer helpers, and `tests/test_release_metadata.py`, while
+  `.github/workflows/release-automation.yml` already carries the remediated
+  `softprops/action-gh-release@v3` path plus a `GARECUT release contract
+  target: v1.2.0-rc7` marker.
+- Absent contradictory product input, this plan freezes the renewed recut
+  target as `1.2.0-rc8` / `v1.2.0-rc8` and requires local plus remote non-reuse
+  checks before dispatch.
 
 ## Interface Freeze Gates
 
-- [ ] IF-0-GARECUT-1 - Recut version and workflow contract:
+- [ ] IF-0-GARECUT-1 - Renewed recut version and workflow contract:
       `.github/workflows/release-automation.yml`, `pyproject.toml`,
       `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, and
-      `tests/test_release_metadata.py` freeze `1.2.0-rc7` / `v1.2.0-rc7` as
-      the active recut target, retain `peter-evans/create-pull-request@v8`,
-      keep `release_type=custom`, and preserve prerelease-only GitHub Latest
-      and Docker `latest` behavior.
+      `tests/test_release_metadata.py` freeze `1.2.0-rc8` / `v1.2.0-rc8` as
+      the active recut target, retain
+      `peter-evans/create-pull-request@v8`, retain
+      `softprops/action-gh-release@v3`, keep `release_type=custom`, and
+      preserve prerelease-only GitHub Latest plus stable-only Docker `latest`
+      behavior.
 - [ ] IF-0-GARECUT-2 - Pre-dispatch safety contract:
-      release dispatch is allowed only when the checkout is clean enough for
-      release mutation, `HEAD` matches `origin/main`, the remediated workflow is
-      visible, and `v1.2.0-rc7` is unused both locally and on origin.
+      release dispatch is allowed only when the release-affecting worktree is
+      clean enough for mutation, `HEAD` matches `origin/main`, the remediated
+      workflow is visible, and `v1.2.0-rc8` is unused both locally and on
+      origin.
 - [ ] IF-0-GARECUT-3 - Remediated recut observation contract:
       GARECUT captures the Release Automation run URL, run ID, `headSha`,
-      per-job conclusions, release branch or PR disposition, GitHub release
-      state, PyPI publication, and GHCR image identity for `v1.2.0-rc7`.
+      per-job conclusions, `Create GitHub Release` log disposition, release
+      branch or PR disposition, GitHub release state, PyPI publication, and
+      GHCR image identity for `v1.2.0-rc8`.
 - [ ] IF-0-GARECUT-4 - RC-only channel policy contract:
       the recut remains prerelease-only, GitHub Latest stays excluded, Docker
       `latest` stays stable-only, and no GA docs or stable release mutation is
-      introduced by the `rc7` soak itself.
+      introduced by the `rc8` soak itself.
 - [ ] IF-0-GARECUT-5 - Decision handoff contract:
       `docs/validation/ga-rc-evidence.md` records the fresh remediated recut
       evidence, and `docs/validation/ga-final-decision.md` remains a historical
-      `cut another RC` artifact while explicitly pointing the next downstream
-      work back to a renewed `GAREL` decision on top of the fresh `rc7` proof.
+      `cut another RC` artifact while explicitly routing the next downstream
+      work either back to renewed `GAREL` on top of successful `rc8` proof or
+      back to GARECUT remediation/rerun if the recut blocks or fails.
 
 ## Lane Index & Dependencies
 
-- SL-0 - GARECUT contract tests; Depends on: GAREL; Blocks: SL-1, SL-2, SL-3, SL-4; Parallel-safe: no
-- SL-1 - Recut version and remediated workflow freeze; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4; Parallel-safe: yes
-- SL-2 - Recut dispatch and workflow observation; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4; Parallel-safe: no
-- SL-3 - RC recut evidence reducer; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4; Parallel-safe: no
+- SL-0 - Renewed GARECUT contract tests; Depends on: GAREL; Blocks: SL-1, SL-2, SL-3, SL-4; Parallel-safe: no
+- SL-1 - RC8 version and remediated workflow freeze; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4; Parallel-safe: yes
+- SL-2 - RC8 dispatch and workflow observation; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4; Parallel-safe: no
+- SL-3 - RC8 recut evidence reducer; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4; Parallel-safe: no
 - SL-4 - Final decision handoff refresh; Depends on: SL-0, SL-1, SL-2, SL-3; Blocks: GARECUT acceptance; Parallel-safe: no
 
 ## Lanes
 
-### SL-0 - GARECUT Contract Tests
+### SL-0 - Renewed GARECUT Contract Tests
 
-- **Scope**: Freeze the rc7 recut target, remediated workflow expectations, and
-  downstream decision handoff before any release mutation is attempted.
+- **Scope**: Refresh the phase-specific contract tests so the renewed GARECUT
+  path is frozen around the `rc8` recut target and the already-remediated
+  `softprops/action-gh-release@v3` workflow path before any release mutation is
+  attempted.
 - **Owned files**: `tests/docs/test_garecut_rc_recut_contract.py`
 - **Interfaces provided**: IF-0-GARECUT-1, IF-0-GARECUT-2,
   IF-0-GARECUT-3, IF-0-GARECUT-4, IF-0-GARECUT-5
 - **Interfaces consumed**: `docs/validation/ga-readiness-checklist.md`,
   `docs/validation/ga-rc-evidence.md`,
   `docs/validation/ga-final-decision.md`,
+  `specs/phase-plans-v5.md`,
   `.github/workflows/release-automation.yml`,
   `tests/test_release_metadata.py`,
-  `tests/docs/test_garc_rc_soak_contract.py`,
   `tests/docs/test_garel_ga_release_contract.py`
 - **Parallel-safe**: no
 - **Tasks**:
-  - test: Add a dedicated GARECUT docs contract test that requires
-    `docs/validation/ga-final-decision.md` to remain historical and
-    non-authorizing for GA while naming `GARECUT` as fulfilled only after fresh
-    `rc7` evidence exists.
-  - test: Assert that the active recut target is exactly `1.2.0-rc7` /
-    `v1.2.0-rc7`, that `peter-evans/create-pull-request@v8` remains the only
-    allowed create-pull-request action, and that prerelease/latest policy stays
-    frozen through the recut.
-  - test: Assert that `ga-rc-evidence.md` is the only canonical recut evidence
-    writer and that `ga-final-decision.md` cannot silently become a new GA
-    decision inside this phase.
-  - test: Keep this file additive and phase-specific so the existing GARC and
-    GAREL tests remain the lower-level contracts instead of being reopened.
+  - test: Update the GARECUT docs contract test to require the renewed recut
+    target `1.2.0-rc8` / `v1.2.0-rc8`, the remediated
+    `softprops/action-gh-release@v3` workflow path, and the current roadmap
+    steering that routes through another prerelease soak after GAREL.
+  - test: Assert that `docs/validation/ga-final-decision.md` remains
+    historical and non-authorizing for GA while naming `GARECUT` as satisfied
+    only after fresh `rc8` evidence exists.
+  - test: Assert that `docs/validation/ga-rc-evidence.md` remains the only
+    canonical recut evidence writer and that `ga-final-decision.md` cannot
+    silently become a new GA decision inside this phase.
+  - test: Keep this file additive and phase-specific so the existing GAREL and
+    release-metadata tests remain the lower-level contracts instead of being
+    reopened here.
   - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
 
-### SL-1 - Recut Version And Remediated Workflow Freeze
+### SL-1 - RC8 Version And Remediated Workflow Freeze
 
-- **Scope**: Advance the repo-owned release contract from rc6 to rc7 on the
+- **Scope**: Advance the repo-owned release contract from rc7 to rc8 on the
   already-remediated workflow path without widening into GA channel changes.
 - **Owned files**: `.github/workflows/release-automation.yml`,
   `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`,
@@ -131,112 +145,116 @@ Current repo state gathered during planning:
 - **Tasks**:
   - test: Re-run `tests/test_release_metadata.py` first and treat this lane as
     a repair-plus-version-bump lane only for the repo-owned recut contract.
-  - impl: Advance the frozen release identity from `1.2.0-rc6` /
-    `v1.2.0-rc6` to `1.2.0-rc7` / `v1.2.0-rc7` in the workflow defaults,
+  - impl: Advance the frozen release identity from `1.2.0-rc7` /
+    `v1.2.0-rc7` to `1.2.0-rc8` / `v1.2.0-rc8` in the workflow defaults,
     package metadata, changelog, installer defaults, and release-metadata
     assertions.
   - impl: Preserve `release_type=custom`, `auto_merge=false`,
-    `peter-evans/create-pull-request@v8`, prerelease GitHub release behavior,
-    and stable-only Docker `latest`; do not introduce stable `1.2.0` behavior
-    in this lane.
+    `peter-evans/create-pull-request@v8`,
+    `softprops/action-gh-release@v3`, prerelease GitHub release behavior, and
+    stable-only Docker `latest`; do not introduce stable `1.2.0` behavior in
+    this lane.
   - impl: Keep docs churn narrow by only touching the installer/version
     surfaces that `tests/test_release_metadata.py` already treats as part of
     the active release contract.
   - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
-  - verify: `rg -n "1\\.2\\.0-rc7|v1\\.2\\.0-rc7|create-pull-request@v8|release_type=custom|auto_merge=false|latest" .github/workflows/release-automation.yml pyproject.toml mcp_server/__init__.py CHANGELOG.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1 tests/test_release_metadata.py`
+  - verify: `rg -n "1\\.2\\.0-rc8|v1\\.2\\.0-rc8|create-pull-request@v8|softprops/action-gh-release@v3|release_type=custom|auto_merge=false|latest" .github/workflows/release-automation.yml pyproject.toml mcp_server/__init__.py CHANGELOG.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1 tests/test_release_metadata.py`
 
-### SL-2 - Recut Dispatch And Workflow Observation
+### SL-2 - RC8 Dispatch And Workflow Observation
 
-- **Scope**: Dispatch the remediated rc7 prerelease and capture the actual
+- **Scope**: Dispatch the remediated rc8 prerelease and capture the actual
   workflow and publication facts needed for downstream reduction.
 - **Owned files**: none (local git and GitHub release state only)
 - **Interfaces provided**: observed IF-0-GARECUT-2 and IF-0-GARECUT-3; runtime
   facts for IF-0-GARECUT-4 and IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 assertions; SL-1 rc7 release contract;
+- **Interfaces consumed**: SL-0 assertions; SL-1 rc8 release contract;
   `docs/validation/ga-final-decision.md`,
   `docs/validation/ga-rc-evidence.md`
 - **Parallel-safe**: no
 - **Tasks**:
   - test: Re-run the narrowed GARECUT and release-metadata checks locally
-    before dispatch so the repo-owned rc7 surfaces are coherent.
+    before dispatch so the repo-owned rc8 surfaces are coherent.
   - test: Run the required pre-dispatch probes immediately before mutation:
     `git status --short --branch`, `git fetch origin main --tags --prune`,
-    `git rev-parse HEAD origin/main`, `git tag -l v1.2.0-rc7`,
-    `git ls-remote --tags origin refs/tags/v1.2.0-rc7`, and
+    `git rev-parse HEAD origin/main`, `git tag -l v1.2.0-rc8`,
+    `git ls-remote --tags origin refs/tags/v1.2.0-rc8`, and
     `gh workflow view "Release Automation"`.
   - impl: If the release-affecting worktree is dirty, `HEAD` differs from
-    `origin/main`, or `v1.2.0-rc7` already exists locally or remotely, stop
-    before dispatch and carry the blocked state into SL-3.
-  - impl: Dispatch `gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false`, watch the run to completion, and capture run identity plus per-job outcomes.
-  - impl: Record the resulting GitHub prerelease state, release branch or PR
-    disposition, PyPI publication, and GHCR image identity on the remediated
-    workflow path; do not mutate GA state even if the recut succeeds.
+    `origin/main`, or `v1.2.0-rc8` already exists locally or remotely, stop
+    before dispatch and carry the blocked state into SL-3 and SL-4.
+  - impl: Dispatch `gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false`, watch the run to completion, and capture run identity plus per-job outcomes.
+  - impl: Record the `Create GitHub Release` job log disposition, GitHub
+    prerelease state, release branch or PR disposition, PyPI publication, and
+    GHCR image identity on the remediated workflow path; do not mutate GA state
+    even if the recut succeeds.
   - verify: `uv run pytest tests/test_release_metadata.py tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
   - verify: `git status --short --branch`
   - verify: `git fetch origin main --tags --prune`
   - verify: `git rev-parse HEAD origin/main`
-  - verify: `git tag -l v1.2.0-rc7`
-  - verify: `git ls-remote --tags origin refs/tags/v1.2.0-rc7`
+  - verify: `git tag -l v1.2.0-rc8`
+  - verify: `git ls-remote --tags origin refs/tags/v1.2.0-rc8`
   - verify: `gh workflow view "Release Automation"`
-  - verify: `gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false`
+  - verify: `gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false`
   - verify: `gh run list --workflow "Release Automation" --limit 10`
   - verify: `gh run watch <run-id> --exit-status`
   - verify: `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
-  - verify: `gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`
-  - verify: `gh pr list --state all --head release/v1.2.0-rc7 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title`
+  - verify: `gh run view <run-id> --job <create-github-release-job-id> --log`
+  - verify: `gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`
+  - verify: `gh pr list --state all --head release/v1.2.0-rc8 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title`
   - verify: `python -m pip index versions index-it-mcp --pre`
-  - verify: `docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc7`
+  - verify: `docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8`
 
-### SL-3 - RC Recut Evidence Reducer
+### SL-3 - RC8 Recut Evidence Reducer
 
-- **Scope**: Reduce the rc7 pre-dispatch, dispatch, workflow, and publication
+- **Scope**: Reduce the rc8 pre-dispatch, dispatch, workflow, and publication
   facts into the canonical prerelease evidence artifact.
 - **Owned files**: `docs/validation/ga-rc-evidence.md`
 - **Interfaces provided**: IF-0-GARECUT-3, IF-0-GARECUT-4,
   and the evidence portion of IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc7 contract
+- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc8 contract
   surfaces; SL-2 recut observation facts
 - **Parallel-safe**: no
 - **Tasks**:
   - test: Rewrite `docs/validation/ga-rc-evidence.md` only after SL-2 has a
-    terminal outcome so the artifact reflects one coherent rc7 recut attempt.
+    terminal outcome so the artifact reflects one coherent rc8 recut attempt.
   - impl: Record exact UTC capture time, selected commit, local and remote tag
     non-reuse results, dispatch inputs, run URL and ID, per-job conclusions,
-    release branch or PR disposition, GitHub prerelease state, PyPI package
-    identity, GHCR tag identity, and rollback or no-rollback disposition for
-    `v1.2.0-rc7`.
+    `Create GitHub Release` log disposition, release branch or PR disposition,
+    GitHub prerelease state, PyPI package identity, GHCR tag identity, and
+    rollback or no-rollback disposition for `v1.2.0-rc8`.
   - impl: If SL-2 stops before dispatch or fails mid-run, keep the artifact
     explicit about the blocked or failed state instead of implying a successful
     recut.
   - impl: Preserve metadata-only reporting; do not print tokens, raw logs, or
     secret-bearing command output.
-  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garc_rc_soak_contract.py -v --no-cov`
-  - verify: `rg -n "v1\\.2\\.0-rc7|Release Automation|PyPI|GHCR|prerelease|latest|blocked before dispatch|workflow failed after dispatch|recut succeeded" docs/validation/ga-rc-evidence.md`
+  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov`
+  - verify: `rg -n "v1\\.2\\.0-rc8|Release Automation|PyPI|GHCR|softprops/action-gh-release@v3|prerelease|latest|blocked before dispatch|workflow failed after dispatch|recut succeeded" docs/validation/ga-rc-evidence.md`
 
 ### SL-4 - Final Decision Handoff Refresh
 
 - **Scope**: Refresh the historical GA decision artifact so it clearly hands
-  the next downstream work back to a renewed GAREL reduction on top of the
-  fresh rc7 evidence.
+  the next downstream work either back to renewed GAREL on top of fresh rc8
+  evidence or back to GARECUT remediation if the recut did not land cleanly.
 - **Owned files**: `docs/validation/ga-final-decision.md`
 - **Interfaces provided**: final-decision portion of IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc7 workflow
+- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc8 workflow
   disposition; SL-2 recut observation facts; SL-3 refreshed
   `docs/validation/ga-rc-evidence.md`
 - **Parallel-safe**: no
 - **Tasks**:
   - test: Keep `docs/validation/ga-final-decision.md` historical and
-    non-authorizing for GA during GARECUT; this lane may refresh the next-step
+    non-authorizing for GA during GARECUT; this lane may refresh next-step
     status, but it must not mutate the repo into a new stable-release decision.
-  - impl: Preserve the original GAREL decision rationale that required another
-    RC because the old `rc6` soak predated the remediated workflow path.
-  - impl: Add or refresh a status section that references the new
-    `v1.2.0-rc7` recut evidence outcome and states whether the repository is
-    now ready for a renewed GAREL decision phase.
-  - impl: If the rc7 recut failed or was blocked, keep the next step on
+  - impl: Preserve the existing GAREL decision rationale that another RC is
+    required because `softprops/action-gh-release@v3` has not yet been soaked
+    on a prerelease candidate.
+  - impl: If the rc8 recut succeeds, add or refresh a status section that
+    references the new `v1.2.0-rc8` evidence outcome and states that the
+    repository is ready for a renewed GAREL decision phase.
+  - impl: If the rc8 recut fails or is blocked, keep the next step on
     remediating or rerunning GARECUT rather than reopening GA.
   - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov`
-  - verify: `rg -n "cut another RC|GARECUT|v1\\.2\\.0-rc7|renewed GAREL|ship GA|defer GA" docs/validation/ga-final-decision.md`
+  - verify: `rg -n "cut another RC|GARECUT|v1\\.2\\.0-rc8|renewed GAREL|ship GA|defer GA|softprops/action-gh-release@v3" docs/validation/ga-final-decision.md`
 
 ## Verification
 
@@ -248,7 +266,7 @@ Contract and repo-owned version checks:
 ```bash
 uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
 uv run pytest tests/test_release_metadata.py -v --no-cov
-rg -n "1\\.2\\.0-rc7|v1\\.2\\.0-rc7|create-pull-request@v8|release_type=custom|auto_merge=false|latest" \
+rg -n "1\\.2\\.0-rc8|v1\\.2\\.0-rc8|create-pull-request@v8|softprops/action-gh-release@v3|release_type=custom|auto_merge=false|latest" \
   .github/workflows/release-automation.yml \
   pyproject.toml \
   mcp_server/__init__.py \
@@ -264,24 +282,25 @@ Pre-dispatch and recut observation:
 git status --short --branch
 git fetch origin main --tags --prune
 git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc7
-git ls-remote --tags origin refs/tags/v1.2.0-rc7
+git tag -l v1.2.0-rc8
+git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
-gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false
+gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false
 gh run list --workflow "Release Automation" --limit 10
 gh run watch <run-id> --exit-status
 gh run view <run-id> --json url,headSha,status,conclusion,jobs
-gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
-gh pr list --state all --head release/v1.2.0-rc7 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title
+gh run view <run-id> --job <create-github-release-job-id> --log
+gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+gh pr list --state all --head release/v1.2.0-rc8 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title
 python -m pip index versions index-it-mcp --pre
-docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc7
+docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```
 
 Reducer artifact checks:
 
 ```bash
-uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garc_rc_soak_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov
-rg -n "v1\\.2\\.0-rc7|Release Automation|PyPI|GHCR|renewed GAREL|blocked before dispatch|workflow failed after dispatch|recut succeeded" \
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov
+rg -n "v1\\.2\\.0-rc8|Release Automation|PyPI|GHCR|softprops/action-gh-release@v3|renewed GAREL|blocked before dispatch|workflow failed after dispatch|recut succeeded" \
   docs/validation/ga-rc-evidence.md \
   docs/validation/ga-final-decision.md
 git status --short -- docs/validation/ga-rc-evidence.md docs/validation/ga-final-decision.md
@@ -290,19 +309,22 @@ git status --short -- docs/validation/ga-rc-evidence.md docs/validation/ga-final
 ## Acceptance Criteria
 
 - [ ] Repo-owned release surfaces and the remediated workflow freeze
-      `1.2.0-rc7` / `v1.2.0-rc7`, retain
-      `peter-evans/create-pull-request@v8`, and preserve prerelease-only
-      GitHub Latest plus stable-only Docker `latest` policy.
-- [ ] Pre-dispatch checks confirm a clean enough release worktree,
+      `1.2.0-rc8` / `v1.2.0-rc8`, retain
+      `peter-evans/create-pull-request@v8` and
+      `softprops/action-gh-release@v3`, and preserve prerelease-only GitHub
+      Latest plus stable-only Docker `latest` policy.
+- [ ] Pre-dispatch checks confirm a clean enough release-affecting worktree,
       `HEAD == origin/main`, workflow visibility, and no reused local or remote
-      `v1.2.0-rc7` tag before dispatch.
+      `v1.2.0-rc8` tag before dispatch.
 - [ ] Release Automation is dispatched only with
-      `version=v1.2.0-rc7`, `release_type=custom`, and `auto_merge=false`.
-- [ ] The remediated recut run records terminal workflow results, GitHub
-      prerelease state, PyPI package publication, GHCR image identity, and
-      release branch or PR disposition for `v1.2.0-rc7`.
-- [ ] `docs/validation/ga-rc-evidence.md` records the fresh rc7 recut outcome
+      `version=v1.2.0-rc8`, `release_type=custom`, and `auto_merge=false`.
+- [ ] The remediated recut run records terminal workflow results, `Create
+      GitHub Release` log disposition, GitHub prerelease state, PyPI package
+      publication, GHCR image identity, and release branch or PR disposition
+      for `v1.2.0-rc8`.
+- [ ] `docs/validation/ga-rc-evidence.md` records the fresh rc8 recut outcome
       using metadata-only reporting.
 - [ ] `docs/validation/ga-final-decision.md` remains historical, references the
-      recut outcome, and points the next downstream work to a renewed GAREL
-      decision instead of silently authorizing GA.
+      rc8 outcome, and routes the next downstream work to renewed GAREL only if
+      the recut succeeds; otherwise it keeps the next step on GARECUT
+      remediation or rerun.

--- a/plans/phase-plan-v5-garel.md
+++ b/plans/phase-plan-v5-garel.md
@@ -2,80 +2,90 @@
 phase_loop_plan_version: 1
 phase: GAREL
 roadmap: specs/phase-plans-v5.md
-roadmap_sha256: 57de286822c56cae88a9d3ad319a51aa3609470a0fd647796b3fc4b73e983614
+roadmap_sha256: aab3b0f990ecc5f821e2d94dbc48faa6cc3f8a14e6a53da68f983b8be85730dd
 ---
 # GAREL: GA Decision and Release
 
 ## Context
 
-GAREL is the seventh and terminal phase in the v5 GA-hardening roadmap. It
-must reduce the completed GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS, and GARC
-artifacts into one singular release decision and must stop before mutation
-unless that decision is explicitly `ship GA`.
+GAREL is the renewed terminal decision phase in the v5 GA-hardening roadmap.
+Its job is to reduce the completed GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS,
+and GARECUT evidence into one final release decision and to stop before any
+stable release mutation unless that decision is explicitly `ship GA`.
 
 Current repo state gathered during planning:
 
-- The checkout is on `main` at `3d5a3aa14af5950dc3e6c20bc66d3f0c81998c28`,
-  matching `origin/main`, but the worktree is intentionally dirty with
-  user-owned updates in `docs/validation/ga-rc-evidence.md`,
-  `tests/docs/test_garc_rc_soak_contract.py`, and
-  `specs/phase-plans-v5.md`; GAREL execution must preserve those edits and
-  treat the modified roadmap as the active baseline rather than reverting it.
-- `.codex/phase-loop/state.json` already records `GABASE`, `GAGOV`,
-  `GASUPPORT`, `GAE2E`, `GAOPS`, and `GARC` as complete while `GAREL` remains
-  the current unplanned phase, so this plan should hand directly to
-  `codex-execute-phase` instead of reopening earlier scope.
-- `docs/validation/ga-rc-evidence.md` now records a successful `v1.2.0-rc6`
-  soak and explicitly forwards one unresolved GAREL blocker: the
-  `peter-evans/create-pull-request@v7` Node 20 deprecation warning emitted by
-  the `Merge Release Branch` job in
-  `.github/workflows/release-automation.yml`.
-- `docs/validation/ga-final-decision.md` and
-  `docs/validation/ga-release-evidence.md` do not exist yet; they are the
-  canonical missing reducer artifacts reserved for this phase by
-  `docs/validation/ga-readiness-checklist.md`.
-- Public docs, support matrix text, and install helpers still present the
-  `1.2.0-rc6` beta/public-alpha posture. GAREL therefore needs a conditional
-  release path: if the final decision is not `ship GA`, those surfaces should
-  remain prerelease-only and only the decision artifact should change.
-- If the final decision is `ship GA`, the stable artifact identity should be
-  derived from the current `rc6` line as `1.2.0` / `v1.2.0`, and the release
-  workflow, package metadata, docs, GitHub release state, PyPI package, GHCR
-  tags, install flows, and rollback documentation must all align on that
-  stable channel.
+- The checkout is on `main` at `a3adcea5cd569571a2c4ce3d863317e9f14519bc`,
+  matching `origin/main`.
+- `specs/phase-plans-v5.md` is already modified and staged in the worktree, so
+  the amended roadmap is the active user-owned baseline and is protected from
+  `git clean -fd`.
+- `.codex/phase-loop/state.json` records roadmap SHA
+  `aab3b0f990ecc5f821e2d94dbc48faa6cc3f8a14e6a53da68f983b8be85730dd`,
+  marks `GARECUT` complete, marks `GAREL` unplanned, and carries ledger
+  warnings that older GAREL plan/event provenance no longer matches the
+  amended roadmap.
+- `docs/validation/ga-final-decision.md` now exists as a historical artifact
+  recording the earlier `cut another RC` outcome and explicitly routes the
+  next decision back through renewed GAREL after the successful `v1.2.0-rc7`
+  recut.
+- `docs/validation/ga-rc-evidence.md` records the successful
+  `v1.2.0-rc7` GARECUT run and the new remaining release blocker: a GitHub
+  Actions Node 20 deprecation annotation from
+  `softprops/action-gh-release@v2` in `Create GitHub Release`.
+- `.github/workflows/release-automation.yml` already uses
+  `peter-evans/create-pull-request@v8`, still uses
+  `softprops/action-gh-release@v2`, defaults to `v1.2.0-rc7`, and accepts
+  `release_type` values `custom|patch|minor|major`; there is no separate
+  `stable` input, so a stable GA dispatch must use the real workflow contract.
+- `tests/test_release_metadata.py` still freezes the active prerelease
+  contract to `1.2.0-rc7` / `v1.2.0-rc7`.
+- `docs/validation/ga-release-evidence.md` remains intentionally absent and is
+  still reserved for the `ship GA` branch only.
+- The worktree also contains user-owned in-flight updates in
+  `docs/validation/ga-final-decision.md`,
+  `docs/validation/ga-rc-evidence.md`,
+  `tests/docs/test_garecut_rc_recut_contract.py`, and
+  `tests/docs/test_garel_ga_release_contract.py`; GAREL execution must build
+  on those edits rather than revert them.
 
 ## Interface Freeze Gates
 
 - [ ] IF-0-GAREL-1 - Final decision contract:
       `docs/validation/ga-final-decision.md` states exactly one of `ship GA`,
       `cut another RC`, or `defer GA`, cites the canonical GABASE, GAGOV,
-      GASUPPORT, GAE2E, GAOPS, and GARC evidence inputs, and names the next
-      roadmap or RC scope when the answer is not `ship GA`.
-- [ ] IF-0-GAREL-2 - Workflow-runtime disposition contract:
-      `.github/workflows/release-automation.yml`,
-      `tests/test_release_metadata.py`, and the final decision artifact either
-      remove the `peter-evans/create-pull-request@v7` Node 20 deprecation path
-      or explicitly record why the warning is acceptable before any GA dispatch.
-- [ ] IF-0-GAREL-3 - Stable release channel contract:
+      GASUPPORT, GAE2E, GAOPS, and GARECUT evidence inputs, carries the
+      `softprops/action-gh-release@v2` disposition, and names the next roadmap
+      or RC scope whenever the answer is not `ship GA`.
+- [ ] IF-0-GAREL-2 - Workflow-runtime and dispatch contract:
+      `.github/workflows/release-automation.yml` and
+      `tests/test_release_metadata.py` either remove the
+      `softprops/action-gh-release@v2` Node 20 warning from the stable path or
+      freeze an explicit accepted-risk posture in the final decision artifact
+      before any GA dispatch, and the GA dispatch command uses the actual
+      workflow interface.
+- [ ] IF-0-GAREL-3 - Release-channel alignment contract:
       if the decision is `ship GA`, repo-owned version surfaces, public docs,
-      support-tier claims, GitHub Latest posture, Docker `latest`, and install
-      helpers all align on stable `1.2.0` / `v1.2.0`; otherwise those surfaces
-      remain on `1.2.0-rc6` / `v1.2.0-rc6` with no GA mutation.
+      support claims, installer defaults, GitHub Latest posture, and Docker
+      `latest` guidance align on stable `1.2.0` / `v1.2.0`; otherwise those
+      surfaces remain on prerelease `1.2.0-rc7` / `v1.2.0-rc7` with no stable
+      mutation.
 - [ ] IF-0-GAREL-4 - Post-release verification contract:
       the selected channel state is proven by targeted docs tests,
-      release-metadata tests, release smoke or clean-checkout install checks,
-      and GitHub release metadata probes, and any failure blocks GA instead of
-      being reduced away in prose.
+      release-metadata checks, release-smoke coverage, clean-checkout or fresh
+      install verification, and GitHub release metadata probes, and any
+      failure blocks GA instead of being reduced away in prose.
 - [ ] IF-0-GAREL-5 - GA evidence reducer contract:
-      `docs/validation/ga-release-evidence.md` is written only on the `ship GA`
-      path and records dispatch inputs, workflow URL / run ID / `headSha`,
-      release/channel state, PyPI and GHCR identities, install verification,
-      rollback disposition, and redacted metadata only.
+      `docs/validation/ga-release-evidence.md` is written only on the
+      `ship GA` branch and records dispatch inputs, workflow URL and run ID,
+      `headSha`, release/channel state, GitHub Latest posture, PyPI and GHCR
+      identities, install verification, rollback disposition, and redacted
+      metadata only.
 
 ## Lane Index & Dependencies
 
-- SL-0 - GAREL contract tests; Depends on: GARC; Blocks: SL-1, SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: no
-- SL-1 - Release workflow runtime and GA-dispatch policy; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: yes
+- SL-0 - Renewed GAREL contract tests; Depends on: GARECUT; Blocks: SL-1, SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: no
+- SL-1 - Release workflow warning remediation and dispatch policy; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4, SL-5, SL-6; Parallel-safe: yes
 - SL-2 - Final decision reducer; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4, SL-5, SL-6; Parallel-safe: no
 - SL-3 - Stable package and changelog contract; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4, SL-5, SL-6; Parallel-safe: yes
 - SL-4 - Public docs and operator channel alignment; Depends on: SL-0, SL-1, SL-2, SL-3; Blocks: SL-5, SL-6; Parallel-safe: yes
@@ -84,10 +94,11 @@ Current repo state gathered during planning:
 
 ## Lanes
 
-### SL-0 - GAREL Contract Tests
+### SL-0 - Renewed GAREL Contract Tests
 
-- **Scope**: Freeze the final-decision, workflow-runtime, stable-channel, and
-  conditional evidence-writing rules before any GA mutation is attempted.
+- **Scope**: Refresh the phase-specific contract tests so the renewed GAREL
+  path is frozen around the `rc7` evidence and the `softprops` runtime
+  warning before any stable mutation is attempted.
 - **Owned files**: `tests/docs/test_garel_ga_release_contract.py`
 - **Interfaces provided**: IF-0-GAREL-1, IF-0-GAREL-2, IF-0-GAREL-3,
   IF-0-GAREL-4, IF-0-GAREL-5
@@ -96,6 +107,7 @@ Current repo state gathered during planning:
   `docs/validation/ga-e2e-evidence.md`,
   `docs/validation/ga-operations-evidence.md`,
   `docs/validation/ga-rc-evidence.md`,
+  `docs/validation/ga-final-decision.md`,
   `.github/workflows/release-automation.yml`,
   `tests/test_release_metadata.py`,
   `tests/smoke/test_release_smoke_contract.py`,
@@ -105,61 +117,62 @@ Current repo state gathered during planning:
   `docs/operations/user-action-runbook.md`
 - **Parallel-safe**: no
 - **Tasks**:
-  - test: Add a dedicated GAREL docs contract test that requires
-    `docs/validation/ga-final-decision.md` to state exactly one allowed
-    decision, cite all prerequisite GA-hardening artifacts, and name the next
-    scope when the decision is not `ship GA`.
-  - test: Assert that `docs/validation/ga-release-evidence.md` is required only
-    on the `ship GA` path and that non-ship paths keep stable-release claims,
-    stable Docker `latest`, and GitHub Latest mutation out of active docs.
-  - test: Assert that the Node 20 warning from
-    `peter-evans/create-pull-request@v7` is either gone from the workflow or
-    explicitly dispositioned in the final decision artifact before GA dispatch.
-  - test: Keep this test additive and phase-specific so GABASE, GAGOV, GAOPS,
-    GARC, release-metadata, and smoke tests remain the lower-level supporting
-    contracts rather than being redefined here.
+  - test: Update the GAREL docs contract test to require the renewed decision
+    artifact to consume the successful `v1.2.0-rc7` recut evidence and to
+    treat any older pre-GARECUT GAREL assumptions as stale.
+  - test: Assert that the `softprops/action-gh-release@v2` Node 20 warning is
+    either remediated in the workflow or explicitly dispositioned in
+    `docs/validation/ga-final-decision.md` before any stable dispatch is
+    allowed.
+  - test: Assert that `docs/validation/ga-release-evidence.md` remains absent
+    unless the renewed decision actually chooses `ship GA`.
+  - test: Keep this file phase-specific and additive so GABASE, GARECUT,
+    release-metadata, and release-smoke tests remain the lower-level contracts
+    rather than being redefined here.
   - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
 
-### SL-1 - Release Workflow Runtime And GA-Dispatch Policy
+### SL-1 - Release Workflow Warning Remediation And Dispatch Policy
 
-- **Scope**: Resolve or explicitly disposition the release-workflow runtime
-  warning and freeze the GA dispatch policy before the final decision is made.
+- **Scope**: Resolve or explicitly disposition the remaining release-workflow
+  runtime warning and freeze the real GA dispatch interface before the final
+  decision is reduced.
 - **Owned files**: `.github/workflows/release-automation.yml`,
-  `tests/test_release_metadata.py`, `tests/smoke/test_release_smoke_contract.py`
-- **Interfaces provided**: IF-0-GAREL-2; the workflow portion of
+  `tests/test_release_metadata.py`
+- **Interfaces provided**: IF-0-GAREL-2; workflow portions of
   IF-0-GAREL-3 and IF-0-GAREL-4
 - **Interfaces consumed**: SL-0 GAREL assertions;
   `docs/validation/ga-rc-evidence.md`,
+  `docs/validation/ga-final-decision.md`,
   `docs/validation/ga-governance-evidence.md`,
   `docs/validation/ga-readiness-checklist.md`
 - **Parallel-safe**: yes
 - **Tasks**:
-  - test: Reproduce the current workflow-runtime warning from the successful
-    `v1.2.0-rc6` run by inspecting the `Merge Release Branch` job logs and use
-    that exact warning text as the repair target.
-  - impl: Upgrade or replace `peter-evans/create-pull-request@v7` in
-    `.github/workflows/release-automation.yml`, or explicitly codify the
-    accepted-risk path if GitHub Actions still emits the Node 20 warning and
-    the GA decision chooses not to mutate the workflow.
-  - impl: Freeze the GA dispatch semantics in the workflow and tests: stable
-    `v1.2.0` must not be treated as a prerelease, GitHub Latest and Docker
-    `latest` must change only on the `ship GA` path, and release automation
-    must keep non-ship paths mutation-free.
-  - impl: Update the release-metadata and smoke-contract tests only where they
-    need to distinguish the stable GA path from the current `rc6` prerelease
-    path; avoid reopening unrelated RC automation behavior.
-  - verify: `uv run pytest tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
-  - verify: `gh run view 24913315931 --job 72961441162 --log`
-  - verify: `rg -n "create-pull-request|Node 20|prerelease|latest|v1\\.2\\.0-rc6|v1\\.2\\.0" .github/workflows/release-automation.yml tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py`
+  - test: Reproduce the current workflow-runtime concern from the GARECUT
+    evidence and use that exact `softprops/action-gh-release@v2` Node 20
+    warning as the repair or acceptance target.
+  - impl: Upgrade, replace, or explicitly risk-accept the
+    `softprops/action-gh-release@v2` path for stable GA dispatch without
+    reopening the already-remediated `create-pull-request@v8` work.
+  - impl: Freeze the stable dispatch semantics against the real workflow
+    shape: GA dispatch must use `gh workflow run "Release Automation" -f
+    version=v1.2.0 -f release_type=custom -f auto_merge=false` unless the
+    workflow contract itself is intentionally changed first.
+  - impl: Update `tests/test_release_metadata.py` only where it needs to
+    distinguish the stable `v1.2.0` path from the active `v1.2.0-rc7`
+    prerelease contract; do not broaden this lane into unrelated release
+    automation cleanup.
+  - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
+  - verify: `rg -n "softprops/action-gh-release|create-pull-request@v8|release_type|is_prerelease|v1\\.2\\.0-rc7|v1\\.2\\.0" .github/workflows/release-automation.yml tests/test_release_metadata.py`
+  - verify: `gh run view 24919438766 --json url,headSha,status,conclusion,jobs`
 
 ### SL-2 - Final Decision Reducer
 
 - **Scope**: Reduce the upstream GA-hardening evidence and workflow-runtime
-  disposition into the singular go/no-go decision artifact before any stable
-  mutation occurs.
+  disposition into the singular renewed GAREL decision artifact before any
+  stable mutation occurs.
 - **Owned files**: `docs/validation/ga-final-decision.md`
-- **Interfaces provided**: IF-0-GAREL-1; the decision input to IF-0-GAREL-3
-  and IF-0-GAREL-5
+- **Interfaces provided**: IF-0-GAREL-1; the decision input to
+  IF-0-GAREL-3 and IF-0-GAREL-5
 - **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow-runtime
   disposition; `docs/validation/ga-readiness-checklist.md`,
   `docs/validation/ga-governance-evidence.md`,
@@ -168,122 +181,132 @@ Current repo state gathered during planning:
   `docs/validation/ga-rc-evidence.md`
 - **Parallel-safe**: no
 - **Tasks**:
-  - test: Write the decision artifact only after the workflow-runtime warning,
-    support posture, operations evidence, and RC soak evidence have been read
-    together; do not let a successful `rc6` soak alone imply GA approval.
+  - test: Write the renewed decision artifact only after the `softprops`
+    warning disposition, support posture, operations evidence, and `rc7`
+    evidence have been read together; a successful recut alone does not imply
+    GA approval.
   - impl: Record exactly one decision: `ship GA`, `cut another RC`, or
     `defer GA`.
   - impl: If the decision is not `ship GA`, name the next roadmap or RC scope,
-    keep all stable-release mutations blocked, and make `ga-release-evidence.md`
-    explicitly unnecessary for that branch.
-  - impl: If the decision is `ship GA`, state the exact prerequisites that are
-    satisfied for stable `1.2.0` / `v1.2.0`, including the disposition of the
-    Node 20 workflow warning, before SL-3 through SL-6 mutate release surfaces.
-  - impl: Preserve the historical-artifact banner and metadata-only reporting
-    pattern used by the other GA evidence reducers.
+    keep all stable mutations blocked, and make
+    `docs/validation/ga-release-evidence.md` explicitly unnecessary for that
+    branch.
+  - impl: If the decision is `ship GA`, state the exact prerequisites
+    satisfied for stable `1.2.0` / `v1.2.0`, including the final disposition
+    of the `softprops` runtime warning, before SL-3 through SL-6 mutate
+    release surfaces.
+  - impl: Preserve the historical-artifact and metadata-only reporting pattern
+    already used by the GA evidence artifacts.
   - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
-  - verify: `rg -n "Final decision|ship GA|cut another RC|defer GA|ga-readiness-checklist|ga-governance-evidence|ga-e2e-evidence|ga-operations-evidence|ga-rc-evidence|Node 20" docs/validation/ga-final-decision.md`
+  - verify: `rg -n "ship GA|cut another RC|defer GA|ga-readiness-checklist|ga-governance-evidence|ga-e2e-evidence|ga-operations-evidence|ga-rc-evidence|softprops/action-gh-release@v2|Node 20|v1\\.2\\.0-rc7|v1\\.2\\.0" docs/validation/ga-final-decision.md`
 
 ### SL-3 - Stable Package And Changelog Contract
 
-- **Scope**: Align repo-owned release metadata to the final decision without
-  mutating public docs or installer guidance directly.
+- **Scope**: Align repo-owned release metadata to the renewed final decision
+  without directly mutating the public docs or runbooks.
 - **Owned files**: `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`
-- **Interfaces provided**: package/version portion of IF-0-GAREL-3 and
+- **Interfaces provided**: package/version portions of IF-0-GAREL-3 and
   IF-0-GAREL-4
 - **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow dispatch
   policy; SL-2 final decision artifact
 - **Parallel-safe**: yes
 - **Tasks**:
-  - test: Treat this lane as conditional on SL-2. If the decision is not
-    `ship GA`, verify that `1.2.0-rc6` remains the active package contract and
-    do not rewrite package metadata.
-  - impl: If the decision is `ship GA`, advance the repo-owned release identity
-    from `1.2.0-rc6` / `v1.2.0-rc6` to stable `1.2.0` / `v1.2.0` in
-    `pyproject.toml`, `mcp_server/__init__.py`, and the new changelog section.
+  - test: Treat this lane as conditional on SL-2. If the renewed decision is
+    not `ship GA`, verify that `1.2.0-rc7` remains the active package contract
+    and do not rewrite package metadata.
+  - impl: If the renewed decision is `ship GA`, advance the repo-owned release
+    identity from `1.2.0-rc7` / `v1.2.0-rc7` to stable `1.2.0` / `v1.2.0` in
+    `pyproject.toml`, `mcp_server/__init__.py`, and the active changelog
+    section.
   - impl: Keep the changelog explicit about the release-channel transition and
-    any remaining non-GA or deferred surfaces instead of silently erasing the
-    prerelease history.
+    any remaining non-GA or deferred surfaces instead of erasing prerelease
+    history.
   - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
-  - verify: `rg -n "1\\.2\\.0-rc6|1\\.2\\.0|v1\\.2\\.0-rc6|v1\\.2\\.0" pyproject.toml mcp_server/__init__.py CHANGELOG.md`
+  - verify: `rg -n "1\\.2\\.0-rc7|1\\.2\\.0|v1\\.2\\.0-rc7|v1\\.2\\.0" pyproject.toml mcp_server/__init__.py CHANGELOG.md`
 
 ### SL-4 - Public Docs And Operator Channel Alignment
 
-- **Scope**: Align user-facing docs, support tiers, and operator runbooks with
-  the final GAREL decision after repo-owned metadata has settled.
+- **Scope**: Align user-facing docs, support tiers, installer defaults, and
+  operator runbooks with the renewed GAREL decision after repo-owned metadata
+  has settled.
 - **Owned files**: `README.md`, `docs/GETTING_STARTED.md`,
   `docs/DOCKER_GUIDE.md`, `docs/MCP_CONFIGURATION.md`,
   `docs/SUPPORT_MATRIX.md`, `docs/operations/deployment-runbook.md`,
   `docs/operations/user-action-runbook.md`,
   `scripts/install-mcp-docker.sh`, `scripts/install-mcp-docker.ps1`
-- **Interfaces provided**: public-doc portion of IF-0-GAREL-3 and
+- **Interfaces provided**: public-doc portions of IF-0-GAREL-3 and
   IF-0-GAREL-4
 - **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow/runtime
   policy; SL-2 final decision artifact; SL-3 package and changelog contract
 - **Parallel-safe**: yes
 - **Tasks**:
-  - test: Use SL-0 to fail first on any public doc that claims GA or stable
-    release before the final decision artifact authorizes it.
-  - impl: If the decision is `ship GA`, switch the active docs, support matrix,
-    installer defaults, and operator runbooks from the `rc6` beta/public-alpha
-    posture to stable `1.2.0` guidance, including GitHub Latest and Docker
-    `latest` expectations.
+  - test: Use SL-0 to fail first on any doc or installer surface that claims
+    GA or a stable release before the renewed decision artifact authorizes it.
+  - impl: If the decision is `ship GA`, switch the active docs, support
+    matrix, installer defaults, and operator runbooks from the current
+    prerelease `rc7` posture to stable `1.2.0` guidance, including GitHub
+    Latest and Docker `latest` expectations.
   - impl: If the decision is `cut another RC` or `defer GA`, keep the public
-    surfaces on `rc6` posture and update only the decision-routing language so
-    the repo does not imply a stable release that did not happen.
-  - impl: Preserve the frozen support-tier and topology limits from GASUPPORT;
-    GAREL can narrow channel wording, but it must not broaden language/runtime
-    claims or multi-worktree support.
+    surfaces on prerelease posture, but still refresh stale `rc5` or `rc6`
+    wording so the repo describes the current `rc7` state accurately.
+  - impl: Preserve the frozen support-tier vocabulary and v3 topology limits
+    from GABASE and GASUPPORT; GAREL may narrow channel wording, but it must
+    not broaden language/runtime claims or multi-worktree support.
   - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/docs/test_gabase_ga_readiness_contract.py -v --no-cov`
-  - verify: `rg -n "1\\.2\\.0-rc6|1\\.2\\.0|v1\\.2\\.0-rc6|v1\\.2\\.0|public-alpha|beta|GA|GitHub Latest|stable Docker latest|ga-final-decision|ga-readiness-checklist" README.md docs/GETTING_STARTED.md docs/DOCKER_GUIDE.md docs/MCP_CONFIGURATION.md docs/SUPPORT_MATRIX.md docs/operations/deployment-runbook.md docs/operations/user-action-runbook.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1`
+  - verify: `rg -n "1\\.2\\.0-rc5|1\\.2\\.0-rc6|1\\.2\\.0-rc7|1\\.2\\.0|public-alpha|beta|GA|GitHub Latest|docker latest|ga-final-decision|ga-release-evidence" README.md docs/GETTING_STARTED.md docs/DOCKER_GUIDE.md docs/MCP_CONFIGURATION.md docs/SUPPORT_MATRIX.md docs/operations/deployment-runbook.md docs/operations/user-action-runbook.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1`
 
 ### SL-5 - GA Dispatch And Post-Release Verification
 
-- **Scope**: Execute the stable release only when SL-2 chose `ship GA`, then
-  capture the post-release verification needed to prove the final channel state.
-- **Owned files**: none (GitHub workflow runs, release metadata, package index,
-  container registry, and clean-checkout verification results)
-- **Interfaces provided**: observed IF-0-GAREL-4 and release facts for
+- **Scope**: Execute the stable release only when SL-2 chooses `ship GA`, then
+  capture the operational verification needed to prove the final channel
+  state.
+- **Owned files**: none
+- **Interfaces provided**: observed IF-0-GAREL-4 and runtime facts for
   IF-0-GAREL-5
 - **Interfaces consumed**: SL-0 GAREL assertions; SL-1 release workflow and
-  policy; SL-2 final decision; SL-3 stable package contract; SL-4 public docs
-  alignment
+  dispatch policy; SL-2 final decision; SL-3 stable package contract; SL-4
+  public docs alignment
 - **Parallel-safe**: no
 - **Tasks**:
-  - test: If SL-2 did not choose `ship GA`, stop here with no release mutation
-    and preserve the blocked/no-op outcome for SL-6.
-  - test: On the `ship GA` path, rerun the narrowed contract tests before
-    dispatch so workflow policy, package metadata, changelog, public docs, and
-    support claims are coherent.
+  - test: If SL-2 does not choose `ship GA`, stop here with no release
+    mutation and preserve the no-op path for SL-6.
+  - test: On the `ship GA` path, rerun the narrowed contract checks before
+    dispatch so workflow policy, package metadata, changelog, docs, support
+    claims, and installer defaults are coherent.
   - test: Re-qualify the release state with clean-branch, synchronized
-    `origin/main`, and stable-tag non-reuse checks before dispatching GA.
-  - impl: Dispatch Release Automation with the stable version input
-    `v1.2.0` and governance-approved settings only after the Node 20 warning
-    has been remediated or explicitly accepted in SL-2.
+    `origin/main`, stable-tag non-reuse, and release-workflow visibility checks
+    immediately before dispatching GA.
+  - impl: Dispatch Release Automation only after the `softprops` warning has
+    been remediated or explicitly accepted in SL-2, using the real workflow
+    input contract for stable `v1.2.0`.
   - impl: Watch the run to completion, then verify GitHub release, PyPI,
-    GHCR, installer/download flows, and clean-checkout smoke against the stable
-    release artifacts.
-  - impl: If any dispatch, publish, or clean-checkout verification step fails,
+    GHCR, clean-checkout install flows, and release smokes against the stable
+    artifacts.
+  - impl: If any dispatch, publish, or post-release verification step fails,
     stop before claiming GA success and route the blocker back into
-    `docs/validation/ga-final-decision.md` plus `docs/validation/ga-release-evidence.md`.
+    `docs/validation/ga-final-decision.md` plus
+    `docs/validation/ga-release-evidence.md`.
   - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
   - verify: `git status --short --branch`
   - verify: `git fetch origin main --tags --prune`
   - verify: `git rev-parse HEAD origin/main`
   - verify: `git tag -l v1.2.0`
   - verify: `git ls-remote --tags origin refs/tags/v1.2.0`
-  - verify: `gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=stable -f auto_merge=false`
+  - verify: `gh workflow view "Release Automation"`
+  - verify: `gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=custom -f auto_merge=false`
   - verify: `gh run list --workflow "Release Automation" --limit 10`
   - verify: `gh run watch <run-id> --exit-status`
   - verify: `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
   - verify: `gh release view v1.2.0 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,isLatest,publishedAt,targetCommitish,url,assets`
+  - verify: `python -m pip index versions index-it-mcp`
+  - verify: `docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0`
   - verify: `make release-smoke`
   - verify: `make release-smoke-container`
 
 ### SL-6 - GA Release Evidence Reducer
 
-- **Scope**: Reduce the decision, stable release execution, and post-release
-  verification into the canonical GA release evidence artifact.
+- **Scope**: Reduce the renewed decision, stable release execution, and
+  post-release verification into the canonical GA release evidence artifact.
 - **Owned files**: `docs/validation/ga-release-evidence.md`
 - **Interfaces provided**: IF-0-GAREL-5
 - **Interfaces consumed**: SL-0 GAREL assertions; SL-1 workflow/runtime
@@ -297,52 +320,91 @@ Current repo state gathered during planning:
 - **Parallel-safe**: no
 - **Tasks**:
   - test: Write `docs/validation/ga-release-evidence.md` only when SL-2 chose
-    `ship GA` and SL-5 captured an actual stable release run plus post-release
-    verification results.
-  - impl: Record the stable dispatch inputs, run URL / run ID / `headSha`,
+    `ship GA` and SL-5 captured an actual stable release run plus
+    post-release verification results.
+  - impl: Record the stable dispatch inputs, run URL and run ID, `headSha`,
     per-job conclusions, tag target, GitHub release state including Latest
-    posture, PyPI and GHCR identities, install/smoke verification, and rollback
-    disposition using redacted metadata only.
+    posture, PyPI and GHCR identities, install and smoke verification, and
+    rollback disposition using redacted metadata only.
   - impl: If SL-2 chose a non-ship path, keep this file absent and make
     `docs/validation/ga-final-decision.md` the only reducer artifact for the
     phase.
-  - impl: Preserve the historical-artifact banner pattern and make the artifact
-    explicit about whether the stable release succeeded, failed after dispatch,
-    or was never attempted because the final decision did not authorize it.
+  - impl: Preserve the historical-artifact banner pattern and make the
+    artifact explicit about whether the stable release succeeded, failed after
+    dispatch, or was never attempted because the renewed decision did not
+    authorize it.
   - verify: `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
   - verify: `rg -n "Historical artifact|v1\\.2\\.0|Release Automation|run ID|GitHub release|isLatest|PyPI|GHCR|release-smoke|rollback|ship GA" docs/validation/ga-release-evidence.md`
 
 ## Verification
 
-- `uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov`
-- `uv run pytest tests/test_release_metadata.py tests/smoke/test_release_smoke_contract.py -v --no-cov`
-- `uv run pytest tests/docs/test_garel_ga_release_contract.py tests/docs/test_gabase_ga_readiness_contract.py -v --no-cov`
-- `gh run view 24913315931 --job 72961441162 --log`
-- `git status --short --branch`
-- `git fetch origin main --tags --prune`
-- `git rev-parse HEAD origin/main`
-- `git tag -l v1.2.0`
-- `git ls-remote --tags origin refs/tags/v1.2.0`
-- `gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=stable -f auto_merge=false`
-- `gh run list --workflow "Release Automation" --limit 10`
-- `gh run watch <run-id> --exit-status`
-- `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
-- `gh release view v1.2.0 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,isLatest,publishedAt,targetCommitish,url,assets`
-- `make release-smoke`
-- `make release-smoke-container`
+Planning-only run: do not execute these during plan creation. Run them during
+`codex-execute-phase` or manual GAREL execution.
+
+Contract and workflow checks:
+
+```bash
+uv run pytest tests/docs/test_garel_ga_release_contract.py -v --no-cov
+uv run pytest tests/test_release_metadata.py -v --no-cov
+uv run pytest tests/smoke/test_release_smoke_contract.py -v --no-cov
+rg -n "softprops/action-gh-release|create-pull-request@v8|release_type|is_prerelease|v1\\.2\\.0-rc7|v1\\.2\\.0" \
+  .github/workflows/release-automation.yml \
+  tests/test_release_metadata.py
+gh run view 24919438766 --json url,headSha,status,conclusion,jobs
+```
+
+Decision and doc alignment checks:
+
+```bash
+uv run pytest tests/docs/test_garel_ga_release_contract.py tests/docs/test_gabase_ga_readiness_contract.py -v --no-cov
+rg -n "ship GA|cut another RC|defer GA|softprops/action-gh-release@v2|Node 20|v1\\.2\\.0-rc7|v1\\.2\\.0" \
+  docs/validation/ga-final-decision.md
+rg -n "1\\.2\\.0-rc5|1\\.2\\.0-rc6|1\\.2\\.0-rc7|1\\.2\\.0|public-alpha|beta|GA|GitHub Latest|docker latest" \
+  README.md \
+  docs/GETTING_STARTED.md \
+  docs/DOCKER_GUIDE.md \
+  docs/MCP_CONFIGURATION.md \
+  docs/SUPPORT_MATRIX.md \
+  docs/operations/deployment-runbook.md \
+  docs/operations/user-action-runbook.md \
+  scripts/install-mcp-docker.sh \
+  scripts/install-mcp-docker.ps1
+```
+
+Stable-release execution checks, only if SL-2 chooses `ship GA`:
+
+```bash
+git status --short --branch
+git fetch origin main --tags --prune
+git rev-parse HEAD origin/main
+git tag -l v1.2.0
+git ls-remote --tags origin refs/tags/v1.2.0
+gh workflow view "Release Automation"
+gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=custom -f auto_merge=false
+gh run list --workflow "Release Automation" --limit 10
+gh run watch <run-id> --exit-status
+gh run view <run-id> --json url,headSha,status,conclusion,jobs
+gh release view v1.2.0 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,isLatest,publishedAt,targetCommitish,url,assets
+python -m pip index versions index-it-mcp
+docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0
+make release-smoke
+make release-smoke-container
+```
 
 ## Acceptance Criteria
 
 - [ ] `docs/validation/ga-final-decision.md` exists and states exactly one of
       `ship GA`, `cut another RC`, or `defer GA`, citing the canonical
-      GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS, and GARC evidence.
-- [ ] The Node 20 workflow warning from the GARC soak is remediated or
-      explicitly dispositioned before any GA dispatch is attempted.
-- [ ] If the decision is not `ship GA`, no stable release mutation occurs and
-      the final decision artifact names the next roadmap or RC scope.
-- [ ] If the decision is `ship GA`, repo-owned metadata, public docs, support
-      claims, install helpers, GitHub Latest posture, and Docker `latest`
-      guidance all align on stable `1.2.0` / `v1.2.0`.
+      GABASE, GAGOV, GASUPPORT, GAE2E, GAOPS, and GARECUT evidence.
+- [ ] The remaining `softprops/action-gh-release@v2` Node 20 warning is
+      remediated or explicitly dispositioned before any GA dispatch is
+      attempted.
+- [ ] If the renewed decision is not `ship GA`, no stable release mutation
+      occurs and the final decision artifact names the next roadmap or RC
+      scope.
+- [ ] If the renewed decision is `ship GA`, repo-owned metadata, public docs,
+      support claims, installer defaults, GitHub Latest posture, and Docker
+      `latest` guidance all align on stable `1.2.0` / `v1.2.0`.
 - [ ] Stable dispatch and post-release verification either succeed and are
       recorded in `docs/validation/ga-release-evidence.md`, or fail in an
       explicit blocker state without silently implying GA success.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "index-it-mcp"
 # Historical GARC soak target: 1.2.0-rc6.
-version = "1.2.0-rc7"
+version = "1.2.0-rc8"
 description = "Local-first code indexer for AI assistants via Model Context Protocol (MCP)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/install-mcp-docker.ps1
+++ b/scripts/install-mcp-docker.ps1
@@ -2,8 +2,8 @@
 # PowerShell script to install and configure MCP Index with Docker
 
 param(
-    [string]$Variant = "v1.2.0-rc7",
-    [string]$Version = "v1.2.0-rc7"
+    [string]$Variant = "v1.2.0-rc8",
+    [string]$Version = "v1.2.0-rc8"
 )
 
 # Configuration
@@ -80,7 +80,7 @@ function Install-Docker {
 function Select-Variant {
     Write-Host ""
     Write-Host "Choose MCP Index variant:"
-    Write-Host "1) v1.2.0-rc7  - Active RC/public-alpha image (recommended)"
+    Write-Host "1) v1.2.0-rc8  - Active RC/public-alpha image (recommended)"
     Write-Host "2) latest      - Stable-only channel; may not exist before GA"
     Write-Host "3) local-smoke - Local smoke image built by make release-smoke-container"
     Write-Host ""
@@ -97,8 +97,8 @@ function Select-Variant {
             Write-Host "[INFO] Selected: local-smoke" -ForegroundColor Green
         }
         default {
-            $script:Variant = "v1.2.0-rc7"
-            Write-Host "[INFO] Selected: v1.2.0-rc7" -ForegroundColor Green
+            $script:Variant = "v1.2.0-rc8"
+            Write-Host "[INFO] Selected: v1.2.0-rc8" -ForegroundColor Green
         }
     }
 }
@@ -115,7 +115,7 @@ function Create-Launcher {
 REM MCP Index Docker Launcher for Windows
 
 SET MCP_VARIANT=%MCP_VARIANT%
-IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc7
+IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc8
 
 SET MCP_IMAGE=ghcr.io/viperjuice/code-index-mcp
 SET WORKSPACE=%CD%

--- a/scripts/install-mcp-docker.sh
+++ b/scripts/install-mcp-docker.sh
@@ -12,8 +12,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-MCP_VERSION="${MCP_VERSION:-v1.2.0-rc7}"
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"
+MCP_VERSION="${MCP_VERSION:-v1.2.0-rc8}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-ghcr.io}"
 MCP_IMAGE="${DOCKER_REGISTRY}/viperjuice/code-index-mcp"
 
@@ -115,7 +115,7 @@ install_docker() {
 choose_variant() {
     echo
     echo "Choose MCP Index variant:"
-    echo "1) v1.2.0-rc7  - Active RC/public-alpha image (recommended)"
+    echo "1) v1.2.0-rc8  - Active RC/public-alpha image (recommended)"
     echo "2) latest      - Stable-only channel; may not exist before GA"
     echo "3) local-smoke - Local smoke image built by make release-smoke-container"
     echo
@@ -133,8 +133,8 @@ choose_variant() {
             print_info "Selected: local-smoke"
             ;;
         *)
-            MCP_VARIANT="v1.2.0-rc7"
-            print_info "Selected: v1.2.0-rc7"
+            MCP_VARIANT="v1.2.0-rc8"
+            print_info "Selected: v1.2.0-rc8"
             ;;
     esac
 }
@@ -155,7 +155,7 @@ create_launcher() {
 # MCP Index Docker Launcher
 
 # Default settings
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"
 MCP_IMAGE="${MCP_IMAGE:-ghcr.io/viperjuice/code-index-mcp}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
 

--- a/specs/phase-plans-v5.md
+++ b/specs/phase-plans-v5.md
@@ -356,7 +356,7 @@ Cut and observe a post-hardening RC before making any GA release decision.
 **Scope notes**
 
 This phase is operational release execution. GABASE freezes the follow-up RC
-version as `v1.2.0-rc6` before planning this phase.
+version as `v1.2.0-rc7` before planning this phase.
 
 **Non-goals**
 
@@ -413,9 +413,13 @@ This phase is a guarded decision reducer plus release execution. It must stop
 before mutation if governance, support, E2E, operations, or RC soak evidence is
 missing. GARC surfaced a GitHub Actions warning that
 `peter-evans/create-pull-request@v7` still runs on the deprecated Node 20
-runtime in the `Merge Release Branch` job, so GAREL must either upgrade or
-replace that action, or explicitly record why the warning is acceptable for the
-GA path before dispatching another release.
+runtime in the `Merge Release Branch` job, and GARECUT later proved that path
+was remediated on `peter-evans/create-pull-request@v8` during successful run
+`24919438766`. That same GARECUT run also emitted a new Node 20 deprecation
+annotation for `softprops/action-gh-release@v2` in `Create GitHub Release`.
+GAREL has since remediated that path to `softprops/action-gh-release@v3`, so
+the next downstream work is another prerelease soak on the newly remediated
+release path before any stable GA dispatch is reconsidered.
 
 **Non-goals**
 
@@ -480,6 +484,9 @@ support, E2E, and operations. GAREL waits for the follow-up RC soak.
 - If GAREL remediates release-workflow runtime drift and concludes that another
   prerelease soak is required, plan `GARECUT` next and treat any older
   downstream GAREL assumptions as stale.
+- After a successful GARECUT, route back through `codex-plan-phase
+  specs/phase-plans-v5.md GAREL`; any older GAREL plan that predates the
+  post-GARECUT or post-remediation release-workflow steering is stale.
 
 ## Verification
 
@@ -531,7 +538,7 @@ uv run pytest tests/docs tests/smoke tests/test_release_metadata.py tests/test_r
 make alpha-production-matrix
 make release-smoke
 make release-smoke-container
-gh workflow run "Release Automation" -f version=<ga-version> -f release_type=stable -f auto_merge=<approved-policy>
+gh workflow run "Release Automation" -f version=<ga-version> -f release_type=custom -f auto_merge=false
 gh release view <ga-version>
 
 # GARECUT
@@ -552,7 +559,7 @@ any future GA ship decision is reconsidered.
 **Exit criteria**
 - [ ] The release workflow no longer depends on the deprecated Node 20 action
       path that GARC surfaced.
-- [ ] A new RC version after `v1.2.0-rc6` is frozen and dispatched through the
+- [ ] A new RC version after `v1.2.0-rc7` is frozen and dispatched through the
       remediated workflow.
 - [ ] The recut workflow run completes with prerelease policy intact: GitHub
       Latest remains excluded and Docker `latest` remains stable-only.

--- a/tests/docs/test_gabase_ga_readiness_contract.py
+++ b/tests/docs/test_gabase_ga_readiness_contract.py
@@ -81,7 +81,7 @@ def test_checklist_exists_with_required_sections_and_baseline():
 
     for expected in (
         "v1.2.0-rc5",
-        "v1.2.0-rc6",
+        "v1.2.0-rc7",
         "canonical GABASE checklist",
     ):
         assert expected in text
@@ -117,8 +117,8 @@ def test_public_docs_remain_pre_ga_and_route_to_canonical_artifacts():
         text = _read(path)
         lowered = text.lower()
 
-        if "1.2.0-rc6" not in text:
-            failures.append(f"{path.relative_to(REPO)} missing rc6 baseline")
+        if "1.2.0-rc7" not in text:
+            failures.append(f"{path.relative_to(REPO)} missing rc7 baseline")
         if ("public-alpha" not in lowered) and ("beta" not in lowered):
             failures.append(f"{path.relative_to(REPO)} missing public-alpha/beta language")
         if "ga-readiness-checklist" not in text:
@@ -153,7 +153,7 @@ def test_runbooks_point_future_ga_work_to_checklist_and_refresh_artifacts():
             "GAOPS",
             "GARC",
             "GAREL",
-            "v1.2.0-rc6",
+            "v1.2.0-rc7",
             "manual enforcement",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"

--- a/tests/docs/test_gabase_ga_readiness_contract.py
+++ b/tests/docs/test_gabase_ga_readiness_contract.py
@@ -81,7 +81,7 @@ def test_checklist_exists_with_required_sections_and_baseline():
 
     for expected in (
         "v1.2.0-rc5",
-        "v1.2.0-rc7",
+        "v1.2.0-rc8",
         "canonical GABASE checklist",
     ):
         assert expected in text
@@ -117,8 +117,8 @@ def test_public_docs_remain_pre_ga_and_route_to_canonical_artifacts():
         text = _read(path)
         lowered = text.lower()
 
-        if "1.2.0-rc7" not in text:
-            failures.append(f"{path.relative_to(REPO)} missing rc7 baseline")
+        if "1.2.0-rc8" not in text:
+            failures.append(f"{path.relative_to(REPO)} missing rc8 baseline")
         if ("public-alpha" not in lowered) and ("beta" not in lowered):
             failures.append(f"{path.relative_to(REPO)} missing public-alpha/beta language")
         if "ga-readiness-checklist" not in text:
@@ -153,7 +153,7 @@ def test_runbooks_point_future_ga_work_to_checklist_and_refresh_artifacts():
             "GAOPS",
             "GARC",
             "GAREL",
-            "v1.2.0-rc7",
+            "v1.2.0-rc8",
             "manual enforcement",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"

--- a/tests/docs/test_gaclose_evidence_closeout.py
+++ b/tests/docs/test_gaclose_evidence_closeout.py
@@ -15,7 +15,7 @@ TRIAGE = REPO / "docs" / "HISTORICAL-ARTIFACTS-TRIAGE.md"
 
 PUBLIC_ALPHA_VERSION = "1.2.0-rc5"
 PUBLIC_ALPHA_TAG = "v1.2.0-rc5"
-CURRENT_PUBLIC_ALPHA_VERSION = "1.2.0-rc7"
+CURRENT_PUBLIC_ALPHA_VERSION = "1.2.0-rc8"
 HISTORICAL_BANNER = "> **Historical artifact — as-of 2026-04-18, may not reflect current behavior**"
 
 PUBLIC_SURFACES = [

--- a/tests/docs/test_gaclose_evidence_closeout.py
+++ b/tests/docs/test_gaclose_evidence_closeout.py
@@ -15,7 +15,7 @@ TRIAGE = REPO / "docs" / "HISTORICAL-ARTIFACTS-TRIAGE.md"
 
 PUBLIC_ALPHA_VERSION = "1.2.0-rc5"
 PUBLIC_ALPHA_TAG = "v1.2.0-rc5"
-CURRENT_PUBLIC_ALPHA_VERSION = "1.2.0-rc6"
+CURRENT_PUBLIC_ALPHA_VERSION = "1.2.0-rc7"
 HISTORICAL_BANNER = "> **Historical artifact — as-of 2026-04-18, may not reflect current behavior**"
 
 PUBLIC_SURFACES = [

--- a/tests/docs/test_gagov_governance_contract.py
+++ b/tests/docs/test_gagov_governance_contract.py
@@ -34,6 +34,13 @@ REQUIRED_POLICY_TERMS = [
     "auto_merge=false",
     "Docker latest",
 ]
+RUNBOOK_POLICY_TERMS = [
+    "v1.2.0-rc8",
+    "v2.15.0-alpha.1",
+    "GitHub Latest",
+    "auto_merge=false",
+    "Docker latest",
+]
 
 
 def _read(path: Path) -> str:
@@ -74,7 +81,7 @@ def test_runbooks_record_enforced_governance_and_blocker_response():
         for gate in REQUIRED_GATES:
             assert gate in text, f"{path} missing {gate!r}"
 
-        for term in REQUIRED_POLICY_TERMS:
+        for term in RUNBOOK_POLICY_TERMS:
             assert term in text, f"{path} missing {term!r}"
 
 

--- a/tests/docs/test_gaops_operations_contract.py
+++ b/tests/docs/test_gaops_operations_contract.py
@@ -72,7 +72,7 @@ def test_gaops_runbooks_define_operator_sections_and_canonical_sources():
             "index rebuild",
             "incident response",
             "support triage",
-            "v1.2.0-rc6",
+            "v1.2.0-rc7",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"
 

--- a/tests/docs/test_gaops_operations_contract.py
+++ b/tests/docs/test_gaops_operations_contract.py
@@ -72,7 +72,7 @@ def test_gaops_runbooks_define_operator_sections_and_canonical_sources():
             "index rebuild",
             "incident response",
             "support triage",
-            "v1.2.0-rc7",
+            "v1.2.0-rc8",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"
 

--- a/tests/docs/test_garc_rc_soak_contract.py
+++ b/tests/docs/test_garc_rc_soak_contract.py
@@ -44,13 +44,13 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def test_rc7_contract_surfaces_are_frozen():
+def test_rc8_contract_surfaces_are_frozen():
     for path in SURFACES:
         text = _read(path)
-        assert "1.2.0-rc7" in text or "v1.2.0-rc7" in text, path
+        assert "1.2.0-rc8" in text or "v1.2.0-rc8" in text, path
 
     workflow = _read(RELEASE_WORKFLOW)
-    assert "default: 'v1.2.0-rc7'" in workflow
+    assert "default: 'v1.2.0-rc8'" in workflow
     assert "release_type=custom" in "\n".join(
         [workflow, _read(DEPLOYMENT_RUNBOOK), _read(USER_ACTION_RUNBOOK)]
     )
@@ -86,14 +86,14 @@ def test_runbooks_freeze_pre_dispatch_and_observation_commands():
         "git status --short --branch",
         "git fetch origin main --tags --prune",
         "git rev-parse HEAD origin/main",
-        "git tag -l v1.2.0-rc7",
-        "git ls-remote --tags origin refs/tags/v1.2.0-rc7",
+        "git tag -l v1.2.0-rc8",
+        "git ls-remote --tags origin refs/tags/v1.2.0-rc8",
         'gh workflow view "Release Automation"',
-        'gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false',
+        'gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false',
         'gh run list --workflow "Release Automation" --limit 10',
         "gh run watch <run-id> --exit-status",
         "gh run view <run-id> --json url,headSha,status,conclusion,jobs",
-        "gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets",
+        "gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets",
         "blocked before dispatch",
         "ga-rc-evidence.md",
     ):
@@ -123,7 +123,7 @@ def test_ga_rc_evidence_exists_and_records_blocked_or_observed_state():
         "## Rollback And Next-Step Disposition",
         "## Verification",
         "plans/phase-plan-v5-garc.md",
-        "v1.2.0-rc7",
+        "v1.2.0-rc8",
         "git status --short --branch",
         'gh workflow view "Release Automation"',
         "auto_merge=false",

--- a/tests/docs/test_garc_rc_soak_contract.py
+++ b/tests/docs/test_garc_rc_soak_contract.py
@@ -44,13 +44,13 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def test_rc6_contract_surfaces_are_frozen():
+def test_rc7_contract_surfaces_are_frozen():
     for path in SURFACES:
         text = _read(path)
-        assert "1.2.0-rc6" in text or "v1.2.0-rc6" in text, path
+        assert "1.2.0-rc7" in text or "v1.2.0-rc7" in text, path
 
     workflow = _read(RELEASE_WORKFLOW)
-    assert "default: 'v1.2.0-rc6'" in workflow
+    assert "default: 'v1.2.0-rc7'" in workflow
     assert "release_type=custom" in "\n".join(
         [workflow, _read(DEPLOYMENT_RUNBOOK), _read(USER_ACTION_RUNBOOK)]
     )
@@ -86,14 +86,14 @@ def test_runbooks_freeze_pre_dispatch_and_observation_commands():
         "git status --short --branch",
         "git fetch origin main --tags --prune",
         "git rev-parse HEAD origin/main",
-        "git tag -l v1.2.0-rc6",
-        "git ls-remote --tags origin refs/tags/v1.2.0-rc6",
+        "git tag -l v1.2.0-rc7",
+        "git ls-remote --tags origin refs/tags/v1.2.0-rc7",
         'gh workflow view "Release Automation"',
-        'gh workflow run "Release Automation" -f version=v1.2.0-rc6 -f release_type=custom -f auto_merge=false',
+        'gh workflow run "Release Automation" -f version=v1.2.0-rc7 -f release_type=custom -f auto_merge=false',
         'gh run list --workflow "Release Automation" --limit 10',
         "gh run watch <run-id> --exit-status",
         "gh run view <run-id> --json url,headSha,status,conclusion,jobs",
-        "gh release view v1.2.0-rc6 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets",
+        "gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets",
         "blocked before dispatch",
         "ga-rc-evidence.md",
     ):
@@ -123,7 +123,7 @@ def test_ga_rc_evidence_exists_and_records_blocked_or_observed_state():
         "## Rollback And Next-Step Disposition",
         "## Verification",
         "plans/phase-plan-v5-garc.md",
-        "v1.2.0-rc6",
+        "v1.2.0-rc7",
         "git status --short --branch",
         'gh workflow view "Release Automation"',
         "auto_merge=false",
@@ -135,6 +135,7 @@ def test_ga_rc_evidence_exists_and_records_blocked_or_observed_state():
     assert (
         "blocked before dispatch" in evidence
         or "follow-up RC soak succeeded" in evidence
+        or "recut succeeded" in evidence
         or "workflow failed after dispatch" in evidence
     )
 

--- a/tests/docs/test_garecut_rc_recut_contract.py
+++ b/tests/docs/test_garecut_rc_recut_contract.py
@@ -18,17 +18,17 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def test_rc7_contract_surfaces_and_workflow_path_are_frozen():
+def test_rc8_contract_surfaces_and_workflow_path_are_frozen():
     workflow = _read(WORKFLOW)
     release_metadata = _read(RELEASE_METADATA)
 
-    for expected in ("v1.2.0-rc7", "1.2.0-rc7", "peter-evans/create-pull-request@v8"):
+    for expected in ("v1.2.0-rc8", "1.2.0-rc8", "softprops/action-gh-release@v3"):
         assert expected in workflow
 
-    for expected in ("v1.2.0-rc7", "1.2.0-rc7", "release_type=custom"):
+    for expected in ("v1.2.0-rc8", "1.2.0-rc8", "release_type=custom"):
         assert expected in release_metadata
 
-    assert "peter-evans/create-pull-request@v7" not in workflow
+    assert "softprops/action-gh-release@v2" not in workflow
     assert "latest" in workflow
 
 
@@ -42,12 +42,13 @@ def test_ga_rc_evidence_is_the_canonical_recut_artifact():
     for expected in (
         "# GA RC Evidence",
         "plans/phase-plan-v5-garecut.md",
-        "v1.2.0-rc7",
+        "v1.2.0-rc8",
         "Release Automation",
         "PyPI",
         "GHCR",
         "prerelease",
         "latest",
+        "softprops/action-gh-release@v3",
     ):
         assert expected in evidence
 
@@ -67,12 +68,14 @@ def test_final_decision_stays_historical_and_routes_to_the_next_phase_explicitly
         "# GA Final Decision",
         "cut another RC",
         "GARECUT",
-        "v1.2.0-rc7",
-        "renewed GAREL",
+        "v1.2.0-rc8",
+        "rerunning GARECUT",
         "blocked before dispatch",
+        "softprops/action-gh-release@v3",
     ):
         assert expected in decision
 
     assert "- Final decision: `ship GA`." not in decision
     assert "- Final decision: `defer GA`." not in decision
     assert "### Phase 8 — Post-Remediation RC Recut (GARECUT)" in roadmap
+    assert "softprops/action-gh-release@v3" in roadmap

--- a/tests/docs/test_garel_ga_release_contract.py
+++ b/tests/docs/test_garel_ga_release_contract.py
@@ -67,8 +67,10 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
         "docs/validation/ga-e2e-evidence.md",
         "docs/validation/ga-operations-evidence.md",
         "docs/validation/ga-rc-evidence.md",
-        "v1.2.0-rc6",
+        "v1.2.0-rc7",
+        "v1.2.0-rc8",
         "peter-evans/create-pull-request@v8",
+        "softprops/action-gh-release@v3",
         "Node 20",
         "specs/phase-plans-v5.md",
         "GARECUT",
@@ -101,7 +103,9 @@ def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
 
     assert "peter-evans/create-pull-request@v8" in workflow
     assert "peter-evans/create-pull-request@v7" not in workflow
-    assert "Node.js 20 actions are deprecated" in decision
-    assert "updated release workflow requires" in decision
-    assert "another prerelease soak" in decision
+    assert "softprops/action-gh-release@v3" in workflow
+    assert "softprops/action-gh-release@v2" not in workflow
+    assert "the immediate next step is rerunning GARECUT" in decision.replace("\n", " ")
+    assert "Current recut outcome: `blocked before dispatch`" in decision
     assert "### Phase 8 — Post-Remediation RC Recut (GARECUT)" in roadmap
+    assert "softprops/action-gh-release@v3" in roadmap

--- a/tests/docs/test_p23_doc_truth.py
+++ b/tests/docs/test_p23_doc_truth.py
@@ -106,10 +106,10 @@ def test_docker_docs_use_current_image_package_only():
         assert "ghcr.io/viperjuice/code-index-mcp" in _read(path)
 
 
-def test_active_release_docs_name_rc6_and_alpha_or_beta_status():
+def test_active_release_docs_name_rc8_and_alpha_or_beta_status():
     for path in ACTIVE_DOCS:
         text = _read(path).lower()
-        assert "1.2.0-rc6" in text, f"{path.relative_to(REPO_ROOT)} missing 1.2.0-rc6"
+        assert "1.2.0-rc8" in text, f"{path.relative_to(REPO_ROOT)} missing 1.2.0-rc8"
         assert ("alpha" in text) or (
             "beta" in text
         ), f"{path.relative_to(REPO_ROOT)} missing alpha/beta status language"

--- a/tests/docs/test_p25_release_checklist.py
+++ b/tests/docs/test_p25_release_checklist.py
@@ -57,7 +57,7 @@ def test_release_governance_policy_documented_in_operator_runbooks():
             "manual enforcement",
             "branch protection",
             "ruleset",
-            "v1.2.0-rc5",
+            "v1.2.0-rc8",
             "v2.15.0-alpha.1",
             "GitHub Latest",
             "auto_merge=false",

--- a/tests/docs/test_p34_public_alpha_recut.py
+++ b/tests/docs/test_p34_public_alpha_recut.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent.parent
 
-PUBLIC_ALPHA_VERSION = "1.2.0-rc6"
-PUBLIC_ALPHA_TAG = "v1.2.0-rc6"
-CURRENT_RECUT_VERSION = "1.2.0-rc7"
-CURRENT_RECUT_TAG = "v1.2.0-rc7"
+PUBLIC_ALPHA_VERSION = "1.2.0-rc8"
+PUBLIC_ALPHA_TAG = "v1.2.0-rc8"
+CURRENT_RECUT_VERSION = "1.2.0-rc8"
+CURRENT_RECUT_TAG = "v1.2.0-rc8"
 
 PUBLIC_SURFACES = [
     "README.md",
@@ -74,7 +74,7 @@ def test_public_surfaces_share_v3_operating_model():
         assert missing == [], f"{relative} missing {missing}"
 
 
-def test_release_surfaces_use_rc5_identifier():
+def test_release_surfaces_use_current_rc_identifier():
     surfaces = [
         "README.md",
         "docs/GETTING_STARTED.md",
@@ -122,7 +122,7 @@ def test_public_alpha_checklist_names_required_p34_gates():
         "uv run pytest tests/smoke tests/docs tests/test_release_metadata.py",
         "make release-smoke release-smoke-container",
         "tests/docs/test_p34_public_alpha_recut.py",
-        "git tag -l v1.2.0-rc6",
+        "git tag -l v1.2.0-rc8",
     ):
         assert expected in text
 

--- a/tests/docs/test_p8_historical_sweep.py
+++ b/tests/docs/test_p8_historical_sweep.py
@@ -12,9 +12,9 @@ SWEEP_DIRS = [
 ]
 TRIAGE_LOG = REPO_ROOT / "docs" / "HISTORICAL-ARTIFACTS-TRIAGE.md"
 BANNER_REGEX = re.compile(
-    r"^> \*\*Historical artifact \u2014 as-of 2026-04-(18|24), may not reflect current behavior\*\*\s*$"
+    r"^> \*\*Historical artifact \u2014 as-of 2026-04-(18|24|25), may not reflect current behavior\*\*\s*$"
 )
-VALID_AS_OF_DATES = {"2026-04-18", "2026-04-24"}
+VALID_AS_OF_DATES = {"2026-04-18", "2026-04-24", "2026-04-25"}
 VALID_DISPOSITIONS = {"deleted", "bannered", "rewritten"}
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -75,7 +75,7 @@ def test_release_workflow_matches_rc_contract():
     assert f"GARECUT release contract target: {EXPECTED_TAG}" in workflow
     assert (
         'gh workflow run "Release Automation" -f version=v1.2.0 '
-        '-f release_type=custom -f auto_merge=false'
+        "-f release_type=custom -f auto_merge=false"
     ) in workflow
     assert "peter-evans/create-pull-request@v8" in workflow
     assert "softprops/action-gh-release@v3" in workflow

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,4 +1,4 @@
-"""Release metadata assertions for the active v1.2.0-rc7 contract.
+"""Release metadata assertions for the active v1.2.0-rc8 contract.
 
 Historical GARC soak target: v1.2.0-rc6.
 """
@@ -15,8 +15,8 @@ except ImportError:  # Python <3.11
 
 
 REPO = Path(__file__).parent.parent
-EXPECTED_VERSION = "1.2.0-rc7"
-EXPECTED_TAG = "v1.2.0-rc7"
+EXPECTED_VERSION = "1.2.0-rc8"
+EXPECTED_TAG = "v1.2.0-rc8"
 GA_RC_EVIDENCE = REPO / "docs" / "validation" / "ga-rc-evidence.md"
 DOCKER_INSTALLERS = (
     "scripts/install-mcp-docker.sh",
@@ -63,7 +63,7 @@ def test_readme_distribution_identity_remains_stable():
 def test_changelog_has_rc_contract_section():
     changelog = _read_text("CHANGELOG.md")
 
-    assert f"## [{EXPECTED_VERSION}] — 2026-04-24" in changelog
+    assert f"## [{EXPECTED_VERSION}] — 2026-04-25" in changelog
 
 
 def test_release_workflow_matches_rc_contract():
@@ -73,8 +73,14 @@ def test_release_workflow_matches_rc_contract():
     assert f"default: '{EXPECTED_TAG}'" in workflow
     assert "default: 'custom'" in workflow
     assert f"GARECUT release contract target: {EXPECTED_TAG}" in workflow
+    assert (
+        'gh workflow run "Release Automation" -f version=v1.2.0 '
+        '-f release_type=custom -f auto_merge=false'
+    ) in workflow
     assert "peter-evans/create-pull-request@v8" in workflow
+    assert "softprops/action-gh-release@v3" in workflow
     assert "peter-evans/create-pull-request@v7" not in workflow
+    assert "softprops/action-gh-release@v2" not in workflow
     assert 'grep -q "version = \\"$VERSION_NO_V\\"" pyproject.toml' in workflow
     assert 'grep -q "__version__ = \\"$VERSION_NO_V\\"" mcp_server/__init__.py' in workflow
     assert "Prerelease tags must use release_type=custom" in workflow
@@ -114,7 +120,7 @@ def test_release_candidate_tag_is_not_reused_locally():
     assert tag_commit in evidence, f"{EXPECTED_TAG} exists but points at undocumented {tag_commit}"
 
 
-def test_installers_and_download_helper_match_rc7_identity_contract():
+def test_installers_and_download_helper_match_rc8_identity_contract():
     for relative_path in DOCKER_INSTALLERS:
         text = _read_text(relative_path)
         assert EXPECTED_TAG in text
@@ -126,9 +132,9 @@ def test_installers_and_download_helper_match_rc7_identity_contract():
     powershell = _read_text("scripts/install-mcp-docker.ps1")
     download_helper = _read_text("scripts/download-release.py")
 
-    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc7}"' in shell
-    assert 'param(\n    [string]$Variant = "v1.2.0-rc7"' in powershell
-    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc7' in powershell
+    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"' in shell
+    assert 'param(\n    [string]$Variant = "v1.2.0-rc8"' in powershell
+    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc8' in powershell
 
     for expected in (
         "index_it_mcp-",

--- a/uv.lock
+++ b/uv.lock
@@ -1711,7 +1711,7 @@ wheels = [
 
 [[package]]
 name = "index-it-mcp"
-version = "1.2.0rc7"
+version = "1.2.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- preserve the GARECUT/GAREL rc8 recut baseline from the dirty phase-loop worktree
- refresh active release docs, installer metadata, and release contract tests for v1.2.0-rc8
- keep GA final decision evidence in pre-GA/non-ship posture while routing release work through the rc8 recut path

## Verification
- make alpha-docs-truth
- uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py -v --no-cov