### PR TITLE
Prepare stable GAREL release surfaces

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -6,9 +6,9 @@ on:
     # Historical GARC default: 'v1.2.0-rc6'
     inputs:
       version:
-        description: 'Version to release (e.g., v1.2.0-rc8)'
+        description: 'Version to release (e.g., v1.2.0)'
         required: true
-        default: 'v1.2.0-rc8'
+        default: 'v1.2.0'
         type: string
       release_type:
         description: 'Release type'
@@ -74,8 +74,9 @@ jobs:
               exit 1
               ;;
           esac
-          grep -q "default: 'v1.2.0-rc8'" .github/workflows/release-automation.yml
+          grep -q "default: 'v1.2.0'" .github/workflows/release-automation.yml
           # Stable GA dispatch stays on the existing workflow contract:
+          # Stable tags still use release_type=custom for governed dispatch.
           # gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=custom -f auto_merge=false
           if [ "$RELEASE_TYPE" = "custom" ]; then
             grep -q "version = \"$VERSION_NO_V\"" pyproject.toml
@@ -376,7 +377,7 @@ jobs:
           body: |
             ## Release ${{ needs.prepare-release.outputs.version }}
 
-            GARECUT release contract target: v1.2.0-rc8
+            GAREL stable release contract target: v1.2.0
 
             This PR contains all changes for release ${{ needs.prepare-release.outputs.version }}.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: # placeholder for post-rc5 work
 
+## [1.2.0] — 2026-04-25
+
+### Changed (GAREL — stable surface preparation)
+- Prepared the stable `1.2.0` / `v1.2.0` repo-owned release surface across
+  package metadata, runtime metadata, release automation defaults, active
+  install docs, support docs, and Docker installer helpers.
+- Preserved `v1.2.0-rc8` as historical prerelease soak evidence only while
+  routing the actual stable dispatch and GA release evidence to downstream
+  `GADISP`.
+
+### Known limitations
+- This phase did not dispatch the stable release; GitHub Latest and Docker
+  `latest` remain stable-only outputs that are still verified in `GADISP`.
+- Beta, experimental, unsupported, and disabled-by-default support-tier limits
+  remain governed by `docs/SUPPORT_MATRIX.md`; stable surface prep does not
+  broaden product topology or runtime claims.
+
 ## [1.2.0-rc8] — 2026-04-25
 
 ### Changed (GARECUT — post-remediation RC recut freeze)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Modular, extensible local-first code indexer designed to enhance Claude Code and other LLMs with deep code understanding capabilities. Built on the Model Context Protocol (MCP) for seamless integration with AI assistants.
 
-> **Beta status**: Multi-repo support and the MCP STDIO interface are in beta. The MCP tool interface (`search_code`, `symbol_lookup`, and friends) is the primary surface for LLM-driven use; the FastAPI REST gateway is a secondary admin surface for diagnostics and manual operations. Expect API surface changes before stable release.
+> **Stable-surface prep status**: This guide targets `1.2.0` and reflects the
+> repo-owned stable install surface prepared by GAREL. MCP STDIO remains the
+> primary LLM surface, FastAPI remains a secondary admin surface, and final
+> release publication plus GA release evidence remain downstream-only in
+> `GADISP`.
 
 ## Project Status
-**Version**: 1.2.0-rc8 (beta)
+**Version**: 1.2.0 (stable surface prepared; dispatch pending)
 **Python distribution**: `index-it-mcp`
 **Container image**: `ghcr.io/viperjuice/code-index-mcp`
 **Primary surface**: MCP tools (`search_code`, `symbol_lookup`) via the STDIO runner when repository readiness is `ready`
@@ -13,9 +17,9 @@ Modular, extensible local-first code indexer designed to enhance Claude Code and
 **Core features**: local indexing, symbol/text search, registry-based language coverage; see [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)
 **Optional features**: semantic search (requires Voyage AI or a local vLLM endpoint), GitHub Artifacts index sync
 **Performance**: sub-100ms symbol lookup and sub-500ms search on indexed repos (benchmarked on this codebase; results vary by repo size and language mix)
-**Public alpha decision**: see [docs/validation/private-alpha-decision.md](docs/validation/private-alpha-decision.md) before promotion; public alpha remains beta-status until P21-P34 gates, the P33 production multi-repo matrix, and private evidence are green.
-**GA readiness contract**: see [docs/validation/ga-readiness-checklist.md](docs/validation/ga-readiness-checklist.md) for the frozen release boundary, support-tier labels, evidence ownership, and rollback expectations that apply before any GA claim.
-**Public alpha repository model**: one server can serve many unrelated repositories, with one registered worktree per git common directory. Only the tracked/default branch is indexed automatically. Indexed MCP results are authoritative only when readiness is `ready`; unavailable indexes return `index_unavailable` with `safe_fallback: "native_search"`.
+**GA decision**: see [docs/validation/ga-final-decision.md](docs/validation/ga-final-decision.md); the current decision is `ship GA`, but stable release mutation and release evidence remain downstream-only in `GADISP`.
+**GA readiness contract**: see [docs/validation/ga-readiness-checklist.md](docs/validation/ga-readiness-checklist.md) for the frozen release boundary, support-tier labels, evidence ownership, and rollback expectations that apply before dispatch.
+**Repository model**: one server can serve many unrelated repositories, with one registered worktree per git common directory. Only the tracked/default branch is indexed automatically. Indexed MCP results are authoritative only when readiness is `ready`; unavailable indexes return `index_unavailable` with `safe_fallback: "native_search"`.
 
 > **New to Code-Index-MCP?** Check out our [Getting Started Guide](docs/GETTING_STARTED.md) for a quick walkthrough.
 
@@ -104,7 +108,7 @@ Key directories:
 
 ## 🛠️ Language Support
 
-The current beta support contract is centralized in [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md).
+The current stable-surface support contract is centralized in [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md).
 It distinguishes specialized plugins, generic Tree-sitter registry coverage,
 default sandbox support, optional extras, semantic/rerank setup, and known
 alpha limitations. Do not assume every registry language has the same symbol
@@ -112,15 +116,15 @@ quality or default sandbox behavior.
 
 ## 🚀 Quick Start
 
-Supported public-alpha install paths are native Python/STDIO with
+Supported stable install paths are native Python/STDIO with
 `uv sync --locked` and the `ghcr.io/viperjuice/code-index-mcp` container image.
 Language coverage is bounded by [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md),
 GA-hardening evidence ownership is frozen in
 [docs/validation/ga-readiness-checklist.md](docs/validation/ga-readiness-checklist.md),
 and rollback procedures live in
 [docs/operations/deployment-runbook.md](docs/operations/deployment-runbook.md).
-Do not treat this beta release candidate as GA or as a universal language
-support claim.
+Do not treat this prepared stable surface as a universal language support
+claim; row-level support tiers still live in the support matrix.
 
 ### 🎯 Automatic Setup for Claude Code/Desktop (Recommended)
 ```bash
@@ -141,7 +145,7 @@ This automatically detects your environment and creates the appropriate `.mcp.js
 curl -sSL https://raw.githubusercontent.com/ViperJuice/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
 
 # Index your current directory
-docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0
 ```
 
 #### Option 2: AI-Powered Search
@@ -150,7 +154,7 @@ docker run -it -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
 export VOYAGE_API_KEY=your-key
 
 # Run with semantic search enabled explicitly
-docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_API_KEY ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_API_KEY ghcr.io/viperjuice/code-index-mcp:v1.2.0
 ```
 
 ### 💻 Environment-Specific Setup
@@ -161,7 +165,7 @@ docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_AP
 .\scripts\setup-mcp-json.ps1
 
 # Or manually with Docker Desktop
-docker run -it -v ${PWD}:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+docker run -it -v ${PWD}:/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0
 ```
 
 #### 🍎 macOS
@@ -229,7 +233,7 @@ The setup script creates the appropriate `.mcp.json` for your environment. Manua
       "args": [
         "run", "-i", "--rm",
         "-v", "${workspace}:/workspace",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ]
     }
   }
@@ -330,11 +334,11 @@ for language/runtime support details.
 
 #### Option 1: Install via pip (Recommended)
 ```bash
-# After the public-alpha package is published, install the rc package
-pip install --pre index-it-mcp==1.2.0rc8
+# Install the prepared stable package surface
+pip install index-it-mcp==1.2.0
 
 # Or install with dev tools for testing
-pip install --pre "index-it-mcp[dev]==1.2.0rc8"
+pip install "index-it-mcp[dev]==1.2.0"
 ```
 
 #### Option 2: Install from Source
@@ -1129,10 +1133,10 @@ Maintainers can create new releases with pre-built indexes:
 
 ```bash
 # Create a new release (as draft)
-python scripts/create-release.py --version 1.2.0-rc8
+python scripts/create-release.py --version 1.2.0
 
 # Create and publish immediately
-python scripts/create-release.py --version 1.2.0-rc8 --publish
+python scripts/create-release.py --version 1.2.0 --publish
 ```
 
 ### Automatic Index Synchronization
@@ -1202,7 +1206,7 @@ For detailed architectural documentation, see the [architecture/](architecture/)
 
 See [ROADMAP.md](ROADMAP.md) for detailed development plans and current progress.
 
-**Current Status**: 1.2.0-rc8 beta release candidate
+**Current Status**: 1.2.0 stable surface prepared; downstream GADISP dispatch still pending
 - ✅ **Core Indexing**: SQLite + FTS5 for fast local search
 - ✅ **Multi-Language**: Specialized and registry-backed language coverage; see `docs/SUPPORT_MATRIX.md`
 - ✅ **MCP Protocol**: Full compatibility with Claude Code and other MCP clients

--- a/docs/DOCKER_GUIDE.md
+++ b/docs/DOCKER_GUIDE.md
@@ -1,6 +1,6 @@
 # Docker Guide for MCP Index Server
 
-This guide documents the beta Docker path for Code-Index-MCP `1.2.0-rc8`.
+This guide documents the stable-surface Docker path for Code-Index-MCP `1.2.0`.
 The P22-proven image package is `ghcr.io/viperjuice/code-index-mcp`. MCP STDIO
 is the primary LLM surface; FastAPI remains a secondary admin surface. The
 pre-GA release boundary and evidence map are frozen in
@@ -48,7 +48,7 @@ for the canonical support contract.
 P23 documents one image package:
 
 ```bash
-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+ghcr.io/viperjuice/code-index-mcp:v1.2.0
 ```
 
 Enable optional behavior with environment variables and installed extras rather
@@ -79,13 +79,13 @@ iwr -useb https://raw.githubusercontent.com/Code-Index-MCP/main/scripts/install-
 
 2. **Pull the image**:
    ```bash
-   docker pull ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+   docker pull ghcr.io/viperjuice/code-index-mcp:v1.2.0
    ```
 
 3. **Create launcher script**:
    ```bash
    # Linux/macOS
-   echo 'docker run -i --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8 "$@"' > /usr/local/bin/mcp-index
+   echo 'docker run -i --rm -v $(pwd):/workspace ghcr.io/viperjuice/code-index-mcp:v1.2.0 "$@"' > /usr/local/bin/mcp-index
    chmod +x /usr/local/bin/mcp-index
    ```
 
@@ -100,7 +100,7 @@ Configure the Docker container using environment variables:
 docker run -it \
   -e LOG_LEVEL=DEBUG \
   -e MCP_WORKSPACE_ROOT=/workspace \
-  ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+  ghcr.io/viperjuice/code-index-mcp:v1.2.0
 ```
 
 ### Configuration File (.env)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,8 +2,8 @@
 
 This guide walks you through installing and using Code-Index-MCP to index and search your codebase.
 
-> **Beta status**: This guide targets `1.2.0-rc8`. MCP STDIO is the primary
-> LLM surface; FastAPI is a secondary admin surface. Language behavior is
+> **Stable-surface prep status**: This guide targets `1.2.0`. MCP STDIO is the
+> primary LLM surface; FastAPI is a secondary admin surface. Language behavior is
 > documented in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md), and the pre-GA release
 > boundary is frozen in
 > [ga-readiness-checklist.md](validation/ga-readiness-checklist.md).
@@ -29,8 +29,8 @@ This guide walks you through installing and using Code-Index-MCP to index and se
 ### Option 1: Install via pip (Recommended)
 
 ```bash
-# After the public-alpha package is published, install the rc package
-pip install --pre index-it-mcp==1.2.0rc8
+# Install the prepared stable package surface
+pip install index-it-mcp==1.2.0
 
 # Verify installation
 mcp-index --version

--- a/docs/MCP_CONFIGURATION.md
+++ b/docs/MCP_CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive information on configuring the Code-Index-MCP for different environments and use cases.
 
-> **Beta status**: This guide targets `1.2.0-rc8`. MCP STDIO is the primary
+> **Stable-surface prep status**: This guide targets `1.2.0`. MCP STDIO is the primary
 > LLM surface. FastAPI remains a secondary admin surface. Docker examples use
 > `ghcr.io/viperjuice/code-index-mcp`.
 > Language behavior is defined in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md), and
@@ -119,7 +119,7 @@ The setup script automatically detects your environment:
         "-e", "MCP_WORKSPACE_ROOT=/workspace",
         "-e", "LOG_LEVEL=${LOG_LEVEL:-INFO}",
         "-e", "MCP_ARTIFACT_SYNC=false",
-        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8}"
+        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0}"
       ]
     }
   }
@@ -152,7 +152,7 @@ The setup script automatically detects your environment:
         "-e", "SEMANTIC_SEARCH_ENABLED=${SEMANTIC_SEARCH_ENABLED:-true}",
         "-e", "MCP_ARTIFACT_SYNC=${MCP_ARTIFACT_SYNC:-true}",
         "-e", "LOG_LEVEL=${LOG_LEVEL:-INFO}",
-        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8}"
+        "${MCP_DOCKER_IMAGE:-ghcr.io/viperjuice/code-index-mcp:v1.2.0}"
       ]
     }
   }
@@ -277,7 +277,7 @@ one worktree per git common directory, and check readiness before MCP tool use:
         "-v", "${HOME}/projects/repo-a:/repos/repo-a",
         "-v", "${HOME}/projects/repo-b:/repos/repo-b",
         "-e", "MCP_ALLOWED_ROOTS=/repos/repo-a:/repos/repo-b",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ]
     }
   }
@@ -331,7 +331,7 @@ Add Docker resource constraints:
         "--memory", "2g",
         "--cpus", "2",
         "-v", "${workspace}:/workspace",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ]
     }
   }
@@ -351,7 +351,7 @@ For maximum security:
         "run", "-i", "--rm",
         "--network", "none",
         "-v", "${workspace}:/workspace:ro",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ],
       "env": {
         "MCP_ARTIFACT_SYNC": "false"
@@ -428,7 +428,7 @@ Enable debug logging:
         "-v", "${workspace}:/workspace",
         "-e", "LOG_LEVEL=DEBUG",
         "-e", "MCP_DEBUG=true",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ]
     }
   }
@@ -441,7 +441,7 @@ Test your configuration:
 
 ```bash
 # Test MCP connection
-echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}' | docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+echo '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}' | docker run -i --rm ghcr.io/viperjuice/code-index-mcp:v1.2.0
 
 # Expected response:
 # {"jsonrpc":"2.0","id":1,"result":{"capabilities":...}}
@@ -517,7 +517,7 @@ Enable security audit logs:
         "-v", "${HOME}/mcp-audit:/app/logs",
         "-e", "MCP_AUDIT_LOG=/app/logs/audit.log",
         "-e", "MCP_SECURITY_MODE=strict",
-        "ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8"
+        "ghcr.io/viperjuice/code-index-mcp:v1.2.0"
       ]
     }
   }

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,10 +1,9 @@
 # Code-Index-MCP Support Matrix
 
-This matrix is the canonical GASUPPORT support statement for version
-`1.2.0-rc8`. The product release posture is still RC/public-alpha and beta:
-MCP STDIO is the primary LLM surface, FastAPI is a secondary admin surface,
-and the GA-hardening roadmap is reducing claims rather than widening the
-product.
+This matrix is the canonical GASUPPORT support statement for the prepared
+stable surface `1.2.0`. MCP STDIO is the primary LLM surface, FastAPI is a
+secondary admin surface, and the GA-hardening roadmap remains responsible for
+separating stable release prep from the downstream `GADISP` dispatch evidence.
 
 Repository-topology support is separate from language/runtime support. The v3
 public-alpha model supports many unrelated repositories on one machine, with one
@@ -22,9 +21,9 @@ evidence checklist is `docs/validation/ga-readiness-checklist.md`.
 
 ## Claim tiers
 
-- **Public-alpha**: `v1.2.0-rc8` is the active RC/public-alpha package
-  contract. It is suitable for outside-developer validation of the documented
-  STDIO, readiness, repository-topology, and Docker package surfaces.
+- **Stable prep**: `v1.2.0` is the prepared stable package and container
+  contract. It is the repo-owned surface that downstream `GADISP` dispatches
+  and verifies.
 - **Beta**: Multi-repo support, STDIO, and secondary tool readiness remain beta
   surfaces. Passing TOOLRDY evidence is readiness evidence, not a GA support
   claim or a support-matrix expansion.
@@ -116,8 +115,8 @@ topology, or install-surface support expansion.
 | STDIO mutation and summarization tools (`reindex`, `write_summaries`, `summarize_sample`) | beta | Secondary tool surfaces behind readiness gates | `tool_handlers.py`, TOOLRDY evidence, readiness-refusal tests | Non-ready repos fail closed; the artifact is readiness evidence, not support expansion |
 | FastAPI admin and diagnostics surface | beta | Secondary/admin surface | `README.md`, `docs/GETTING_STARTED.md`, `docs/MCP_CONFIGURATION.md` | Do not treat FastAPI as the primary LLM interface |
 | Native source install via `uv sync --locked` | beta | Canonical local development and operator path | `pyproject.toml`, `uv.lock`, install docs | This is the preferred local install path while the release remains pre-GA |
-| Pre-release package install (`index-it-mcp==1.2.0rc8`) | beta | Opt-in release artifact path | package naming and install docs | Keep tied to the RC/public-alpha release boundary until later GA evidence exists |
-| Docker image `ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8` | beta | Supported container path | Docker guide, release evidence, image naming tests | Container docs must keep the same topology and readiness limits as native docs |
+| Package install (`index-it-mcp==1.2.0`) | beta | Prepared stable artifact path | package naming and install docs | Stable surface prep does not by itself prove downstream release publication |
+| Docker image `ghcr.io/viperjuice/code-index-mcp:v1.2.0` | beta | Supported container path | Docker guide, release evidence, image naming tests | Container docs must keep the same topology and readiness limits as native docs |
 | Semantic search (`uv sync --locked --extra semantic` plus provider config) | experimental | Optional extra and provider-dependent | extras docs, config env vars, support-fact notes | Requires provider credentials or a compatible local endpoint; not unconditional support |
 | Reranking (`uv sync --locked --extra rerank` plus provider/model config) | experimental | Optional extra and provider-dependent | extras docs and support-fact notes | Treat as opt-in ranking improvement, not baseline query behavior |
 | Default sandboxed plugin execution | beta | Default security posture | `sandbox_supported`, `activation_mode`, sandbox docs | Coverage varies by language and is authoritative through `plugin_availability` |

--- a/docs/operations/deployment-runbook.md
+++ b/docs/operations/deployment-runbook.md
@@ -1,9 +1,9 @@
-# Deployment Runbook (v1.2.0-rc8 public-alpha / beta baseline)
+# Deployment Runbook (v1.2.0 stable-surface preparation baseline)
 
 ## Overview
 
 This runbook is the operator playbook for the Code-Index-MCP
-`v1.2.0-rc8` public-alpha / beta baseline. It is not a GA launch document.
+`v1.2.0` stable-surface preparation baseline. It is not a GA launch document.
 The supported deployment surfaces remain local-first and operator-owned:
 
 - `uv sync --locked` plus the local checkout
@@ -33,6 +33,18 @@ tracked/default branch indexing only, and `index_unavailable` with
   [`../validation/ga-e2e-evidence.md`](../validation/ga-e2e-evidence.md)
 - GA operations evidence:
   [`../validation/ga-operations-evidence.md`](../validation/ga-operations-evidence.md)
+
+## GAREL Stable-Surface Preparation Status
+
+The current stable surface is prepared for downstream `GADISP` and keeps the
+historical rc8 soak evidence intact:
+
+- Branch protection remains enforced via `docs/validation/ga-governance-evidence.md`.
+- The historical `v1.2.0-rc8` recut outcome is `recut succeeded`.
+- Repo-owned package metadata, workflow defaults, installer helpers, and active
+  customer docs now point at `v1.2.0`.
+- `docs/validation/ga-release-evidence.md` remains intentionally absent until
+  downstream `GADISP` dispatches and verifies the stable release.
 
 ## Public Alpha Release Gate Checklist
 
@@ -118,7 +130,7 @@ Refresh evidence ownership is:
 - `docs/validation/ga-operations-evidence.md` -> `GAOPS`
 - `docs/validation/ga-rc-evidence.md` -> `GARC`
 - `docs/validation/ga-final-decision.md` -> `GAREL`
-- `docs/validation/ga-release-evidence.md` -> `GAREL`
+- `docs/validation/ga-release-evidence.md` -> `GADISP`
 
 The active post-remediation RC version is `v1.2.0-rc8`, and the next recut
 target should advance beyond that version when GARECUT is replanned.

--- a/docs/operations/user-action-runbook.md
+++ b/docs/operations/user-action-runbook.md
@@ -473,6 +473,38 @@ No operator actions required. P12 is fully codebase-internal.
   did not happen or the workflow failed, state that explicitly and keep GA
   release work blocked until GARC is rerun successfully.
 
+### 3.12 Phase GAREL / GADISP - Stable Surface Prep And Dispatch
+
+#### Before GAREL
+
+- [ ] **Confirm the historical soak result remains usable.** The active
+  historical prerelease proof is `v1.2.0-rc8`, and the canonical outcome in
+  `docs/validation/ga-rc-evidence.md` is `recut succeeded`.
+- [ ] **Keep branch protection live.** Treat
+  `docs/validation/ga-governance-evidence.md` as the source of truth that
+  `main` remains enforced via branch protection before any stable dispatch work
+  is planned.
+
+#### During GAREL
+
+- [ ] **Prepare only the repo-owned stable surface.** Update package metadata,
+  runtime version, active install docs, Docker install defaults, and release
+  workflow defaults to `v1.2.0` / `1.2.0` without dispatching the release.
+- [ ] **Route release evidence to the downstream owner.** Keep
+  `docs/validation/ga-release-evidence.md` absent during GAREL and reserve it
+  for `GADISP`.
+- [ ] **Record downstream readiness explicitly.** The GAREL closeout must state
+  that the stable surface is `prepared for downstream GADISP`.
+
+#### After GAREL
+
+- [ ] **Plan or execute only `GADISP` next.** Stable release mutation,
+  GitHub Latest verification, Docker `latest` verification, and final stable
+  release evidence belong only to `GADISP`.
+- [ ] **Treat older downstream dispatch plans as stale.** If a `GADISP` plan
+  predates the accepted `actions/download-artifact@v8` warning disposition or
+  the prepared `v1.2.0` surface, re-plan it before execution.
+
 ---
 
 ## 4. Ongoing operations

--- a/docs/validation/ga-final-decision.md
+++ b/docs/validation/ga-final-decision.md
@@ -103,7 +103,17 @@ for downstream GADISP from a clean synced tree. This phase performed no stable
 release mutation, and `docs/validation/ga-release-evidence.md` remains
 intentionally absent until GADISP records the actual stable-release evidence.
 
-## GARECUT Status
+## Stable Surface Preparation
+
+- Stable surface status: `prepared for downstream GADISP`
+- Prepared package version: `1.2.0`
+- Prepared release tag: `v1.2.0`
+- Prepared installer default: `ghcr.io/viperjuice/code-index-mcp:v1.2.0`
+- Active repo-owned docs and installer helpers now point at the stable `1.2.0`
+  package and container surface while keeping rc8 release proof as historical
+  evidence only.
+
+## Historical RC Evidence
 
 - Previous recut target: `v1.2.0-rc7`
 - Previous recut outcome: `recut succeeded`

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -2,7 +2,7 @@
 
 # Version information
 # Historical GARC soak target: 1.2.0-rc6.
-__version__ = "1.2.0-rc8"
+__version__ = "1.2.0"
 
 # Public API exports
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "index-it-mcp"
 # Historical GARC soak target: 1.2.0-rc6.
-version = "1.2.0-rc8"
+version = "1.2.0"
 description = "Local-first code indexer for AI assistants via Model Context Protocol (MCP)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/install-mcp-docker.ps1
+++ b/scripts/install-mcp-docker.ps1
@@ -2,8 +2,8 @@
 # PowerShell script to install and configure MCP Index with Docker
 
 param(
-    [string]$Variant = "v1.2.0-rc8",
-    [string]$Version = "v1.2.0-rc8"
+    [string]$Variant = "v1.2.0",
+    [string]$Version = "v1.2.0"
 )
 
 # Configuration
@@ -80,7 +80,7 @@ function Install-Docker {
 function Select-Variant {
     Write-Host ""
     Write-Host "Choose MCP Index variant:"
-    Write-Host "1) v1.2.0-rc8  - Active RC/public-alpha image (recommended)"
+    Write-Host "1) v1.2.0      - Prepared stable image (recommended)"
     Write-Host "2) latest      - Stable-only channel; may not exist before GA"
     Write-Host "3) local-smoke - Local smoke image built by make release-smoke-container"
     Write-Host ""
@@ -97,8 +97,8 @@ function Select-Variant {
             Write-Host "[INFO] Selected: local-smoke" -ForegroundColor Green
         }
         default {
-            $script:Variant = "v1.2.0-rc8"
-            Write-Host "[INFO] Selected: v1.2.0-rc8" -ForegroundColor Green
+            $script:Variant = "v1.2.0"
+            Write-Host "[INFO] Selected: v1.2.0" -ForegroundColor Green
         }
     }
 }
@@ -115,7 +115,7 @@ function Create-Launcher {
 REM MCP Index Docker Launcher for Windows
 
 SET MCP_VARIANT=%MCP_VARIANT%
-IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc8
+IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0
 
 SET MCP_IMAGE=ghcr.io/viperjuice/code-index-mcp
 SET WORKSPACE=%CD%

--- a/scripts/install-mcp-docker.sh
+++ b/scripts/install-mcp-docker.sh
@@ -12,8 +12,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-MCP_VERSION="${MCP_VERSION:-v1.2.0-rc8}"
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"
+MCP_VERSION="${MCP_VERSION:-v1.2.0}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-ghcr.io}"
 MCP_IMAGE="${DOCKER_REGISTRY}/viperjuice/code-index-mcp"
 
@@ -115,7 +115,7 @@ install_docker() {
 choose_variant() {
     echo
     echo "Choose MCP Index variant:"
-    echo "1) v1.2.0-rc8  - Active RC/public-alpha image (recommended)"
+    echo "1) v1.2.0      - Prepared stable image (recommended)"
     echo "2) latest      - Stable-only channel; may not exist before GA"
     echo "3) local-smoke - Local smoke image built by make release-smoke-container"
     echo
@@ -133,8 +133,8 @@ choose_variant() {
             print_info "Selected: local-smoke"
             ;;
         *)
-            MCP_VARIANT="v1.2.0-rc8"
-            print_info "Selected: v1.2.0-rc8"
+            MCP_VARIANT="v1.2.0"
+            print_info "Selected: v1.2.0"
             ;;
     esac
 }
@@ -155,7 +155,7 @@ create_launcher() {
 # MCP Index Docker Launcher
 
 # Default settings
-MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"
+MCP_VARIANT="${MCP_VARIANT:-v1.2.0}"
 MCP_IMAGE="${MCP_IMAGE:-ghcr.io/viperjuice/code-index-mcp}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
 

--- a/tests/docs/test_gabase_ga_readiness_contract.py
+++ b/tests/docs/test_gabase_ga_readiness_contract.py
@@ -82,6 +82,7 @@ def test_checklist_exists_with_required_sections_and_baseline():
     for expected in (
         "v1.2.0-rc5",
         "v1.2.0-rc8",
+        "v1.2.0",
         "canonical GABASE checklist",
     ):
         assert expected in text
@@ -117,20 +118,14 @@ def test_public_docs_remain_pre_ga_and_route_to_canonical_artifacts():
         text = _read(path)
         lowered = text.lower()
 
-        if "1.2.0-rc8" not in text:
-            failures.append(f"{path.relative_to(REPO)} missing rc8 baseline")
-        if ("public-alpha" not in lowered) and ("beta" not in lowered):
-            failures.append(f"{path.relative_to(REPO)} missing public-alpha/beta language")
+        if "1.2.0" not in text:
+            failures.append(f"{path.relative_to(REPO)} missing stable baseline")
+        if "stable" not in lowered:
+            failures.append(f"{path.relative_to(REPO)} missing stable language")
         if "ga-readiness-checklist" not in text:
             failures.append(f"{path.relative_to(REPO)} missing checklist reference")
         if "SUPPORT_MATRIX.md" not in text:
             failures.append(f"{path.relative_to(REPO)} missing support matrix reference")
-        for phrase in FORBIDDEN_PUBLIC_LAUNCH_PHRASES:
-            if phrase in text:
-                failures.append(
-                    f"{path.relative_to(REPO)} contains forbidden launch phrase {phrase!r}"
-                )
-
     assert failures == []
 
 
@@ -153,7 +148,8 @@ def test_runbooks_point_future_ga_work_to_checklist_and_refresh_artifacts():
             "GAOPS",
             "GARC",
             "GAREL",
-            "v1.2.0-rc8",
-            "manual enforcement",
+            "GADISP",
+            "v1.2.0",
+            "branch protection",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"

--- a/tests/docs/test_gaclose_evidence_closeout.py
+++ b/tests/docs/test_gaclose_evidence_closeout.py
@@ -15,7 +15,8 @@ TRIAGE = REPO / "docs" / "HISTORICAL-ARTIFACTS-TRIAGE.md"
 
 PUBLIC_ALPHA_VERSION = "1.2.0-rc5"
 PUBLIC_ALPHA_TAG = "v1.2.0-rc5"
-CURRENT_PUBLIC_ALPHA_VERSION = "1.2.0-rc8"
+CURRENT_STABLE_VERSION = "1.2.0"
+HISTORICAL_PUBLIC_ALPHA_VERSION = "1.2.0-rc8"
 HISTORICAL_BANNER = "> **Historical artifact — as-of 2026-04-18, may not reflect current behavior**"
 
 PUBLIC_SURFACES = [
@@ -71,12 +72,14 @@ def test_decision_artifact_states_exactly_one_allowed_decision():
     assert "Next command: `codex-phase-roadmap-builder specs/phase-plans-v4.md`" in text
 
 
-def test_active_public_release_surfaces_are_current_rc_and_not_latest_driven():
+def test_active_release_surfaces_are_stable_prepared_and_not_latest_driven():
     failures = []
     for relative in PUBLIC_SURFACES:
         text = _read(relative)
-        if CURRENT_PUBLIC_ALPHA_VERSION not in text:
-            failures.append(f"{relative}: missing {CURRENT_PUBLIC_ALPHA_VERSION}")
+        if CURRENT_STABLE_VERSION not in text:
+            failures.append(f"{relative}: missing {CURRENT_STABLE_VERSION}")
+        if relative == "CHANGELOG.md" and HISTORICAL_PUBLIC_ALPHA_VERSION not in text:
+            failures.append(f"{relative}: missing historical {HISTORICAL_PUBLIC_ALPHA_VERSION}")
         if relative != "CHANGELOG.md" and "1.2.0-rc4" in text:
             failures.append(f"{relative}: active RC4 version reference")
         if "v1.2.0-rc4" in text:
@@ -94,7 +97,7 @@ def test_support_matrix_freezes_claim_tiers_and_topology_limits():
 
     for expected in (
         "Claim tiers",
-        "Public-alpha",
+        "public-alpha",
         "Beta",
         "GA",
         "GA-supported",

--- a/tests/docs/test_gaops_operations_contract.py
+++ b/tests/docs/test_gaops_operations_contract.py
@@ -72,7 +72,7 @@ def test_gaops_runbooks_define_operator_sections_and_canonical_sources():
             "index rebuild",
             "incident response",
             "support triage",
-            "v1.2.0-rc8",
+            "v1.2.0",
         ):
             assert expected in text, f"{path.relative_to(REPO)} missing {expected!r}"
 

--- a/tests/docs/test_garc_rc_soak_contract.py
+++ b/tests/docs/test_garc_rc_soak_contract.py
@@ -45,12 +45,12 @@ def _read(path: Path) -> str:
 
 
 def test_rc8_contract_surfaces_are_frozen():
-    for path in SURFACES:
+    for path in (GA_RC, CHANGELOG, REPO / "docs" / "validation" / "ga-final-decision.md"):
         text = _read(path)
         assert "1.2.0-rc8" in text or "v1.2.0-rc8" in text, path
 
     workflow = _read(RELEASE_WORKFLOW)
-    assert "default: 'v1.2.0-rc8'" in workflow
+    assert "default: 'v1.2.0'" in workflow
     assert "release_type=custom" in "\n".join(
         [workflow, _read(DEPLOYMENT_RUNBOOK), _read(USER_ACTION_RUNBOOK)]
     )
@@ -75,7 +75,7 @@ def test_public_surfaces_preserve_rc_only_channel_posture():
     for expected in ("public-alpha", "beta", "docker `latest`", "github latest"):
         assert expected in combined
 
-    for forbidden in ("ship ga", "generally available"):
+    for forbidden in ("active stable surface", "v1.2.0 is the active public version"):
         assert forbidden not in combined
 
 
@@ -94,7 +94,7 @@ def test_runbooks_freeze_pre_dispatch_and_observation_commands():
         "gh run watch <run-id> --exit-status",
         "gh run view <run-id> --json url,headSha,status,conclusion,jobs",
         "gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets",
-        "blocked before dispatch",
+        "recut succeeded",
         "ga-rc-evidence.md",
     ):
         assert expected in combined

--- a/tests/docs/test_garecut_rc_recut_contract.py
+++ b/tests/docs/test_garecut_rc_recut_contract.py
@@ -21,12 +21,16 @@ def _read(path: Path) -> str:
 def test_rc8_contract_surfaces_and_workflow_path_are_frozen():
     workflow = _read(WORKFLOW)
     release_metadata = _read(RELEASE_METADATA)
+    evidence = _read(GA_RC)
 
-    for expected in ("v1.2.0-rc8", "1.2.0-rc8", "softprops/action-gh-release@v3"):
+    for expected in ("v1.2.0", "1.2.0", "softprops/action-gh-release@v3"):
         assert expected in workflow
 
-    for expected in ("v1.2.0-rc8", "1.2.0-rc8", "release_type=custom"):
+    for expected in ("v1.2.0", "1.2.0", "release_type=custom"):
         assert expected in release_metadata
+
+    for expected in ("v1.2.0-rc8", "1.2.0-rc8", "recut succeeded"):
+        assert expected in evidence
 
     assert "softprops/action-gh-release@v2" not in workflow
     assert "latest" in workflow
@@ -68,9 +72,10 @@ def test_final_decision_stays_historical_and_routes_to_the_next_phase_explicitly
         "# GA Final Decision",
         "ship GA",
         "GAREL",
+        "v1.2.0",
         "v1.2.0-rc8",
         "ready for GADISP planning",
-        "recut succeeded",
+        "authorized for downstream GADISP",
         "actions/download-artifact@v8",
         "accepted as non-blocking for GA",
         "softprops/action-gh-release@v3",

--- a/tests/docs/test_garel_ga_release_contract.py
+++ b/tests/docs/test_garel_ga_release_contract.py
@@ -59,7 +59,8 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
         "## Decision Inputs",
         "## Workflow Runtime Disposition",
         "## Final Decision",
-        "## GARECUT Status",
+        "## Stable Surface Preparation",
+        "## Historical RC Evidence",
         "## Next Scope",
         "## Verification",
         "ship GA",
@@ -68,7 +69,7 @@ def test_final_decision_exists_and_cites_all_ga_inputs():
         "docs/validation/ga-e2e-evidence.md",
         "docs/validation/ga-operations-evidence.md",
         "docs/validation/ga-rc-evidence.md",
-        "v1.2.0-rc7",
+        "v1.2.0",
         "v1.2.0-rc8",
         "softprops/action-gh-release@v3",
         "actions/download-artifact@v8",
@@ -94,11 +95,11 @@ def test_ship_decision_defers_release_evidence_to_gadisp_and_keeps_public_surfac
     assert not GA_RELEASE.exists()
 
     combined = "\n".join(_read(path) for path in PUBLIC_SURFACES).lower()
-    for expected in ("public-alpha", "beta", "github latest", "docker `latest`"):
+    for expected in ("stable", "github latest", "docker `latest`"):
         assert expected in combined
-
-    for forbidden in ("ship ga", "generally available"):
-        assert forbidden not in combined
+    for path in (README, GETTING_STARTED, MCP_CONFIGURATION, DOCKER_GUIDE, SUPPORT_MATRIX):
+        text = _read(path)
+        assert "1.2.0" in text, f"{path.relative_to(REPO)} missing stable surface version"
 
 
 def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
@@ -112,7 +113,7 @@ def test_workflow_runtime_warning_is_remediated_before_any_future_ga_dispatch():
     assert "softprops/action-gh-release@v2" not in workflow
     assert "GitHub's latest published release is still" in decision
     assert "`v8.0.1`" in decision
-    assert "Current recut outcome: `recut succeeded`" in decision
+    assert "Stable surface status: `prepared for downstream GADISP`" in decision
     assert "actions/download-artifact@v8" in decision
     assert "Buffer()" in decision
     assert "accepted as non-blocking for GA" in decision

--- a/tests/docs/test_p23_doc_truth.py
+++ b/tests/docs/test_p23_doc_truth.py
@@ -11,6 +11,15 @@ ACTIVE_DOCS = [
     REPO_ROOT / "docs" / "DOCKER_GUIDE.md",
     REPO_ROOT / "docs" / "MCP_CONFIGURATION.md",
     REPO_ROOT / "docs" / "operations" / "deployment-runbook.md",
+]
+RELEASE_SURFACE_DOCS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "GETTING_STARTED.md",
+    REPO_ROOT / "docs" / "DOCKER_GUIDE.md",
+    REPO_ROOT / "docs" / "MCP_CONFIGURATION.md",
+    REPO_ROOT / "docs" / "operations" / "deployment-runbook.md",
+]
+SUPPORTING_ACTIVE_DOCS = [
     REPO_ROOT / "docs" / "security" / "attestation.md",
     REPO_ROOT / "docs" / "security" / "path-guard.md",
     REPO_ROOT / "docs" / "security" / "sandbox.md",
@@ -106,13 +115,13 @@ def test_docker_docs_use_current_image_package_only():
         assert "ghcr.io/viperjuice/code-index-mcp" in _read(path)
 
 
-def test_active_release_docs_name_rc8_and_alpha_or_beta_status():
-    for path in ACTIVE_DOCS:
+def test_active_release_docs_name_stable_surface_and_support_status():
+    for path in RELEASE_SURFACE_DOCS:
         text = _read(path).lower()
-        assert "1.2.0-rc8" in text, f"{path.relative_to(REPO_ROOT)} missing 1.2.0-rc8"
-        assert ("alpha" in text) or (
-            "beta" in text
-        ), f"{path.relative_to(REPO_ROOT)} missing alpha/beta status language"
+        assert "1.2.0" in text, f"{path.relative_to(REPO_ROOT)} missing 1.2.0"
+        assert ("stable" in text) or (
+            "ga" in text
+        ), f"{path.relative_to(REPO_ROOT)} missing stable/ga status language"
 
 
 def test_active_docs_link_to_support_matrix_for_language_claims():

--- a/tests/docs/test_p26_public_alpha_decision.py
+++ b/tests/docs/test_p26_public_alpha_decision.py
@@ -92,18 +92,19 @@ def test_runbooks_document_private_alpha_go_no_go_procedure():
         assert category in surfaces
 
 
-def test_public_alpha_release_surfaces_include_required_truth_fields():
-    surfaces = {
-        "README.md": _read("README.md"),
-        "CHANGELOG.md": _read("CHANGELOG.md"),
-    }
+def test_public_alpha_history_and_current_release_surfaces_include_required_truth_fields():
+    readme = _read("README.md")
+    changelog = _read("CHANGELOG.md")
 
-    for relative_path, text in surfaces.items():
-        lower = text.lower()
-        assert "docs/validation/private-alpha-decision.md" in text
-        assert "docs/SUPPORT_MATRIX.md" in text
-        assert "public alpha" in lower
-        assert "beta" in lower
-        assert "rollback" in lower
-        assert "release-smoke" in lower or "docker" in lower
-        assert "uv sync --locked" in text or "ghcr.io/viperjuice/code-index-mcp" in text
+    assert "docs/SUPPORT_MATRIX.md" in readme
+    assert "stable surface prepared" in readme.lower()
+    assert "GADISP" in readme
+    assert "rollback" in _read("docs/operations/deployment-runbook.md").lower()
+    assert "uv sync --locked" in readme
+    assert "ghcr.io/viperjuice/code-index-mcp" in readme
+
+    lower_changelog = changelog.lower()
+    assert "docs/validation/private-alpha-decision.md" in changelog
+    assert "public alpha" in lower_changelog
+    assert "beta" in lower_changelog
+    assert "release-smoke" in lower_changelog or "docker" in lower_changelog

--- a/tests/docs/test_p34_public_alpha_recut.py
+++ b/tests/docs/test_p34_public_alpha_recut.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent.parent
 
+PREPARED_STABLE_VERSION = "1.2.0"
+PREPARED_STABLE_TAG = "v1.2.0"
 PUBLIC_ALPHA_VERSION = "1.2.0-rc8"
 PUBLIC_ALPHA_TAG = "v1.2.0-rc8"
 CURRENT_RECUT_VERSION = "1.2.0-rc8"
@@ -74,7 +76,7 @@ def test_public_surfaces_share_v3_operating_model():
         assert missing == [], f"{relative} missing {missing}"
 
 
-def test_release_surfaces_use_current_rc_identifier():
+def test_release_surfaces_use_prepared_stable_identifier_and_preserve_rc_history():
     surfaces = [
         "README.md",
         "docs/GETTING_STARTED.md",
@@ -86,17 +88,20 @@ def test_release_surfaces_use_current_rc_identifier():
     ]
     for relative in surfaces:
         text = _read(relative)
-        assert PUBLIC_ALPHA_VERSION in text, relative
+        assert PREPARED_STABLE_VERSION in text, relative
         if relative != "CHANGELOG.md":
             assert "1.2.0-rc4" not in text, relative
-    assert PUBLIC_ALPHA_TAG in _read(".github/workflows/release-automation.yml")
+    assert PUBLIC_ALPHA_VERSION in _read("CHANGELOG.md")
+    assert PREPARED_STABLE_TAG in _read(".github/workflows/release-automation.yml")
 
 
 def test_active_release_instructions_do_not_reference_rc4_or_stale_recut_target():
     for relative in ACTIVE_RC4_DRIFT_SURFACES:
         text = _read(relative)
         assert (
-            PUBLIC_ALPHA_VERSION in text
+            PREPARED_STABLE_VERSION in text
+            or PREPARED_STABLE_TAG in text
+            or PUBLIC_ALPHA_VERSION in text
             or PUBLIC_ALPHA_TAG in text
             or CURRENT_RECUT_VERSION in text
             or CURRENT_RECUT_TAG in text

--- a/tests/docs/test_p8_customer_docs_alignment.py
+++ b/tests/docs/test_p8_customer_docs_alignment.py
@@ -51,25 +51,25 @@ def test_readme_no_stale_claims():
 # ---------------------------------------------------------------------------
 
 
-def test_readme_beta_admonition_near_top():
+def test_readme_status_admonition_near_top():
     text = _readme_text()
     head = "\n".join(text.splitlines()[:80])
     assert (
-        "> **Beta status**:" in head
-    ), "README missing '> **Beta status**:' blockquote within first 80 lines"
+        "> **Stable-surface prep status**:" in head
+    ), "README missing stable-surface status blockquote within first 80 lines"
     # Body must name MCP as primary and FastAPI/REST as secondary admin surface.
     # Search the full admonition block (contiguous blockquote lines).
     admonition_blocks = re.findall(r"(?:^>.*\n)+", text, re.MULTILINE)
-    beta_blocks = [b for b in admonition_blocks if "Beta status" in b]
-    assert len(beta_blocks) >= 1, "No 'Beta status' admonition block found"
-    beta_body = "\n".join(beta_blocks)
-    assert "MCP" in beta_body, "Beta admonition does not name MCP as primary surface"
-    assert ("FastAPI" in beta_body) or (
-        "REST" in beta_body
-    ), "Beta admonition does not name FastAPI/REST as secondary admin surface"
-    assert ("secondary" in beta_body.lower()) or (
-        "admin" in beta_body.lower()
-    ), "Beta admonition does not mark FastAPI/REST as secondary/admin"
+    status_blocks = [b for b in admonition_blocks if "Stable-surface prep status" in b]
+    assert len(status_blocks) >= 1, "No stable-surface status admonition block found"
+    status_body = "\n".join(status_blocks)
+    assert "MCP" in status_body, "Status admonition does not name MCP as primary surface"
+    assert ("FastAPI" in status_body) or (
+        "REST" in status_body
+    ), "Status admonition does not name FastAPI/REST as secondary admin surface"
+    assert ("secondary" in status_body.lower()) or (
+        "admin" in status_body.lower()
+    ), "Status admonition does not mark FastAPI/REST as secondary/admin"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,4 +1,4 @@
-"""Release metadata assertions for the active v1.2.0-rc8 contract.
+"""Release metadata assertions for the prepared stable v1.2.0 contract.
 
 Historical GARC soak target: v1.2.0-rc6.
 """
@@ -15,8 +15,8 @@ except ImportError:  # Python <3.11
 
 
 REPO = Path(__file__).parent.parent
-EXPECTED_VERSION = "1.2.0-rc8"
-EXPECTED_TAG = "v1.2.0-rc8"
+EXPECTED_VERSION = "1.2.0"
+EXPECTED_TAG = "v1.2.0"
 GA_RC_EVIDENCE = REPO / "docs" / "validation" / "ga-rc-evidence.md"
 DOCKER_INSTALLERS = (
     "scripts/install-mcp-docker.sh",
@@ -28,7 +28,7 @@ def _read_text(relative_path: str) -> str:
     return (REPO / relative_path).read_text()
 
 
-def test_runtime_version_matches_rc_contract():
+def test_runtime_version_matches_stable_contract():
     import mcp_server
 
     assert mcp_server.__version__ == EXPECTED_VERSION, (
@@ -36,7 +36,7 @@ def test_runtime_version_matches_rc_contract():
     )
 
 
-def test_pyproject_version_matches_rc_contract():
+def test_pyproject_version_matches_stable_contract():
     with (REPO / "pyproject.toml").open("rb") as f:
         data = tomllib.load(f)
 
@@ -60,7 +60,7 @@ def test_readme_distribution_identity_remains_stable():
     assert "**Container image**: `ghcr.io/viperjuice/code-index-mcp`" in readme
 
 
-def test_changelog_has_rc_contract_section():
+def test_changelog_has_stable_contract_section():
     changelog = _read_text("CHANGELOG.md")
 
     assert f"## [{EXPECTED_VERSION}] — 2026-04-25" in changelog
@@ -72,25 +72,25 @@ def test_release_workflow_matches_rc_contract():
     assert f"Version to release (e.g., {EXPECTED_TAG})" in workflow
     assert f"default: '{EXPECTED_TAG}'" in workflow
     assert "default: 'custom'" in workflow
-    assert f"GARECUT release contract target: {EXPECTED_TAG}" in workflow
+    assert f"GAREL stable release contract target: {EXPECTED_TAG}" in workflow
     assert (
-        'gh workflow run "Release Automation" -f version=v1.2.0 '
-        "-f release_type=custom -f auto_merge=false"
-    ) in workflow
+        'gh workflow run "Release Automation" -f version=v1.2.0 -f release_type=custom -f auto_merge=false'
+        in workflow
+    )
     assert "peter-evans/create-pull-request@v8" in workflow
     assert "softprops/action-gh-release@v3" in workflow
     assert "peter-evans/create-pull-request@v7" not in workflow
     assert "softprops/action-gh-release@v2" not in workflow
     assert 'grep -q "version = \\"$VERSION_NO_V\\"" pyproject.toml' in workflow
     assert 'grep -q "__version__ = \\"$VERSION_NO_V\\"" mcp_server/__init__.py' in workflow
-    assert "Prerelease tags must use release_type=custom" in workflow
+    assert "Stable tags still use release_type=custom" in workflow
     assert "prerelease: ${{ needs.prepare-release.outputs.is_prerelease }}" in workflow
     assert "tags: ${{ needs.prepare-release.outputs.docker_tags }}" in workflow
     assert "No automatic documentation rewrite" in workflow
     assert 'sed -i "s/Latest Version:' not in workflow
 
 
-def test_release_candidate_tag_is_not_reused_locally():
+def test_release_tag_is_not_reused_locally():
     result = subprocess.run(
         ["git", "tag", "-l", EXPECTED_TAG],
         capture_output=True,
@@ -116,11 +116,11 @@ def test_release_candidate_tag_is_not_reused_locally():
         return
 
     evidence = GA_RC_EVIDENCE.read_text(encoding="utf-8")
-    assert EXPECTED_TAG in evidence
+    assert EXPECTED_TAG in evidence or "v1.2.0-rc8" in evidence
     assert tag_commit in evidence, f"{EXPECTED_TAG} exists but points at undocumented {tag_commit}"
 
 
-def test_installers_and_download_helper_match_rc8_identity_contract():
+def test_installers_and_download_helper_match_stable_identity_contract():
     for relative_path in DOCKER_INSTALLERS:
         text = _read_text(relative_path)
         assert EXPECTED_TAG in text
@@ -132,9 +132,9 @@ def test_installers_and_download_helper_match_rc8_identity_contract():
     powershell = _read_text("scripts/install-mcp-docker.ps1")
     download_helper = _read_text("scripts/download-release.py")
 
-    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0-rc8}"' in shell
-    assert 'param(\n    [string]$Variant = "v1.2.0-rc8"' in powershell
-    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0-rc8' in powershell
+    assert 'MCP_VARIANT="${MCP_VARIANT:-v1.2.0}"' in shell
+    assert 'param(\n    [string]$Variant = "v1.2.0"' in powershell
+    assert 'IF "%MCP_VARIANT%"=="" SET MCP_VARIANT=v1.2.0' in powershell
 
     for expected in (
         "index_it_mcp-",

--- a/uv.lock
+++ b/uv.lock
@@ -1711,7 +1711,7 @@ wheels = [
 
 [[package]]
 name = "index-it-mcp"
-version = "1.2.0rc8"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- move repo-owned active release surfaces from rc8 to prepared stable 1.2.0/v1.2.0
- preserve rc8 as historical soak evidence and keep GA release evidence deferred to GADISP
- update GAREL and legacy docs contract tests for the stable-prep posture

## Verification
- git diff --check
- uv run pytest tests/docs/test_gaclose_evidence_closeout.py tests/docs/test_p26_public_alpha_decision.py tests/docs/test_p34_public_alpha_recut.py tests/docs/test_p8_customer_docs_alignment.py -v --no-cov
- uv run pytest tests/docs tests/smoke tests/test_release_metadata.py tests/test_requirements_consolidation.py -v --no-cov
- child run also reported pass: make alpha-production-matrix; make release-smoke; make release-smoke-container; test ! -e docs/validation/ga-release-evidence.md