### PR TITLE
Record rc8 recut evidence

### DIFF
--- a/docs/validation/ga-final-decision.md
+++ b/docs/validation/ga-final-decision.md
@@ -31,7 +31,7 @@ Evidence summary:
   They support GA evaluation, but they do not independently authorize stable
   mutation.
 - `docs/validation/ga-rc-evidence.md` now records the `v1.2.0-rc8` GARECUT
-  attempt as `blocked before dispatch` while preserving the earlier successful
+  recut as `recut succeeded` while preserving the earlier successful
   `v1.2.0-rc7` recut as historical evidence.
 - This GAREL execution remediated the remaining `Create GitHub Release`
   Node 20 warning by upgrading `softprops/action-gh-release@v2` to
@@ -52,6 +52,14 @@ This GAREL execution remediated that remaining warning by updating
 That is the correct repair for the workflow runtime, but it means the release
 path that would own a stable GA dispatch has changed again and has not yet been
 soaked on a prerelease candidate.
+
+GARECUT has now provided that fresh prerelease soak through successful run
+`24923402398`, release `v1.2.0-rc8`, PyPI package `1.2.0rc8`, and the matching
+GHCR image. That clears the specific `softprops/action-gh-release@v3` soak
+requirement. However, the same successful `Create GitHub Release` job emitted a
+new non-fatal runtime warning from `actions/download-artifact@v8`:
+`Buffer()` deprecation. Renewed GAREL must disposition that warning before any
+future `ship GA` path is authorized.
 
 ## Final Decision
 
@@ -79,40 +87,45 @@ absent, and all stable-channel changes stay blocked.
 - Previous recut target: `v1.2.0-rc7`
 - Previous recut outcome: `recut succeeded`
 - Current recut target: `v1.2.0-rc8`
-- Current recut outcome: `blocked before dispatch`
-- Current readiness: `rerunning GARECUT after the release-affecting worktree is clean enough`
+- Current recut outcome: `recut succeeded`
+- Current readiness: `ready for renewed GAREL planning`
 
 The prior recut dispatched and completed successfully on
 `https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24919438766`,
 published prerelease `v1.2.0-rc7`, pushed the multi-arch GHCR image, and
 published the `1.2.0rc7` wheel plus sdist to PyPI.
 
-The current rc8 recut did not dispatch because the release-affecting worktree
-is intentionally dirty in `.github/workflows/release-automation.yml`,
-`pyproject.toml`, `mcp_server/__init__.py`, installer helpers, validation docs,
-and release-contract tests even though `HEAD` still matches `origin/main`, the
-workflow is visible, and `v1.2.0-rc8` is unused locally and remotely.
+The current rc8 recut dispatched from clean pre-dispatch state on
+`d2560e95f1b4e7d52eacb025d592275e4b48a084`, completed successfully on run
+`24923402398`, published prerelease `v1.2.0-rc8`, uploaded
+`index_it_mcp-1.2.0rc8` wheel plus sdist to PyPI, and pushed the multi-arch
+GHCR image. The merge job left no new release PR open because the release
+branch no longer differed from `main`.
 
-That keeps the repository on the same historical `cut another RC` decision: the
-release path still needs a fresh prerelease soak on
-`softprops/action-gh-release@v3`, and the immediate next step is rerunning
-GARECUT once the release-affecting tree is clean enough for mutation.
+That advances the repository beyond the old rerun state: the
+`softprops/action-gh-release@v3` path is now soaked, so the immediate next step
+is renewed GAREL planning. The remaining release-runtime follow-up is the new
+`actions/download-artifact@v8` `Buffer()` deprecation warning observed in the
+successful `Create GitHub Release` job.
 
 ## Next Scope
 
 The roadmap now routes to the nearest downstream phase with amended steering:
 
 - Roadmap artifact: `specs/phase-plans-v5.md`
-- Phase 8: `Post-Remediation RC Recut (GARECUT)`
+- Phase 7: `GA Decision and Release (GAREL)` as a renewed downstream reducer on
+  top of successful `v1.2.0-rc8` evidence.
 
 That renewed phase must:
 
-- freeze the next prerelease target after `v1.2.0-rc7`,
-- soak the release workflow with `softprops/action-gh-release@v3`,
-- keep prerelease channel policy intact while proving the remediated release
-  path end-to-end, and
-- route back through a newly planned renewed GAREL only after that RC evidence
-  exists; until then, keep rerunning GARECUT rather than reopening GA.
+- reduce the refreshed `v1.2.0-rc8` prerelease evidence instead of reusing the
+  stale blocked-run assumption,
+- disposition the newly observed `actions/download-artifact@v8`
+  `Buffer()` deprecation warning before any `ship GA` path is allowed,
+- keep GitHub Latest and Docker `latest` stable-only until a deliberate GA
+  release changes those channels, and
+- either authorize GA with explicit release evidence or return to another RC /
+  defer-GA decision with the new runtime warning accounted for.
 
 Any older downstream GARECUT or GAREL plan that predates this roadmap
 amendment is stale and must not be treated as authoritative.
@@ -130,6 +143,9 @@ git rev-parse HEAD origin/main
 git tag -l v1.2.0-rc8
 git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
-gh run view 24919438766 --json url,headSha,status,conclusion,jobs
-gh release view v1.2.0-rc7 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+gh run view 24923402398 --json url,headSha,status,conclusion,jobs
+gh run view 24923402398 --job 72989683995 --log
+gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+curl -sSf https://pypi.org/pypi/index-it-mcp/1.2.0rc8/json
+docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```

--- a/docs/validation/ga-rc-evidence.md
+++ b/docs/validation/ga-rc-evidence.md
@@ -4,24 +4,28 @@
 
 ## Summary
 
-- Evidence captured: `2026-04-25T02:31:42Z`.
+- Evidence captured: `2026-04-25T05:34:39Z`.
 - Active phase plan: `plans/phase-plan-v5-garecut.md`.
 - Selected commit before dispatch evaluation:
-  `a3adcea5cd569571a2c4ce3d863317e9f14519bc`.
+  `d2560e95f1b4e7d52eacb025d592275e4b48a084`.
 - Active recut target: `v1.2.0-rc8`.
-- Conclusion: `blocked before dispatch`.
-- Dispatch attempted: `no`.
-- Blocker: release-affecting worktree remained dirty during the rc8 recut
-  attempt, so `gh workflow run` did not execute.
-- Channel posture preserved: no `v1.2.0-rc8` prerelease was published; GitHub
-  Latest remained excluded and Docker `latest` remained stable-only.
+- Conclusion: `recut succeeded`.
+- Dispatch attempted: `yes`.
+- Run URL: `https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24923402398`
+  (`run ID 24923402398`).
+- Channel posture preserved: `v1.2.0-rc8` published as a prerelease only;
+  GitHub Latest remained excluded and Docker `latest` remained stable-only.
+- Follow-up warning: the `Create GitHub Release` job completed successfully on
+  `softprops/action-gh-release@v3`, but its `actions/download-artifact@v8`
+  step emitted a runtime `Buffer()` deprecation warning that renewed GAREL must
+  disposition before any GA ship path is reconsidered.
 
 ## Pre-dispatch Qualification
 
 | Check | Command | Result | Evidence |
 |---|---|---|---|
-| Release candidate worktree state | `git status --short --branch` | fail | `## main...origin/main` with release-affecting dirty files in `.github/workflows/release-automation.yml`, `pyproject.toml`, `mcp_server/__init__.py`, installer helpers, validation docs, and release-contract tests. |
-| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=a3adcea5cd569571a2c4ce3d863317e9f14519bc`, `origin/main=a3adcea5cd569571a2c4ce3d863317e9f14519bc`. |
+| Release candidate worktree state | `git status --short --branch` | pass | `## main...origin/main` with no tracked-file dirt before dispatch. |
+| Local versus remote branch sync | `git fetch origin main --tags --prune` then `git rev-parse HEAD origin/main` | pass | `HEAD=d2560e95f1b4e7d52eacb025d592275e4b48a084`, `origin/main=d2560e95f1b4e7d52eacb025d592275e4b48a084`. |
 | Local tag reuse | `git tag -l v1.2.0-rc8` | pass | No local `v1.2.0-rc8` tag existed before dispatch evaluation. |
 | Remote tag reuse | `git ls-remote --tags origin refs/tags/v1.2.0-rc8` | pass | No remote `v1.2.0-rc8` tag existed before dispatch evaluation. |
 | Release workflow visibility | `gh workflow view "Release Automation"` | pass | Workflow visible as `Release Automation - release-automation.yml`, workflow id `167401116`. |
@@ -44,17 +48,36 @@ Frozen channel-policy inputs:
 
 ## Workflow Observation
 
-- Dispatch attempted: `no`
-- Run URL: `none - blocked before dispatch`
-- Run ID: `none - blocked before dispatch`
-- `headSha`: `a3adcea5cd569571a2c4ce3d863317e9f14519bc`
-- Workflow status / conclusion: `not started` / `blocked before dispatch`
-- Release branch / PR disposition: no `release/v1.2.0-rc8` branch or PR was
-  created because the recut stopped at the dirty-worktree gate.
-- GitHub release state: no `v1.2.0-rc8` release exists because dispatch did not
-  occur.
-- PyPI publication: none - blocked before dispatch.
-- GHCR image identity: none - blocked before dispatch.
+- Dispatch attempted: `yes`
+- Run URL: `https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24923402398`
+- Run ID: `24923402398`
+- `headSha`: `d2560e95f1b4e7d52eacb025d592275e4b48a084`
+- Workflow status / conclusion: `completed` / `success`
+- Job conclusions:
+  - `Preflight Release Gates`: `success`
+  - `Prepare Release`: `success`
+  - `Run Release Tests`: `success`
+  - `Build Release Artifacts`: `success`
+  - `Create GitHub Release`: `success`
+  - `Merge Release Branch`: `success`
+  - `Post-Release Tasks`: `success`
+- `Create GitHub Release` log disposition: successful tag push, prerelease
+  creation, and PyPI publish on `softprops/action-gh-release@v3`; one
+  non-fatal `Buffer()` deprecation warning was emitted by
+  `actions/download-artifact@v8` before release creation.
+- Release branch / PR disposition: `release/v1.2.0-rc8` was created remotely at
+  `d2560e95f1b4e7d52eacb025d592275e4b48a084`; the merge job reported
+  `pull-request-operation = none`, so no new release PR was left open because
+  the branch no longer differed from `main`.
+- GitHub release state: prerelease `v1.2.0-rc8` published at
+  `2026-04-25T05:30:37Z`:
+  `https://github.com/ViperJuice/Code-Index-MCP/releases/tag/v1.2.0-rc8`
+- Tag target commit: `079338cb70f5078db381f088e93df1e9700b5d96`
+- PyPI publication: `index-it-mcp 1.2.0rc8` published at
+  `https://pypi.org/project/index-it-mcp/1.2.0rc8/`
+- GHCR image identity: `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8` index
+  digest `sha256:352bb88eec59e3f15a19077f2880bafa10241997f3ab2619ed221ac32c9eaa05`
+  with linux/amd64 and linux/arm64 manifests.
 
 ## Release-Channel Policy
 
@@ -63,21 +86,23 @@ Frozen channel-policy inputs:
 - `auto_merge=false` remains the required recut input.
 - GitHub Latest remained excluded from the RC policy source.
 - Docker `latest` remained stable-only.
-- No GA wording or stable-channel claims were introduced by the blocked recut.
+- No GA wording or stable-channel claims were introduced by the successful recut
+  itself.
 
 ## Rollback And Next-Step Disposition
 
-No rollback was required because no rc8 release mutation occurred.
+No rollback was required because the rc8 recut completed successfully and did
+not mutate the stable GA channel.
 
 Next-step disposition:
 
-- Rerun GARECUT after the release-affecting worktree is clean enough for
-  mutation and the intended rc8 surfaces are preserved.
-- A renewed GAREL decision is not yet ready; it still depends on fresh
-  `v1.2.0-rc8` prerelease evidence on the remediated
-  `softprops/action-gh-release@v3` workflow path.
-- Until that rerun succeeds, keep the work inside GARECUT rather than
-  reopening GA or treating older downstream GAREL plans as authoritative.
+- Route back through renewed GAREL planning on top of this fresh
+  `v1.2.0-rc8` prerelease evidence.
+- Carry forward the newly observed `actions/download-artifact@v8`
+  `Buffer()` deprecation warning from the `Create GitHub Release` job as a
+  required runtime-disposition item before any `ship GA` path is authorized.
+- Treat any older downstream GAREL plan as stale after the roadmap amendment
+  that incorporates this new warning.
 
 ## Historical GARC Baseline
 
@@ -108,4 +133,11 @@ git rev-parse HEAD origin/main
 git tag -l v1.2.0-rc8
 git ls-remote --tags origin refs/tags/v1.2.0-rc8
 gh workflow view "Release Automation"
+gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false
+gh run view 24923402398 --json url,headSha,status,conclusion,jobs
+gh run view 24923402398 --job 72989683995 --log
+gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
+gh pr list --state all --search "release/v1.2.0-rc8" --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title
+curl -sSf https://pypi.org/pypi/index-it-mcp/1.2.0rc8/json
+docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 ```

--- a/specs/phase-plans-v5.md
+++ b/specs/phase-plans-v5.md
@@ -487,6 +487,11 @@ support, E2E, and operations. GAREL waits for the follow-up RC soak.
 - After a successful GARECUT, route back through `codex-plan-phase
   specs/phase-plans-v5.md GAREL`; any older GAREL plan that predates the
   post-GARECUT or post-remediation release-workflow steering is stale.
+- Successful `v1.2.0-rc8` GARECUT evidence on run `24923402398` proved the
+  `softprops/action-gh-release@v3` path, but it also surfaced a new
+  `actions/download-artifact@v8` `Buffer()` deprecation warning inside the
+  successful `Create GitHub Release` job. Renewed GAREL must disposition that
+  warning before any `ship GA` decision or GA dispatch.
 
 ## Verification
 

--- a/tests/docs/test_garecut_rc_recut_contract.py
+++ b/tests/docs/test_garecut_rc_recut_contract.py
@@ -67,10 +67,11 @@ def test_final_decision_stays_historical_and_routes_to_the_next_phase_explicitly
     for expected in (
         "# GA Final Decision",
         "cut another RC",
-        "GARECUT",
+        "GAREL",
         "v1.2.0-rc8",
-        "rerunning GARECUT",
-        "blocked before dispatch",
+        "ready for renewed GAREL planning",
+        "recut succeeded",
+        "actions/download-artifact@v8",
         "softprops/action-gh-release@v3",
     ):
         assert expected in decision

--- a/tests/docs/test_garel_ga_release_contract.py
+++ b/tests/docs/test_garel_ga_release_contract.py
@@ -51,7 +51,7 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
     assert "enforced via branch protection" in governance
     assert "ready" in e2e
     assert "plans/phase-plan-v5-gaops.md" in ops
-    assert "follow-up RC soak succeeded" in rc
+    assert "recut succeeded" in rc
 
     for expected in (
         "# GA Final Decision",
@@ -71,9 +71,12 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
         "v1.2.0-rc8",
         "peter-evans/create-pull-request@v8",
         "softprops/action-gh-release@v3",
+        "actions/download-artifact@v8",
+        "Buffer()",
         "Node 20",
         "specs/phase-plans-v5.md",
         "GARECUT",
+        "GAREL",
     ):
         assert expected in decision
 
@@ -105,7 +108,9 @@ def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
     assert "peter-evans/create-pull-request@v7" not in workflow
     assert "softprops/action-gh-release@v3" in workflow
     assert "softprops/action-gh-release@v2" not in workflow
-    assert "the immediate next step is rerunning GARECUT" in decision.replace("\n", " ")
-    assert "Current recut outcome: `blocked before dispatch`" in decision
+    assert "the immediate next step is renewed GAREL planning" in decision.replace("\n", " ")
+    assert "Current recut outcome: `recut succeeded`" in decision
+    assert "actions/download-artifact@v8" in decision
+    assert "Buffer()" in decision
     assert "### Phase 8 — Post-Remediation RC Recut (GARECUT)" in roadmap
     assert "softprops/action-gh-release@v3" in roadmap


### PR DESCRIPTION
## Summary
- record successful v1.2.0-rc8 GARECUT evidence
- update GA final decision and roadmap steering toward renewed GAREL
- freeze the new actions/download-artifact@v8 Buffer() warning in docs tests

## Verification
- uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py -v --no-cov
- live release checks for run 24923402398, GitHub release v1.2.0-rc8, PyPI JSON, and GHCR imagetools inspect