### PR TITLE
Retire GARECUT after stable GA dispatch

### DIFF
--- a/plans/phase-plan-v5-garecut.md
+++ b/plans/phase-plan-v5-garecut.md
@@ -2,329 +2,49 @@
 phase_loop_plan_version: 1
 phase: GARECUT
 roadmap: specs/phase-plans-v5.md
-roadmap_sha256: df5244856bbe79d0f3fe5e6231eaf120b0ff448335a3f8f8134317ebc81f4802
+roadmap_sha256: 6dcfdf73e2fb3403768e168bf6126d367864c94c8f73d6ca2f00da97ad5f6a86
+phase_loop_mutation: none
+status: retired
 ---
-# GARECUT: Post-Remediation RC Recut
+# GARECUT: Retired Post-Remediation RC Recut
 
-## Context
+## Disposition
 
-GARECUT is the renewed phase-8 prerelease recut in the v5 GA-hardening
-roadmap. The current `GAREL` decision in
-`docs/validation/ga-final-decision.md` now records `cut another RC` after
-remediating `softprops/action-gh-release@v2` to
-`softprops/action-gh-release@v3`, so this phase is no longer the old `rc7`
-recut. It is a new prerelease soak on the newly remediated release path before
-any later GA decision is reconsidered.
+GARECUT is obsolete for the v5 GA-hardening roadmap. It was the contingency
+branch for a renewed GAREL decision that required another prerelease soak
+before stable dispatch. Renewed GAREL instead selected `ship GA`, and GADISP
+successfully published stable `v1.2.0` with release evidence in
+`docs/validation/ga-release-evidence.md`.
 
-Current repo state gathered during planning:
+Do not execute this plan with `codex-execute-phase`, and do not dispatch another
+Release Automation prerelease from this artifact.
 
-- The checkout is on `main` at `a3adcea5cd569571a2c4ce3d863317e9f14519bc`,
-  matching `origin/main`, and the active roadmap hash is
-  `df5244856bbe79d0f3fe5e6231eaf120b0ff448335a3f8f8134317ebc81f4802`.
-- `.codex/phase-loop/state.json` marks `GAREL` as executed, `GARECUT` as
-  unplanned, and carries ledger warnings that older GARECUT/GAREL provenance is
-  stale under the amended roadmap.
-- The worktree is intentionally dirty with user-owned follow-through in
-  `.github/workflows/release-automation.yml`,
-  `docs/validation/ga-final-decision.md`,
-  `docs/validation/ga-rc-evidence.md`,
-  `docs/validation/ga-readiness-checklist.md`,
-  `tests/docs/test_garecut_rc_recut_contract.py`,
-  `tests/docs/test_garel_ga_release_contract.py`,
-  `tests/test_release_metadata.py`, and the staged
-  `plans/phase-plan-v5-garel.md`; GARECUT execution must preserve those edits
-  and treat the modified roadmap as the active baseline rather than reverting
-  it.
-- `docs/validation/ga-final-decision.md` explicitly sets the next recut target
-  to `v1.2.0-rc8`, states that another prerelease soak is required on the
-  `softprops/action-gh-release@v3` path, and warns that older downstream
-  GARECUT or GAREL plans are stale.
-- `docs/validation/ga-rc-evidence.md` is still the successful `rc7` recut
-  artifact. It remains the canonical prerelease evidence writer, but it must be
-  refreshed for the next recut attempt instead of being treated as current
-  proof for the new workflow path.
-- Repo-owned release surfaces are still frozen to `1.2.0-rc7` /
-  `v1.2.0-rc7` in `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`,
-  installer helpers, and `tests/test_release_metadata.py`, while
-  `.github/workflows/release-automation.yml` already carries the remediated
-  `softprops/action-gh-release@v3` path plus a `GARECUT release contract
-  target: v1.2.0-rc7` marker.
-- Absent contradictory product input, this plan freezes the renewed recut
-  target as `1.2.0-rc8` / `v1.2.0-rc8` and requires local plus remote non-reuse
-  checks before dispatch.
+## Supersession Evidence
 
-## Interface Freeze Gates
+- `docs/validation/ga-rc-evidence.md` records the successful `v1.2.0-rc8`
+  prerelease recut on the remediated `softprops/action-gh-release@v3` path.
+- `docs/validation/ga-final-decision.md` records the renewed GAREL decision to
+  ship GA and accepts the GitHub-owned
+  `actions/download-artifact@v8` `Buffer()` warning as non-blocking.
+- `docs/validation/ga-release-evidence.md` records the successful GADISP stable
+  dispatch for `v1.2.0`, including GitHub Release, PyPI, GHCR, rollback, and
+  upstream-warning disposition.
+- `specs/phase-plans-v5.md` marks GARECUT retired after successful GADISP
+  evidence.
 
-- [ ] IF-0-GARECUT-1 - Renewed recut version and workflow contract:
-      `.github/workflows/release-automation.yml`, `pyproject.toml`,
-      `mcp_server/__init__.py`, `CHANGELOG.md`, installer helpers, and
-      `tests/test_release_metadata.py` freeze `1.2.0-rc8` / `v1.2.0-rc8` as
-      the active recut target, retain
-      `peter-evans/create-pull-request@v8`, retain
-      `softprops/action-gh-release@v3`, keep `release_type=custom`, and
-      preserve prerelease-only GitHub Latest plus stable-only Docker `latest`
-      behavior.
-- [ ] IF-0-GARECUT-2 - Pre-dispatch safety contract:
-      release dispatch is allowed only when the release-affecting worktree is
-      clean enough for mutation, `HEAD` matches `origin/main`, the remediated
-      workflow is visible, and `v1.2.0-rc8` is unused both locally and on
-      origin.
-- [ ] IF-0-GARECUT-3 - Remediated recut observation contract:
-      GARECUT captures the Release Automation run URL, run ID, `headSha`,
-      per-job conclusions, `Create GitHub Release` log disposition, release
-      branch or PR disposition, GitHub release state, PyPI publication, and
-      GHCR image identity for `v1.2.0-rc8`.
-- [ ] IF-0-GARECUT-4 - RC-only channel policy contract:
-      the recut remains prerelease-only, GitHub Latest stays excluded, Docker
-      `latest` stays stable-only, and no GA docs or stable release mutation is
-      introduced by the `rc8` soak itself.
-- [ ] IF-0-GARECUT-5 - Decision handoff contract:
-      `docs/validation/ga-rc-evidence.md` records the fresh remediated recut
-      evidence, and `docs/validation/ga-final-decision.md` remains a historical
-      `cut another RC` artifact while explicitly routing the next downstream
-      work either back to renewed `GAREL` on top of successful `rc8` proof or
-      back to GARECUT remediation/rerun if the recut blocks or fails.
+## Safe Next Action
 
-## Lane Index & Dependencies
-
-- SL-0 - Renewed GARECUT contract tests; Depends on: GAREL; Blocks: SL-1, SL-2, SL-3, SL-4; Parallel-safe: no
-- SL-1 - RC8 version and remediated workflow freeze; Depends on: SL-0; Blocks: SL-2, SL-3, SL-4; Parallel-safe: yes
-- SL-2 - RC8 dispatch and workflow observation; Depends on: SL-0, SL-1; Blocks: SL-3, SL-4; Parallel-safe: no
-- SL-3 - RC8 recut evidence reducer; Depends on: SL-0, SL-1, SL-2; Blocks: SL-4; Parallel-safe: no
-- SL-4 - Final decision handoff refresh; Depends on: SL-0, SL-1, SL-2, SL-3; Blocks: GARECUT acceptance; Parallel-safe: no
-
-## Lanes
-
-### SL-0 - Renewed GARECUT Contract Tests
-
-- **Scope**: Refresh the phase-specific contract tests so the renewed GARECUT
-  path is frozen around the `rc8` recut target and the already-remediated
-  `softprops/action-gh-release@v3` workflow path before any release mutation is
-  attempted.
-- **Owned files**: `tests/docs/test_garecut_rc_recut_contract.py`
-- **Interfaces provided**: IF-0-GARECUT-1, IF-0-GARECUT-2,
-  IF-0-GARECUT-3, IF-0-GARECUT-4, IF-0-GARECUT-5
-- **Interfaces consumed**: `docs/validation/ga-readiness-checklist.md`,
-  `docs/validation/ga-rc-evidence.md`,
-  `docs/validation/ga-final-decision.md`,
-  `specs/phase-plans-v5.md`,
-  `.github/workflows/release-automation.yml`,
-  `tests/test_release_metadata.py`,
-  `tests/docs/test_garel_ga_release_contract.py`
-- **Parallel-safe**: no
-- **Tasks**:
-  - test: Update the GARECUT docs contract test to require the renewed recut
-    target `1.2.0-rc8` / `v1.2.0-rc8`, the remediated
-    `softprops/action-gh-release@v3` workflow path, and the current roadmap
-    steering that routes through another prerelease soak after GAREL.
-  - test: Assert that `docs/validation/ga-final-decision.md` remains
-    historical and non-authorizing for GA while naming `GARECUT` as satisfied
-    only after fresh `rc8` evidence exists.
-  - test: Assert that `docs/validation/ga-rc-evidence.md` remains the only
-    canonical recut evidence writer and that `ga-final-decision.md` cannot
-    silently become a new GA decision inside this phase.
-  - test: Keep this file additive and phase-specific so the existing GAREL and
-    release-metadata tests remain the lower-level contracts instead of being
-    reopened here.
-  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
-
-### SL-1 - RC8 Version And Remediated Workflow Freeze
-
-- **Scope**: Advance the repo-owned release contract from rc7 to rc8 on the
-  already-remediated workflow path without widening into GA channel changes.
-- **Owned files**: `.github/workflows/release-automation.yml`,
-  `pyproject.toml`, `mcp_server/__init__.py`, `CHANGELOG.md`,
-  `scripts/install-mcp-docker.sh`, `scripts/install-mcp-docker.ps1`,
-  `tests/test_release_metadata.py`
-- **Interfaces provided**: IF-0-GARECUT-1; repo-owned portions of
-  IF-0-GARECUT-2 and IF-0-GARECUT-4
-- **Interfaces consumed**: SL-0 GARECUT assertions;
-  `docs/validation/ga-final-decision.md`,
-  `docs/validation/ga-rc-evidence.md`
-- **Parallel-safe**: yes
-- **Tasks**:
-  - test: Re-run `tests/test_release_metadata.py` first and treat this lane as
-    a repair-plus-version-bump lane only for the repo-owned recut contract.
-  - impl: Advance the frozen release identity from `1.2.0-rc7` /
-    `v1.2.0-rc7` to `1.2.0-rc8` / `v1.2.0-rc8` in the workflow defaults,
-    package metadata, changelog, installer defaults, and release-metadata
-    assertions.
-  - impl: Preserve `release_type=custom`, `auto_merge=false`,
-    `peter-evans/create-pull-request@v8`,
-    `softprops/action-gh-release@v3`, prerelease GitHub release behavior, and
-    stable-only Docker `latest`; do not introduce stable `1.2.0` behavior in
-    this lane.
-  - impl: Keep docs churn narrow by only touching the installer/version
-    surfaces that `tests/test_release_metadata.py` already treats as part of
-    the active release contract.
-  - verify: `uv run pytest tests/test_release_metadata.py -v --no-cov`
-  - verify: `rg -n "1\\.2\\.0-rc8|v1\\.2\\.0-rc8|create-pull-request@v8|softprops/action-gh-release@v3|release_type=custom|auto_merge=false|latest" .github/workflows/release-automation.yml pyproject.toml mcp_server/__init__.py CHANGELOG.md scripts/install-mcp-docker.sh scripts/install-mcp-docker.ps1 tests/test_release_metadata.py`
-
-### SL-2 - RC8 Dispatch And Workflow Observation
-
-- **Scope**: Dispatch the remediated rc8 prerelease and capture the actual
-  workflow and publication facts needed for downstream reduction.
-- **Owned files**: none (local git and GitHub release state only)
-- **Interfaces provided**: observed IF-0-GARECUT-2 and IF-0-GARECUT-3; runtime
-  facts for IF-0-GARECUT-4 and IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 assertions; SL-1 rc8 release contract;
-  `docs/validation/ga-final-decision.md`,
-  `docs/validation/ga-rc-evidence.md`
-- **Parallel-safe**: no
-- **Tasks**:
-  - test: Re-run the narrowed GARECUT and release-metadata checks locally
-    before dispatch so the repo-owned rc8 surfaces are coherent.
-  - test: Run the required pre-dispatch probes immediately before mutation:
-    `git status --short --branch`, `git fetch origin main --tags --prune`,
-    `git rev-parse HEAD origin/main`, `git tag -l v1.2.0-rc8`,
-    `git ls-remote --tags origin refs/tags/v1.2.0-rc8`, and
-    `gh workflow view "Release Automation"`.
-  - impl: If the release-affecting worktree is dirty, `HEAD` differs from
-    `origin/main`, or `v1.2.0-rc8` already exists locally or remotely, stop
-    before dispatch and carry the blocked state into SL-3 and SL-4.
-  - impl: Dispatch `gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false`, watch the run to completion, and capture run identity plus per-job outcomes.
-  - impl: Record the `Create GitHub Release` job log disposition, GitHub
-    prerelease state, release branch or PR disposition, PyPI publication, and
-    GHCR image identity on the remediated workflow path; do not mutate GA state
-    even if the recut succeeds.
-  - verify: `uv run pytest tests/test_release_metadata.py tests/docs/test_garecut_rc_recut_contract.py -v --no-cov`
-  - verify: `git status --short --branch`
-  - verify: `git fetch origin main --tags --prune`
-  - verify: `git rev-parse HEAD origin/main`
-  - verify: `git tag -l v1.2.0-rc8`
-  - verify: `git ls-remote --tags origin refs/tags/v1.2.0-rc8`
-  - verify: `gh workflow view "Release Automation"`
-  - verify: `gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false`
-  - verify: `gh run list --workflow "Release Automation" --limit 10`
-  - verify: `gh run watch <run-id> --exit-status`
-  - verify: `gh run view <run-id> --json url,headSha,status,conclusion,jobs`
-  - verify: `gh run view <run-id> --job <create-github-release-job-id> --log`
-  - verify: `gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets`
-  - verify: `gh pr list --state all --head release/v1.2.0-rc8 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title`
-  - verify: `python -m pip index versions index-it-mcp --pre`
-  - verify: `docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8`
-
-### SL-3 - RC8 Recut Evidence Reducer
-
-- **Scope**: Reduce the rc8 pre-dispatch, dispatch, workflow, and publication
-  facts into the canonical prerelease evidence artifact.
-- **Owned files**: `docs/validation/ga-rc-evidence.md`
-- **Interfaces provided**: IF-0-GARECUT-3, IF-0-GARECUT-4,
-  and the evidence portion of IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc8 contract
-  surfaces; SL-2 recut observation facts
-- **Parallel-safe**: no
-- **Tasks**:
-  - test: Rewrite `docs/validation/ga-rc-evidence.md` only after SL-2 has a
-    terminal outcome so the artifact reflects one coherent rc8 recut attempt.
-  - impl: Record exact UTC capture time, selected commit, local and remote tag
-    non-reuse results, dispatch inputs, run URL and ID, per-job conclusions,
-    `Create GitHub Release` log disposition, release branch or PR disposition,
-    GitHub prerelease state, PyPI package identity, GHCR tag identity, and
-    rollback or no-rollback disposition for `v1.2.0-rc8`.
-  - impl: If SL-2 stops before dispatch or fails mid-run, keep the artifact
-    explicit about the blocked or failed state instead of implying a successful
-    recut.
-  - impl: Preserve metadata-only reporting; do not print tokens, raw logs, or
-    secret-bearing command output.
-  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov`
-  - verify: `rg -n "v1\\.2\\.0-rc8|Release Automation|PyPI|GHCR|softprops/action-gh-release@v3|prerelease|latest|blocked before dispatch|workflow failed after dispatch|recut succeeded" docs/validation/ga-rc-evidence.md`
-
-### SL-4 - Final Decision Handoff Refresh
-
-- **Scope**: Refresh the historical GA decision artifact so it clearly hands
-  the next downstream work either back to renewed GAREL on top of fresh rc8
-  evidence or back to GARECUT remediation if the recut did not land cleanly.
-- **Owned files**: `docs/validation/ga-final-decision.md`
-- **Interfaces provided**: final-decision portion of IF-0-GARECUT-5
-- **Interfaces consumed**: SL-0 GARECUT assertions; SL-1 rc8 workflow
-  disposition; SL-2 recut observation facts; SL-3 refreshed
-  `docs/validation/ga-rc-evidence.md`
-- **Parallel-safe**: no
-- **Tasks**:
-  - test: Keep `docs/validation/ga-final-decision.md` historical and
-    non-authorizing for GA during GARECUT; this lane may refresh next-step
-    status, but it must not mutate the repo into a new stable-release decision.
-  - impl: Preserve the existing GAREL decision rationale that another RC is
-    required because `softprops/action-gh-release@v3` has not yet been soaked
-    on a prerelease candidate.
-  - impl: If the rc8 recut succeeds, add or refresh a status section that
-    references the new `v1.2.0-rc8` evidence outcome and states that the
-    repository is ready for a renewed GAREL decision phase.
-  - impl: If the rc8 recut fails or is blocked, keep the next step on
-    remediating or rerunning GARECUT rather than reopening GA.
-  - verify: `uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov`
-  - verify: `rg -n "cut another RC|GARECUT|v1\\.2\\.0-rc8|renewed GAREL|ship GA|defer GA|softprops/action-gh-release@v3" docs/validation/ga-final-decision.md`
+Treat v5 as closed after phase-loop state records GARECUT as a retired
+contingency. Any future prerelease soak or release-workflow maintenance should
+be planned as a new post-GA roadmap item, not as GARECUT execution.
 
 ## Verification
 
-Planning-only run: do not execute these during plan creation. Run them during
-`codex-execute-phase` or manual GARECUT execution.
-
-Contract and repo-owned version checks:
-
-```bash
-uv run pytest tests/docs/test_garecut_rc_recut_contract.py -v --no-cov
-uv run pytest tests/test_release_metadata.py -v --no-cov
-rg -n "1\\.2\\.0-rc8|v1\\.2\\.0-rc8|create-pull-request@v8|softprops/action-gh-release@v3|release_type=custom|auto_merge=false|latest" \
-  .github/workflows/release-automation.yml \
-  pyproject.toml \
-  mcp_server/__init__.py \
-  CHANGELOG.md \
-  scripts/install-mcp-docker.sh \
-  scripts/install-mcp-docker.ps1 \
-  tests/test_release_metadata.py
-```
-
-Pre-dispatch and recut observation:
-
 ```bash
 git status --short --branch
-git fetch origin main --tags --prune
-git rev-parse HEAD origin/main
-git tag -l v1.2.0-rc8
-git ls-remote --tags origin refs/tags/v1.2.0-rc8
-gh workflow view "Release Automation"
-gh workflow run "Release Automation" -f version=v1.2.0-rc8 -f release_type=custom -f auto_merge=false
-gh run list --workflow "Release Automation" --limit 10
-gh run watch <run-id> --exit-status
-gh run view <run-id> --json url,headSha,status,conclusion,jobs
-gh run view <run-id> --job <create-github-release-job-id> --log
-gh release view v1.2.0-rc8 --repo ViperJuice/Code-Index-MCP --json tagName,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets
-gh pr list --state all --head release/v1.2.0-rc8 --json number,state,isDraft,mergedAt,url,headRefName,baseRefName,title
-python -m pip index versions index-it-mcp --pre
-docker buildx imagetools inspect ghcr.io/viperjuice/code-index-mcp:v1.2.0-rc8
+uv run pytest tests/docs/test_garecut_rc_recut_contract.py \
+  tests/docs/test_garel_ga_release_contract.py \
+  tests/test_release_metadata.py -v --no-cov
+rg -n "GARECUT|retired|v1\\.2\\.0|ga-release-evidence" \
+  specs/phase-plans-v5.md plans/phase-plan-v5-garecut.md docs/validation/ga-release-evidence.md
 ```
-
-Reducer artifact checks:
-
-```bash
-uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py -v --no-cov
-rg -n "v1\\.2\\.0-rc8|Release Automation|PyPI|GHCR|softprops/action-gh-release@v3|renewed GAREL|blocked before dispatch|workflow failed after dispatch|recut succeeded" \
-  docs/validation/ga-rc-evidence.md \
-  docs/validation/ga-final-decision.md
-git status --short -- docs/validation/ga-rc-evidence.md docs/validation/ga-final-decision.md
-```
-
-## Acceptance Criteria
-
-- [ ] Repo-owned release surfaces and the remediated workflow freeze
-      `1.2.0-rc8` / `v1.2.0-rc8`, retain
-      `peter-evans/create-pull-request@v8` and
-      `softprops/action-gh-release@v3`, and preserve prerelease-only GitHub
-      Latest plus stable-only Docker `latest` policy.
-- [ ] Pre-dispatch checks confirm a clean enough release-affecting worktree,
-      `HEAD == origin/main`, workflow visibility, and no reused local or remote
-      `v1.2.0-rc8` tag before dispatch.
-- [ ] Release Automation is dispatched only with
-      `version=v1.2.0-rc8`, `release_type=custom`, and `auto_merge=false`.
-- [ ] The remediated recut run records terminal workflow results, `Create
-      GitHub Release` log disposition, GitHub prerelease state, PyPI package
-      publication, GHCR image identity, and release branch or PR disposition
-      for `v1.2.0-rc8`.
-- [ ] `docs/validation/ga-rc-evidence.md` records the fresh rc8 recut outcome
-      using metadata-only reporting.
-- [ ] `docs/validation/ga-final-decision.md` remains historical, references the
-      rc8 outcome, and routes the next downstream work to renewed GAREL only if
-      the recut succeeds; otherwise it keeps the next step on GARECUT
-      remediation or rerun.

--- a/specs/phase-plans-v5.md
+++ b/specs/phase-plans-v5.md
@@ -468,7 +468,7 @@ GACLOSE
        │              │          ├─> GAOPS ─┐
        └──────────────┘          │          │
                                  └──────────┴─> GARC -> GAREL ─┬─> GADISP
-                                                               └─> GARECUT
+                                                               └─> GARECUT (retired)
 ```
 
 GAGOV and GASUPPORT can be planned after GABASE. GAE2E depends on the support
@@ -476,8 +476,10 @@ contract because the E2E evidence must know which claims it is proving. GAOPS
 depends on governance and E2E evidence so operator procedures reference the
 actual enforced gates and validated runtime behavior. GARC waits for governance,
 support, E2E, and operations. GAREL waits for the follow-up RC soak. From
-renewed GAREL, the ship-GA branch plans GADISP while the another-RC branch
-plans GARECUT and then routes back through GAREL.
+renewed GAREL, the ship-GA branch planned GADISP while the another-RC branch
+would have planned GARECUT and then routed back through GAREL. GARECUT is now
+retired for the v5 roadmap because renewed GAREL selected `ship GA` and GADISP
+successfully published stable `v1.2.0` with release evidence.
 
 ## Execution Notes
 
@@ -495,18 +497,20 @@ plans GARECUT and then routes back through GAREL.
   stable-surface-preparation phase only.
 - If GAREL selects `ship GA`, plan `GADISP` next; any older stable-dispatch
   artifact that predates the current GAREL decision and prep state is stale.
+  After successful GADISP evidence exists, do not plan or execute GARECUT in
+  the v5 roadmap.
 - If GAREL remediates release-workflow runtime drift and concludes that another
-  prerelease soak is required, plan `GARECUT` next and treat any older
-  downstream GAREL assumptions as stale.
+  prerelease soak is required before stable dispatch, plan `GARECUT` next and
+  treat any older downstream GAREL assumptions as stale. That contingency is
+  superseded once GADISP stable release evidence exists.
 - The `actions/download-artifact@v8` `Buffer()` warning observed in the
   successful `v1.2.0-rc8` run is accepted as non-blocking for GA dispatch. The
   action is GitHub-owned, the latest published `v8.0.1` line still emits the
   warning, and the rc8 release proved digest-verified artifact transfer plus
   successful GitHub Release, PyPI, and GHCR publication. Track the upstream
   warning separately, but do not block `GADISP` on it.
-- After a successful GARECUT, route back through `codex-plan-phase
-  specs/phase-plans-v5.md GAREL`; any older GAREL plan that predates the
-  post-GARECUT or post-remediation release-workflow steering is stale.
+- The historical `plans/phase-plan-v5-garecut.md` artifact is retained only as
+  a retired contingency record after GADISP; it must not be executed for v5.
 - GADISP is the only stable-GA phase that may carry
   `phase_loop_mutation: release_dispatch`.
 - Successful `v1.2.0-rc8` GARECUT evidence on run `24923402398` proved the
@@ -575,12 +579,10 @@ gh workflow run "Release Automation" -f version=<ga-version> -f release_type=cus
 gh run watch <run-id> --exit-status
 gh release view <ga-version>
 
-# GARECUT
+# GARECUT (retired contingency; do not execute after successful GADISP)
 git status --short --branch
-uv run pytest tests/docs tests/smoke tests/test_release_metadata.py -v --no-cov
-gh workflow run "Release Automation" -f version=<next-rc-tag> -f release_type=custom -f auto_merge=false
-gh run view <run-id> --job <merge-release-job-id> --log
-gh release view <next-rc-tag>
+rg -n "GARECUT|retired|v1\\.2\\.0|ga-release-evidence" \
+  specs/phase-plans-v5.md docs/validation/ga-release-evidence.md
 ```
 
 ### Phase 8 — GA Stable Dispatch And Release Evidence (GADISP)
@@ -638,34 +640,40 @@ evidence.
 
 ### Phase 9 — Post-Remediation RC Recut (GARECUT)
 
+**Status**
+
+Retired / superseded by successful GADISP stable dispatch.
+
 **Objective**
 
-Soak the remediated release workflow on one more prerelease candidate before
-any future GA ship decision is reconsidered.
+Historical contingency for the branch where renewed GAREL required another
+prerelease soak before stable dispatch. It is no longer execution-ready in v5
+because GAREL selected `ship GA` and GADISP published stable `v1.2.0`.
 
 **Exit criteria**
-- [ ] The release workflow no longer depends on the deprecated Node 20 action
-      path that GARC surfaced.
-- [ ] A new RC version after `v1.2.0-rc7` is frozen and dispatched through the
-      remediated workflow.
-- [ ] The recut workflow run completes with prerelease policy intact: GitHub
-      Latest remains excluded and Docker `latest` remains stable-only.
-- [ ] A fresh RC evidence artifact records the remediated workflow run, its log
-      disposition, and the resulting prerelease channel state.
-- [ ] The repo is ready for a renewed final GA decision only after that fresh
-      recut evidence exists.
+- [x] The release workflow no longer depends on the deprecated
+      `softprops/action-gh-release@v2` path that GARC surfaced.
+- [x] The successful `v1.2.0-rc8` recut proved the remediated
+      `softprops/action-gh-release@v3` path with prerelease policy intact.
+- [x] GAREL selected `ship GA` after the rc8 evidence and accepted the
+      `actions/download-artifact@v8` `Buffer()` warning as non-blocking.
+- [x] GADISP dispatched stable `v1.2.0` and wrote
+      `docs/validation/ga-release-evidence.md`.
+- [x] No post-GADISP prerelease recut is required for the v5 roadmap.
 
 **Scope notes**
 
-This phase is a prerelease recut on the remediated workflow path. It does not
-authorize a stable release by itself. Because the latest
-`actions/download-artifact@v8` `Buffer()` warning has been accepted as
-non-blocking based on successful digest-verified rc8 evidence, another recut is
-not required solely for that warning.
+This phase was the prerelease-recut contingency on the remediated workflow
+path. It did not authorize a stable release by itself. Because the latest
+`actions/download-artifact@v8` `Buffer()` warning was accepted as non-blocking
+based on successful digest-verified rc8 evidence, and GADISP subsequently
+published stable `v1.2.0`, this phase must not be planned or executed after
+GADISP in v5.
 
 **Non-goals**
 
 - No GA dispatch.
+- No post-GADISP prerelease recut.
 - No support-matrix expansion.
 - No topology broadening.
 
@@ -681,4 +689,4 @@ not required solely for that warning.
 - GAREL
 
 **Produces**
-- IF-0-GARECUT-1 — Post-remediation RC recut contract.
+- IF-0-GARECUT-1 — Retired post-remediation RC recut contingency record.


### PR DESCRIPTION
## Summary\n- mark GARECUT retired after successful GADISP stable v1.2.0 evidence\n- replace stale executable GARECUT plan with a retired contingency record\n- remove prerelease dispatch commands from the v5 roadmap verification block\n\n## Verification\n- git diff --check\n- uv run pytest tests/docs/test_garecut_rc_recut_contract.py tests/docs/test_garel_ga_release_contract.py tests/test_release_metadata.py -v --no-cov