### PR TITLE
Accept download-artifact warning for GA dispatch

### DIFF
--- a/docs/validation/ga-final-decision.md
+++ b/docs/validation/ga-final-decision.md
@@ -4,12 +4,13 @@
 
 ## Summary
 
-- Evidence captured: `2026-04-25T12:36:07Z`.
+- Evidence captured: `2026-04-25T17:22:44Z`.
 - Executed decision phase plan: `plans/phase-plan-v5-garel.md`.
-- Final decision: `defer GA`.
-- Stable GA dispatch: `not authorized`.
+- Final decision: `ship GA`.
+- Stable GA dispatch: `authorized for downstream GADISP`.
 - Stable release evidence artifact: `docs/validation/ga-release-evidence.md`
-  remains intentionally absent because no GA release was attempted.
+  remains intentionally absent until downstream GADISP dispatches and verifies
+  the stable release.
 
 ## Decision Inputs
 
@@ -70,13 +71,15 @@ exercise a meaningfully different artifact-download path.
 That means the remaining warning is not evidence that one more prerelease soak
 would answer a new question. Another RC on the same artifact-download line
 would likely reproduce the same warning, while stable GA dispatch remains
-downstream-only and is not owned by this phase. The warning therefore remains an
-unresolved workflow-runtime concern, but it is now classified as a roadmap
-steering blocker rather than a reason to cut another identical RC immediately.
+downstream-only and is not owned by this phase. The operator disposition is that
+the warning is accepted as non-blocking for GA because the rc8 run used
+`digest-mismatch: error`, logged the expected SHA256 digest, completed artifact
+download successfully, and then completed GitHub Release, PyPI, and GHCR
+publication.
 
 ## Final Decision
 
-`defer GA`
+`ship GA`
 
 Rationale:
 
@@ -84,19 +87,21 @@ Rationale:
   `softprops/action-gh-release@v3` path.
 - GitHub's latest published `actions/download-artifact` release remains
   `v8.0.1`, and the repo is already on `actions/download-artifact@v8`.
-- The surviving `Buffer()` deprecation therefore appears on the current
-  artifact-download line rather than on an obviously stale repo pin.
+- The surviving `Buffer()` deprecation appears on the current
+  artifact-download line rather than on an obviously stale repo pin, and is
+  accepted as non-blocking based on the digest-verified rc8 publication path.
 - Another prerelease soak without a workflow-artifact transport change would
   likely reproduce the same warning and would not materially reduce GA risk.
-- This phase can disposition the blocker, but it does not own a separate
-  workflow-runtime remediation lane or the downstream stable dispatch itself.
+- This phase dispositions the blocker but does not perform the downstream
+  stable dispatch itself.
 - GitHub Latest still points at `v2.15.0-alpha.1`, and no `v1.2.0` tag,
   stable GitHub release, stable PyPI release evidence, or Docker `latest`
-  verification was generated in this phase.
+  verification was generated in this phase; those belong to GADISP.
 
-Because the decision is not `ship GA`, no stable release mutation was
-performed, `docs/validation/ga-release-evidence.md` remains intentionally
-absent, and all stable-channel changes stay blocked.
+Because the decision is `ship GA`, stable release mutation is authorized only
+for downstream GADISP from a clean synced tree. This phase performed no stable
+release mutation, and `docs/validation/ga-release-evidence.md` remains
+intentionally absent until GADISP records the actual stable-release evidence.
 
 ## GARECUT Status
 
@@ -104,7 +109,7 @@ absent, and all stable-channel changes stay blocked.
 - Previous recut outcome: `recut succeeded`
 - Current recut target: `v1.2.0-rc8`
 - Current recut outcome: `recut succeeded`
-- Current readiness: `ready for renewed GAREL planning`
+- Current readiness: `ready for GADISP planning`
 
 The prior recut dispatched and completed successfully on
 `https://github.com/ViperJuice/Code-Index-MCP/actions/runs/24919438766`,
@@ -125,25 +130,24 @@ deprecation warning observed in the successful `Create GitHub Release` job.
 
 ## Next Scope
 
-The roadmap now records that existing downstream `ship GA` and `cut another RC`
-plans are both blocked by the unresolved artifact-download warning:
+The roadmap now records that the artifact-download warning is accepted as
+non-blocking for GA dispatch:
 
 - Roadmap artifact: `specs/phase-plans-v5.md`
 - Nearest downstream phase boundary: `GADISP`
-- Downstream disposition: `roadmap extension required before GADISP or GARECUT`
+- Downstream disposition: `GADISP planning/execution authorized`
 
-The next roadmap work must:
+The next phase must:
 
-- decide whether a future phase will remediate the workflow-artifact transport
-  path, explicitly accept the remaining `actions/download-artifact@v8`
-  `Buffer()` warning as non-blocking, or wait for an upstream GitHub fix,
+- record the remaining `actions/download-artifact@v8` `Buffer()` warning as an
+  accepted non-blocking risk in GA release evidence,
 - keep GitHub Latest and Docker `latest` stable-only until a deliberate GA
   release changes those channels, and
-- avoid reusing the current `GADISP` or `GARECUT` plans until the roadmap is
-  extended with that explicit warning-disposition owner.
+- dispatch and verify stable `v1.2.0` only through the dedicated GADISP
+  `phase_loop_mutation: release_dispatch` phase.
 
-Any older downstream `GADISP` or `GARECUT` plan that predates this roadmap
-amendment is stale and must not be treated as authoritative.
+Any older downstream `GADISP` plan that predates this accepted-risk disposition
+is stale and must not be treated as authoritative.
 
 ## Verification
 

--- a/specs/phase-plans-v5.md
+++ b/specs/phase-plans-v5.md
@@ -498,20 +498,24 @@ plans GARECUT and then routes back through GAREL.
 - If GAREL remediates release-workflow runtime drift and concludes that another
   prerelease soak is required, plan `GARECUT` next and treat any older
   downstream GAREL assumptions as stale.
-- If GAREL selects `defer GA` because the latest `actions/download-artifact@v8`
-  line still emits the unresolved `Buffer()` warning and no accepted-risk
-  policy or repo-local remediation was chosen, stop the v5 execution path at
-  GAREL and extend the roadmap before reusing `GADISP` or `GARECUT`.
+- The `actions/download-artifact@v8` `Buffer()` warning observed in the
+  successful `v1.2.0-rc8` run is accepted as non-blocking for GA dispatch. The
+  action is GitHub-owned, the latest published `v8.0.1` line still emits the
+  warning, and the rc8 release proved digest-verified artifact transfer plus
+  successful GitHub Release, PyPI, and GHCR publication. Track the upstream
+  warning separately, but do not block `GADISP` on it.
 - After a successful GARECUT, route back through `codex-plan-phase
   specs/phase-plans-v5.md GAREL`; any older GAREL plan that predates the
   post-GARECUT or post-remediation release-workflow steering is stale.
 - GADISP is the only stable-GA phase that may carry
   `phase_loop_mutation: release_dispatch`.
 - Successful `v1.2.0-rc8` GARECUT evidence on run `24923402398` proved the
-  `softprops/action-gh-release@v3` path, but it also surfaced a new
+  `softprops/action-gh-release@v3` path and surfaced the
   `actions/download-artifact@v8` `Buffer()` deprecation warning inside the
-  successful `Create GitHub Release` job. Renewed GAREL must disposition that
-  warning before any `ship GA` decision or GA dispatch.
+  successful `Create GitHub Release` job. The operator disposition is
+  accepted-risk/non-blocking for GA because artifact download used
+  `digest-mismatch: error`, logged the expected SHA256 digest, and completed
+  before successful GitHub Release, PyPI, and GHCR publication.
 
 ## Verification
 
@@ -606,9 +610,11 @@ post-release evidence only after renewed GAREL selects `ship GA`.
 **Scope notes**
 
 This phase is the only stable-GA mutation phase. It must start from a clean,
-synced tree whose stable surface was already prepared by GAREL. When GAREL
-records `defer GA`, this phase remains blocked until a roadmap extension owns
-the remaining `actions/download-artifact@v8` warning disposition.
+synced tree whose stable surface was already prepared by GAREL. The remaining
+`actions/download-artifact@v8` `Buffer()` warning is accepted as non-blocking
+for GA dispatch based on the successful digest-verified `v1.2.0-rc8` release
+run; GADISP should still record that accepted-risk disposition in GA release
+evidence.
 
 **Non-goals**
 
@@ -652,10 +658,10 @@ any future GA ship decision is reconsidered.
 **Scope notes**
 
 This phase is a prerelease recut on the remediated workflow path. It does not
-authorize a stable release by itself. When GAREL records `defer GA` on the
-latest published `actions/download-artifact@v8` line, this phase is not the
-next step unless a roadmap extension first lands a new workflow-artifact
-transport change to soak.
+authorize a stable release by itself. Because the latest
+`actions/download-artifact@v8` `Buffer()` warning has been accepted as
+non-blocking based on successful digest-verified rc8 evidence, another recut is
+not required solely for that warning.
 
 **Non-goals**
 

--- a/tests/docs/test_garecut_rc_recut_contract.py
+++ b/tests/docs/test_garecut_rc_recut_contract.py
@@ -66,17 +66,18 @@ def test_final_decision_stays_historical_and_routes_to_the_next_phase_explicitly
     assert decision.startswith("> **Historical artifact")
     for expected in (
         "# GA Final Decision",
-        "cut another RC",
+        "ship GA",
         "GAREL",
         "v1.2.0-rc8",
-        "ready for renewed GAREL planning",
+        "ready for GADISP planning",
         "recut succeeded",
         "actions/download-artifact@v8",
+        "accepted as non-blocking for GA",
         "softprops/action-gh-release@v3",
     ):
         assert expected in decision
 
-    assert "- Final decision: `ship GA`." not in decision
-    assert "roadmap extension required before GADISP or GARECUT" in decision
+    assert "- Final decision: `defer GA`." not in decision
+    assert "GADISP planning/execution authorized" in decision
     assert "### Phase 9 — Post-Remediation RC Recut (GARECUT)" in roadmap
     assert "softprops/action-gh-release@v3" in roadmap

--- a/tests/docs/test_garel_ga_release_contract.py
+++ b/tests/docs/test_garel_ga_release_contract.py
@@ -62,7 +62,7 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
         "## GARECUT Status",
         "## Next Scope",
         "## Verification",
-        "defer GA",
+        "ship GA",
         "docs/validation/ga-readiness-checklist.md",
         "docs/validation/ga-governance-evidence.md",
         "docs/validation/ga-e2e-evidence.md",
@@ -80,16 +80,17 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
     ):
         assert expected in decision
 
-    assert "- Final decision: `ship GA`." not in decision
+    assert "- Final decision: `defer GA`." not in decision
     assert "- Final decision: `cut another RC`." not in decision
 
 
-def test_non_ship_decision_keeps_ga_release_evidence_absent_and_public_surfaces_pre_ga():
+def test_ship_decision_defers_release_evidence_to_gadisp_and_keeps_public_surfaces_pre_dispatch():
     decision = _read(GA_FINAL)
 
-    assert "- Final decision: `defer GA`." in decision
+    assert "- Final decision: `ship GA`." in decision
+    assert "Stable GA dispatch: `authorized for downstream GADISP`" in decision
     assert "ga-release-evidence.md`" in decision
-    assert "remains intentionally absent" in decision
+    assert "remains intentionally absent until downstream GADISP" in decision
     assert not GA_RELEASE.exists()
 
     combined = "\n".join(_read(path) for path in PUBLIC_SURFACES).lower()
@@ -114,7 +115,8 @@ def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
     assert "Current recut outcome: `recut succeeded`" in decision
     assert "actions/download-artifact@v8" in decision
     assert "Buffer()" in decision
-    assert "roadmap extension required before GADISP or GARECUT" in decision
+    assert "accepted as non-blocking for GA" in decision
+    assert "GADISP planning/execution authorized" in decision
     assert "### Phase 8 — GA Stable Dispatch And Release Evidence (GADISP)" in roadmap
-    assert "When GAREL records `defer GA`, this phase remains blocked" in roadmap.replace("\n", " ")
+    assert "accepted as non-blocking for GA dispatch" in roadmap.replace("\n", " ")
     assert "softprops/action-gh-release@v3" in roadmap


### PR DESCRIPTION
## Summary
- records the operator decision that the current actions/download-artifact@v8 Buffer warning is accepted as non-blocking for GA dispatch
- updates the GA final decision to ship GA through downstream GADISP while keeping release evidence absent until dispatch
- aligns GAREL/GARECUT contract tests with the accepted-risk disposition

## Verification
- git diff --check
- uv run pytest tests/test_release_metadata.py tests/docs/test_garel_ga_release_contract.py tests/docs/test_garecut_rc_recut_contract.py -v --no-cov