### PR TITLE
Harden dogfood index rebuild

### DIFF
--- a/docs/status/DOGFOOD_INDEX_RESET_2026_04_27.md
+++ b/docs/status/DOGFOOD_INDEX_RESET_2026_04_27.md
@@ -1,0 +1,92 @@
+# Dogfood Index Reset - 2026-04-27
+
+## Scope
+
+Reset stale repo-local index artifacts for `/home/viperjuice/code/Code-Index-MCP`
+and rebuilt the local dogfood index from scratch.
+
+Removed before the clean run:
+
+- `.mcp-index/`
+- `.code_index.db`
+- `code_index.db`
+- `vector_index.qdrant`
+- `.indexes/`
+- `.claude/worktrees/code_index.db`
+
+Left intact:
+
+- `qdrant_storage/` - 11G live Qdrant service storage. A Qdrant process was
+  running on port 6333 and collections are language-level, so this was not
+  deleted as part of the repo-local reset.
+
+## Clean Run
+
+Command:
+
+```bash
+/usr/bin/time -v env \
+  SEMANTIC_SEARCH_ENABLED=true \
+  SEMANTIC_DEFAULT_PROFILE=oss_high \
+  VLLM_EMBEDDING_BASE_URL=http://ai:8001/v1 \
+  OPENAI_API_KEY=dummy-local-key \
+  QDRANT_URL=http://localhost:6333 \
+  uv run mcp-index repository sync --force-full
+```
+
+Result:
+
+- Exit status: 0
+- CLI result: `Indexed 1357 files in 1686.6s`
+- Wall time: `28:10.51`
+- User time: `239.14s`
+- System time: `71.35s`
+- CPU: `18%`
+- Max RSS: `403984 KB`
+- File system outputs: `26694576` blocks
+
+## Final Index State
+
+SQLite counts from `.mcp-index/current.db`:
+
+- Files: `1345`
+- Symbols: `23491`
+- Chunks: `66799`
+- Repositories: `1`
+
+Disk usage:
+
+- `.mcp-index/`: `175M`
+- `qdrant_storage/`: `11G` (not reset)
+
+Repository status after rebuild:
+
+- Repository: `Code-Index-MCP`
+- Repository ID: `74f50742925c9613`
+- Indexed commit: `55eedd68`
+- Readiness: `ready`
+- Query surface: `ready`
+- Artifact backend: `local_workspace`
+- Artifact health: `missing`
+
+## Notes
+
+Preflight reports working-tree drift until the dogfood hardening fixes are
+committed, because the rebuilt index is tied to commit `55eedd68` while the
+working tree contains the fixes that made this clean run reliable.
+
+## Post-Commit Incremental Sync
+
+After committing the dogfood hardening fixes, a normal repository sync advanced
+the index to the new commit.
+
+Result:
+
+- Exit status: 0
+- CLI result: `Indexed 10 files in 11.3s`
+- Wall time: `0:13.50`
+- User time: `7.71s`
+- System time: `0.83s`
+- CPU: `63%`
+- Max RSS: `146512 KB`
+- File system outputs: `203632` blocks

--- a/mcp_server/cli/preflight_commands.py
+++ b/mcp_server/cli/preflight_commands.py
@@ -17,6 +17,8 @@ from .artifact_commands import (
     _get_local_drift,
     _verify_local_index_restored,
 )
+from mcp_server.health.repository_readiness import ReadinessClassifier
+from mcp_server.storage.repository_registry import RepositoryRegistry
 
 
 @dataclass
@@ -135,6 +137,22 @@ def run_preflight() -> PreflightResult:
                 )
             )
 
+    try:
+        registry = RepositoryRegistry()
+        repo_info = registry.get_repository_by_path(Path.cwd())
+        if repo_info is not None:
+            readiness = ReadinessClassifier.classify_registered(repo_info, requested_path=Path.cwd())
+            if not readiness.ready:
+                checks.append(
+                    PreflightCheck(
+                        level="warning",
+                        message=f"Registered repository readiness is {readiness.state.value}.",
+                        command=readiness.remediation,
+                    )
+                )
+    except Exception:
+        pass
+
     status = "ready"
     if any(check.level == "warning" for check in checks):
         status = "warning"
@@ -164,7 +182,7 @@ def run_startup_preflight() -> PreflightResult:
 def preflight() -> None:
     """Check repository and artifact readiness before starting MCP."""
     for line in format_preflight_report(run_preflight()):
-        click.echo(line)
+        click.echo(line, file=sys.stdout)
 
 
 def _load_env_file(path: Path) -> dict:

--- a/mcp_server/dispatcher/dispatcher_enhanced.py
+++ b/mcp_server/dispatcher/dispatcher_enhanced.py
@@ -1820,6 +1820,17 @@ class EnhancedDispatcher:
             start_time = time.time()
             logger.info(f"Indexing {path} with {plugin.lang} plugin")
             shard = plugin.indexFile(path, content)
+            try:
+                self._persist_index_shard(ctx, path, content, plugin.language, shard)
+            except Exception as e:
+                logger.error(f"Failed to persist index shard for {path}: {e}", exc_info=True)
+                return IndexResult(
+                    status=IndexResultStatus.ERROR,
+                    path=path,
+                    observed_hash=None,
+                    actual_hash=None,
+                    error=f"failed to persist index shard: {e}",
+                )
 
             # Update file cache after successful indexing
             try:
@@ -1956,7 +1967,17 @@ class EnhancedDispatcher:
         try:
             start_time = time.time()
             logger.info(f"Indexing {path} with {plugin.lang} plugin (guarded)")
-            plugin.indexFile(path, content)
+            shard = plugin.indexFile(path, content)
+            try:
+                self._persist_index_shard(ctx, path, content, plugin.language, shard)
+            except Exception as e:
+                return IndexResult(
+                    status=IndexResultStatus.ERROR,
+                    path=path,
+                    observed_hash=expected_hash,
+                    actual_hash=actual_hash,
+                    error=f"failed to persist index shard: {e}",
+                )
 
             try:
                 stat = path.stat()
@@ -1997,6 +2018,119 @@ class EnhancedDispatcher:
                 actual_hash=actual_hash,
                 error=str(e),
             )
+
+    def _persist_index_shard(
+        self,
+        ctx: RepoContext,
+        path: Path,
+        content: str,
+        language: str,
+        shard: Dict[str, Any],
+    ) -> None:
+        """Persist a plugin-returned shard into the host SQLite store.
+
+        Sandboxed plugins cannot receive SQLite capabilities, so the dispatcher
+        owns durable writes from their returned shard.
+        """
+        sqlite_store = ctx.sqlite_store
+        if not isinstance(sqlite_store, SQLiteStore):
+            return
+
+        repo_path = Path(getattr(ctx.registry_entry, "path", ctx.workspace_root) or ctx.workspace_root)
+        repo_name = getattr(ctx.registry_entry, "name", None) or repo_path.name
+        repository_row = sqlite_store.ensure_repository_row(repo_path, name=repo_name)
+        try:
+            relative_path = str(path.relative_to(Path(ctx.workspace_root))).replace("\\", "/")
+        except ValueError:
+            relative_path = sqlite_store.path_resolver.normalize_path(path)
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+        file_id = sqlite_store.store_file(
+            repository_id=repository_row,
+            path=path,
+            relative_path=relative_path,
+            language=language,
+            size=len(content.encode("utf-8")),
+            hash=content_hash,
+            content_hash=content_hash,
+            metadata=shard.get("metadata") if isinstance(shard, dict) else None,
+        )
+        self._clear_file_index_rows(sqlite_store, file_id)
+
+        for symbol in shard.get("symbols", []) if isinstance(shard, dict) else []:
+            if not isinstance(symbol, dict):
+                continue
+            name = symbol.get("symbol") or symbol.get("name")
+            if not name:
+                continue
+            span = symbol.get("span") or ()
+            line_start = symbol.get("line_start") or symbol.get("line")
+            line_end = symbol.get("line_end")
+            if not line_start and isinstance(span, (list, tuple)) and span:
+                line_start = span[0]
+            if not line_end and isinstance(span, (list, tuple)) and len(span) > 1:
+                line_end = span[1]
+            line_start = int(line_start or 1)
+            line_end = int(line_end or line_start)
+            sqlite_store.store_symbol(
+                file_id=file_id,
+                name=str(name),
+                kind=str(symbol.get("kind") or "symbol"),
+                line_start=line_start,
+                line_end=line_end,
+                column_start=symbol.get("column_start") or symbol.get("column"),
+                column_end=symbol.get("column_end"),
+                signature=symbol.get("signature"),
+                documentation=symbol.get("documentation") or symbol.get("doc"),
+                metadata=symbol.get("metadata") or symbol,
+            )
+
+        for index, chunk in enumerate(shard.get("chunks", []) if isinstance(shard, dict) else []):
+            if not isinstance(chunk, dict):
+                continue
+            chunk_content = str(chunk.get("content") or "")
+            if not chunk_content:
+                continue
+            start = int(chunk.get("content_start") or chunk.get("byte_start") or 0)
+            end = int(chunk.get("content_end") or chunk.get("byte_end") or start + len(chunk_content))
+            line_start = int(chunk.get("line_start") or chunk.get("start_line") or 1)
+            line_end = int(chunk.get("line_end") or chunk.get("end_line") or line_start)
+            chunk_id = str(
+                chunk.get("chunk_id")
+                or hashlib.sha256(f"{relative_path}:{index}:{start}:{end}".encode("utf-8")).hexdigest()
+            )
+            sqlite_store.store_chunk(
+                file_id=file_id,
+                content=chunk_content,
+                content_start=start,
+                content_end=end,
+                line_start=line_start,
+                line_end=line_end,
+                chunk_id=chunk_id,
+                node_id=str(chunk.get("node_id") or chunk_id),
+                treesitter_file_id=str(chunk.get("file_id") or relative_path),
+                definition_id=chunk.get("definition_id"),
+                parent_chunk_id=chunk.get("parent_chunk_id"),
+                node_type=chunk.get("node_type"),
+                language=language,
+                chunk_index=int(chunk.get("chunk_index") or index),
+                metadata=chunk.get("metadata") or {},
+            )
+
+        with sqlite_store._get_connection() as conn:
+            conn.execute("DELETE FROM fts_code WHERE file_id = ?", (str(file_id),))
+            conn.execute("INSERT INTO fts_code (content, file_id) VALUES (?, ?)", (content, file_id))
+
+    def _clear_file_index_rows(self, sqlite_store: SQLiteStore, file_id: int) -> None:
+        with sqlite_store._get_connection() as conn:
+            conn.execute(
+                "DELETE FROM symbol_trigrams WHERE symbol_id IN "
+                "(SELECT id FROM symbols WHERE file_id = ?)",
+                (file_id,),
+            )
+            conn.execute("DELETE FROM symbols WHERE file_id = ?", (file_id,))
+            conn.execute("DELETE FROM code_chunks WHERE file_id = ?", (file_id,))
+            conn.execute("DELETE FROM fts_code WHERE file_id = ?", (str(file_id),))
 
     def get_statistics(self, ctx: RepoContext) -> Dict[str, Any]:
         """Get statistics about indexed files and languages."""
@@ -2101,18 +2235,32 @@ class EnhancedDispatcher:
                 # First try to match by extension
                 if path.suffix in supported_extensions:
                     # skip_semantic=True — we'll batch semantic embed after the loop
-                    self.index_file(ctx, path, do_semantic=False)
-                    stats["indexed_files"] += 1
-                    semantically_indexed_paths.append(path.resolve())
+                    mutation = self.index_file(ctx, path, do_semantic=False)
+                    if mutation.status == IndexResultStatus.INDEXED:
+                        stats["indexed_files"] += 1
+                        semantically_indexed_paths.append(path.resolve())
+                    elif self._is_non_indexable_result(mutation):
+                        stats["ignored_files"] += 1
+                    else:
+                        stats["failed_files"] += 1
+                        if mutation.error:
+                            stats.setdefault("errors", []).append(f"{path}: {mutation.error}")
                 # For files without recognized extensions, try each plugin's supports() method
                 # This allows plugins to match by filename patterns (e.g., .env, Dockerfile)
                 else:
                     matched = False
                     for plugin in self._plugin_set_registry.plugins_for(ctx.repo_id):
                         if plugin.supports(path):
-                            self.index_file(ctx, path, do_semantic=False)
-                            stats["indexed_files"] += 1
-                            semantically_indexed_paths.append(path.resolve())
+                            mutation = self.index_file(ctx, path, do_semantic=False)
+                            if mutation.status == IndexResultStatus.INDEXED:
+                                stats["indexed_files"] += 1
+                                semantically_indexed_paths.append(path.resolve())
+                            elif self._is_non_indexable_result(mutation):
+                                stats["ignored_files"] += 1
+                            else:
+                                stats["failed_files"] += 1
+                                if mutation.error:
+                                    stats.setdefault("errors", []).append(f"{path}: {mutation.error}")
                             matched = True
                             break
 
@@ -2163,6 +2311,16 @@ class EnhancedDispatcher:
         )
 
         return stats
+
+    def _is_non_indexable_result(self, mutation: IndexResult) -> bool:
+        if mutation.status in {
+            IndexResultStatus.SKIPPED_UNCHANGED,
+            IndexResultStatus.SKIPPED_TOCTOU,
+        }:
+            return True
+        return mutation.status == IndexResultStatus.ERROR and bool(
+            mutation.error and mutation.error.startswith("No plugin for ")
+        )
 
     def search_documentation(
         self,

--- a/mcp_server/storage/git_index_manager.py
+++ b/mcp_server/storage/git_index_manager.py
@@ -292,6 +292,15 @@ class GitAwareIndexManager:
                 error="; ".join(result.errors) or "Full index failed",
                 duration_seconds=(datetime.now() - start_time).total_seconds(),
             )
+        if not self._index_has_durable_rows(repo_info):
+            self.registry.update_staleness_reason(repo_id, "index_empty")
+            return IndexSyncResult(
+                action="failed",
+                commit=current_commit,
+                files_processed=result.files_processed,
+                error="Full index completed without durable SQLite file rows",
+                duration_seconds=(datetime.now() - start_time).total_seconds(),
+            )
         if self._index_exists(repo_info) and self.registry.update_indexed_commit(
             repo_id, current_commit, branch=current_branch
         ):
@@ -361,6 +370,27 @@ class GitAwareIndexManager:
         if index_location is None:
             return False
         return (Path(index_location) / "current.db").exists()
+
+    def _index_has_durable_rows(self, repo_info: Any) -> bool:
+        index_path = getattr(repo_info, "index_path", None)
+        if index_path is None:
+            return False
+        path = Path(index_path)
+        if not path.exists():
+            return False
+        try:
+            import sqlite3
+
+            conn = sqlite3.connect(str(path))
+            try:
+                cursor = conn.execute(
+                    "SELECT COUNT(*) FROM files WHERE is_deleted = 0 OR is_deleted IS NULL"
+                )
+                return int(cursor.fetchone()[0]) > 0
+            finally:
+                conn.close()
+        except Exception:
+            return False
 
     def _normalize_update_result(self, value: Any) -> UpdateResult:
         if isinstance(value, UpdateResult):

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -636,13 +636,8 @@ class SQLiteStore:
                    updated_at=CURRENT_TIMESTAMP""",
                 (path, name, json.dumps(metadata or {})),
             )
-            if cursor.lastrowid:
-                return cursor.lastrowid
-            else:
-                # If lastrowid is None, it means we updated an existing row
-                # Get the id of the existing repository
-                cursor = conn.execute("SELECT id FROM repositories WHERE path = ?", (path,))
-                return cursor.fetchone()[0]
+            cursor = conn.execute("SELECT id FROM repositories WHERE path = ?", (path,))
+            return cursor.fetchone()[0]
 
     def get_repository(self, path: str) -> Optional[Dict]:
         """Get repository by path."""
@@ -780,15 +775,14 @@ class SQLiteStore:
                     deleted_at,
                 ),
             )
-            if cursor.lastrowid:
-                return cursor.lastrowid
-            else:
-                # Get the id of the existing file
-                cursor = conn.execute(
-                    "SELECT id FROM files WHERE repository_id = ? AND relative_path = ?",
-                    (repository_id, relative_path_str),
-                )
-                return cursor.fetchone()[0]
+            cursor = conn.execute(
+                "SELECT id FROM files WHERE repository_id = ? AND relative_path = ?",
+                (repository_id, relative_path_str),
+            )
+            row = cursor.fetchone()
+            if row is None:  # pragma: no cover - defensive
+                raise RuntimeError(f"Failed to resolve stored file row for {relative_path_str}")
+            return row[0]
 
     def get_file(
         self, file_path: Union[str, Path], repository_id: Optional[int] = None

--- a/mcp_server/storage/store_registry.py
+++ b/mcp_server/storage/store_registry.py
@@ -5,6 +5,7 @@ Thread-safe registry of SQLiteStore instances keyed by repo_id.
 import logging
 import sqlite3
 import threading
+from pathlib import Path
 from typing import Dict
 
 from mcp_server.core.path_resolver import PathResolver
@@ -71,6 +72,8 @@ class StoreRegistry:
                 existing = self._cache.get(repo_id)
                 if existing is not None:
                     return existing
+            index_path_obj = Path(info.index_path)
+            index_path_obj.parent.mkdir(parents=True, exist_ok=True)
             pool = ConnectionPool(
                 factory=lambda p=index_path: sqlite3.connect(p, check_same_thread=False),
                 size=4,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -908,7 +908,7 @@ class TestSymbolRouting:
         store.get_symbol.return_value = []
         store.search_bm25.return_value = []  # BM25 also returns nothing
         d, ctx = self._make_dispatcher_with_ctx(store)
-        results = list(d.search(ctx, "class SemanticIndexer", limit=5))
+        list(d.search(ctx, "class SemanticIndexer", limit=5))
         # BM25 was attempted as fallback
         store.search_bm25.assert_called()
 
@@ -928,7 +928,6 @@ class TestSymbolRouting:
 
 def _make_repo_ctx(sqlite_store=None) -> RepoContext:
     """Build a minimal RepoContext for tests."""
-    from datetime import datetime
     from pathlib import Path
     from unittest.mock import MagicMock
 
@@ -1036,6 +1035,16 @@ class TestEnhancedDispatcherProtocolConformance:
         result = d.index_directory(ctx, tmp_path)
         assert isinstance(result, dict)
 
+    def test_index_directory_treats_unsupported_plugin_files_as_ignored(self, tmp_path):
+        ctx = _make_repo_ctx()
+        target = tmp_path / "data.json"
+        target.write_text('{"ok": true}\n')
+
+        result = Dispatcher([]).index_directory(ctx, tmp_path)
+
+        assert result["failed_files"] == 0
+        assert result["ignored_files"] == 1
+
     def test_remove_file_accepts_ctx(self, tmp_path):
         """remove_file(ctx, path) must accept ctx as first positional arg."""
         ctx = _make_repo_ctx()
@@ -1106,6 +1115,50 @@ class TestEnhancedDispatcherProtocolConformance:
 
         assert result.status == IndexResultStatus.ERROR
         assert result.error == "plugin boom"
+
+    def test_index_file_persists_plugin_shard_to_ctx_sqlite_store(self, tmp_path):
+        from mcp_server.storage.sqlite_store import SQLiteStore
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        target = repo_root / "sample.py"
+        target.write_text("def persisted():\n    return 1\n")
+        store = SQLiteStore(str(tmp_path / "index.db"))
+
+        plugin = MagicMock(spec=IPlugin, lang="python")
+        plugin.language = "python"
+        plugin.supports.return_value = True
+        plugin.indexFile.return_value = {
+            "file": str(target),
+            "language": "python",
+            "symbols": [
+                {
+                    "symbol": "persisted",
+                    "kind": "function",
+                    "line": 1,
+                    "span": [1, 2],
+                    "signature": "def persisted():",
+                }
+            ],
+        }
+        ctx = _make_repo_ctx(store)
+        ctx.registry_entry.path = repo_root
+        ctx.registry_entry.name = "repo"
+        ctx = RepoContext(
+            repo_id=ctx.repo_id,
+            sqlite_store=store,
+            workspace_root=repo_root,
+            tracked_branch=ctx.tracked_branch,
+            registry_entry=ctx.registry_entry,
+        )
+
+        result = Dispatcher([plugin]).index_file(ctx, target)
+
+        repo_row = store.ensure_repository_row(repo_root, name="repo")
+        file_row = store.get_file_by_path("sample.py", repo_row)
+        assert result.status == IndexResultStatus.INDEXED
+        assert file_row is not None
+        assert store.get_symbol("persisted")[0]["file_id"] == file_row["id"]
 
     def test_index_file_returns_skipped_unchanged_when_cache_matches(self, tmp_path):
         plugin = MagicMock(spec=IPlugin, lang="python")
@@ -1193,7 +1246,7 @@ class TestEnhancedDispatcherProtocolConformance:
 
         ctx_a = _make_repo_ctx(store_a)
         d = Dispatcher([])
-        results = list(d.search(ctx_a, "foo"))
+        list(d.search(ctx_a, "foo"))
         # store_b must never be touched
         store_b.search_bm25.assert_not_called()
 

--- a/tests/test_git_index_manager.py
+++ b/tests/test_git_index_manager.py
@@ -4,16 +4,13 @@ import subprocess
 from datetime import datetime
 from inspect import signature
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from mcp_server.core.repo_context import RepoContext
 from mcp_server.dispatcher.dispatcher_enhanced import IndexResult, IndexResultStatus
 from mcp_server.storage.git_index_manager import (
     ChangeSet,
     GitAwareIndexManager,
-    IndexSyncResult,
     UpdateResult,
     should_reindex_for_branch,
 )
@@ -246,7 +243,7 @@ def test_same_branch_advance_triggers_incremental(tmp_path):
     incremental_mock = MagicMock(return_value=UpdateResult(indexed=1))
     manager._incremental_index_update = incremental_mock
 
-    result = manager.sync_repository_index("test-repo-id")
+    manager.sync_repository_index("test-repo-id")
 
     assert (
         incremental_mock.call_count == 1
@@ -338,6 +335,31 @@ def test_sync_repository_index_persists_partial_index_failure(tmp_path):
     registry.update_staleness_reason.assert_called_once_with(
         "test-repo-id", "partial_index_failure"
     )
+
+
+def test_full_index_without_durable_rows_does_not_advance_commit(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    commit = _get_head_commit(repo)
+    repo_info = _make_repo_info(repo, commit)
+    repo_info.last_indexed_commit = None
+    repo_info.index_path.touch()
+
+    registry = MagicMock()
+    registry.get_repository.return_value = repo_info
+    registry.update_git_state.return_value = {"commit": commit, "branch": "main"}
+
+    manager = _make_manager(registry)
+    manager._resolve_ctx = MagicMock(
+        return_value=_make_ctx(repo_info.repository_id, repo, repo_info.index_path)
+    )
+    manager._full_index = MagicMock(return_value=UpdateResult(indexed=1))
+
+    result = manager.sync_repository_index(repo_info.repository_id, force_full=True)
+
+    assert result.action == "failed"
+    assert result.error == "Full index completed without durable SQLite file rows"
+    registry.update_staleness_reason.assert_called_once_with(repo_info.repository_id, "index_empty")
+    registry.update_indexed_commit.assert_not_called()
 
 
 def test_incremental_missing_rename_destination_is_clean_only_after_delete_success(tmp_path):
@@ -494,7 +516,13 @@ def test_clean_full_rebuild_advances_commit_only_with_durable_index(tmp_path):
     registry.update_git_state.return_value = {"commit": old_commit, "branch": "main"}
     registry.update_indexed_commit.return_value = True
 
-    manager = GitAwareIndexManager(registry, CtxSignatureDispatcher())
+    class DurableFullIndexDispatcher(CtxSignatureDispatcher):
+        def index_directory(self, ctx, path, recursive=True):
+            row_id = ctx.sqlite_store.ensure_repository_row(path, name="test-repo")
+            ctx.sqlite_store.store_file(row_id, path=Path(path) / "hello.py", relative_path="hello.py")
+            return super().index_directory(ctx, path, recursive=recursive)
+
+    manager = GitAwareIndexManager(registry, DurableFullIndexDispatcher())
 
     result = manager.sync_repository_index(repo_info.repository_id, force_full=True)
 

--- a/tests/test_preflight_commands.py
+++ b/tests/test_preflight_commands.py
@@ -1,6 +1,11 @@
 from click.testing import CliRunner
 
-from mcp_server.cli.preflight_commands import PreflightResult, preflight
+from mcp_server.cli.preflight_commands import PreflightResult, preflight, run_preflight
+
+
+class _NoRegisteredRepo:
+    def get_repository_by_path(self, path):
+        return None
 
 
 def test_preflight_reports_ready_state(monkeypatch):
@@ -45,6 +50,7 @@ def test_preflight_warns_when_behind_remote(monkeypatch):
             [],
         ),
     )
+    monkeypatch.setattr("mcp_server.cli.preflight_commands.RepositoryRegistry", _NoRegisteredRepo)
 
     result = runner.invoke(preflight)
 
@@ -71,6 +77,7 @@ def test_preflight_warns_when_runtime_files_missing(monkeypatch):
         "mcp_server.cli.preflight_commands._verify_local_index_restored",
         lambda: False,
     )
+    monkeypatch.setattr("mcp_server.cli.preflight_commands.RepositoryRegistry", _NoRegisteredRepo)
 
     result = runner.invoke(preflight)
 
@@ -104,6 +111,7 @@ def test_preflight_warns_when_artifact_differs_from_head(monkeypatch):
             [],
         ),
     )
+    monkeypatch.setattr("mcp_server.cli.preflight_commands.RepositoryRegistry", _NoRegisteredRepo)
 
     result = runner.invoke(preflight)
 
@@ -137,8 +145,56 @@ def test_preflight_handles_no_remote(monkeypatch):
             [],
         ),
     )
+    monkeypatch.setattr("mcp_server.cli.preflight_commands.RepositoryRegistry", _NoRegisteredRepo)
 
     result = runner.invoke(preflight)
 
     assert result.exit_code == 0
     assert "No upstream remote is configured" in result.output
+
+
+def test_preflight_warns_when_registered_repo_index_is_empty(monkeypatch):
+    monkeypatch.setattr(
+        "mcp_server.cli.preflight_commands._get_git_ref_info",
+        lambda: {"head": "abc", "branch": "main"},
+    )
+    monkeypatch.setattr(
+        "mcp_server.cli.preflight_commands._get_artifact_identity",
+        lambda: {"commit": "abc"},
+    )
+    monkeypatch.setattr("mcp_server.cli.preflight_commands._get_upstream_ref", lambda: None)
+    monkeypatch.setattr(
+        "mcp_server.cli.preflight_commands._verify_local_index_restored",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "mcp_server.cli.preflight_commands._get_local_drift",
+        lambda: (
+            type("Detector", (), {"should_use_incremental": lambda self, changes: True})(),
+            [],
+        ),
+    )
+
+    class FakeRegistry:
+        def get_repository_by_path(self, path):
+            return object()
+
+    readiness = type(
+        "Readiness",
+        (),
+        {
+            "ready": False,
+            "state": type("State", (), {"value": "index_empty"})(),
+            "remediation": "Run reindex to populate the repository index.",
+        },
+    )()
+    monkeypatch.setattr("mcp_server.cli.preflight_commands.RepositoryRegistry", FakeRegistry)
+    monkeypatch.setattr(
+        "mcp_server.cli.preflight_commands.ReadinessClassifier.classify_registered",
+        lambda repo_info, requested_path=None: readiness,
+    )
+
+    result = run_preflight()
+
+    assert result.status == "warning"
+    assert any("readiness is index_empty" in check.message for check in result.checks)

--- a/tests/test_store_registry.py
+++ b/tests/test_store_registry.py
@@ -103,6 +103,59 @@ class TestStoreRegistry:
         with pytest.raises(KeyError):
             sr.get("unknown_repo_id_xyz")
 
+    def test_get_creates_index_parent_directory(self, tmp_path):
+        registry_file = tmp_path / "registry.json"
+        registry = RepositoryRegistry(registry_file)
+        index_path = tmp_path / "repo" / ".mcp-index" / "current.db"
+        repo_id = "aabbccdd11223344"
+        repo_info = RepositoryInfo(
+            repository_id=repo_id,
+            name="test-repo",
+            path=tmp_path,
+            index_path=index_path,
+            language_stats={},
+            total_files=0,
+            total_symbols=0,
+            indexed_at=datetime.now(),
+            active=True,
+        )
+        registry.register(repo_info)
+
+        store = StoreRegistry.for_registry(registry).get(repo_id)
+
+        assert isinstance(store, SQLiteStore)
+        assert index_path.exists()
+
+    def test_create_repository_returns_existing_row_after_other_inserts(self, tmp_path):
+        store = SQLiteStore(str(tmp_path / "index.db"))
+        repo_path = str(tmp_path / "repo")
+        first_id = store.create_repository(repo_path, "repo")
+        store.store_file(first_id, path=tmp_path / "file.py", relative_path="file.py")
+
+        second_id = store.create_repository(repo_path, "repo")
+
+        assert second_id == first_id
+
+    def test_store_file_returns_existing_row_after_other_inserts(self, tmp_path):
+        store = SQLiteStore(str(tmp_path / "index.db"))
+        repo_id = store.create_repository(str(tmp_path / "repo"), "repo")
+        first_id = store.store_file(
+            repo_id,
+            path=tmp_path / "file.py",
+            relative_path="file.py",
+            language="python",
+        )
+        store.store_file(repo_id, path=tmp_path / "other.py", relative_path="other.py")
+
+        second_id = store.store_file(
+            repo_id,
+            path=tmp_path / "file.py",
+            relative_path="file.py",
+            language="python",
+        )
+
+        assert second_id == first_id
+
     # --- 6. concurrent get from 8 threads ---
     def test_concurrent_get_same_instance_no_lock_errors(self, tmp_path):
         registry, repo_id, _ = _make_registry_with_repo(tmp_path)


### PR DESCRIPTION
## Summary
- persist sandboxed index shards into the per-repo SQLite store during file indexing
- make repository/file upserts return conflict-safe row ids for incremental updates
- fail full syncs that produce no durable rows and surface readiness in preflight
- capture clean dogfood rebuild metrics in docs/status/DOGFOOD_INDEX_RESET_2026_04_27.md

## Verification
- uv run ruff check mcp_server/dispatcher/dispatcher_enhanced.py mcp_server/storage/sqlite_store.py mcp_server/storage/store_registry.py mcp_server/storage/git_index_manager.py mcp_server/cli/preflight_commands.py tests/test_dispatcher.py tests/test_git_index_manager.py tests/test_store_registry.py tests/test_preflight_commands.py
- uv run pytest tests/test_store_registry.py tests/test_dispatcher.py tests/test_git_index_manager.py tests/test_preflight_commands.py tests/test_repository_readiness.py --no-cov
- clean force-full dogfood sync: Indexed 1357 files in 1686.6s, wall 28:10.51, max RSS 403984 KB
- post-commit sync: Indexed 10 files in 11.3s, wall 0:13.50, max RSS 146512 KB
- final sync: Indexed 1 files in 3.5s, wall 0:05.81, max RSS 144860 KB
- uv run mcp-index repository status: readiness ready, query surface ready
- uv run mcp-index preflight: ready before push