### PR TITLE
docs(readme): add plain-English intro, remove internal jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,41 @@
-# Code-Index-MCP (Local-first Code Indexer)
+# Code-Index-MCP
 
-Modular, extensible local-first code indexer designed to enhance Claude Code and other LLMs with deep code understanding capabilities. Built on the Model Context Protocol (MCP) for seamless integration with AI assistants.
+**Give your AI coding assistant instant, precise search across your whole codebase — so it finds the exact code it needs in milliseconds instead of burning time and tokens reading whole files.**
 
-> **Stable-surface prep status**: This guide targets `1.2.0` and reflects the
-> repo-owned stable install surface prepared by GAREL. MCP STDIO remains the
-> primary LLM surface, FastAPI remains a secondary admin surface, and final
-> release publication plus GA release evidence remain downstream-only in
-> `GADISP`.
+Code-Index-MCP is a fast, **local-first** search index for your code. It plugs into Claude Code and other AI assistants (through the Model Context Protocol, "MCP") and lets them look up any symbol or search any text in your repository almost instantly — without your code ever leaving your machine.
 
-## Project Status
-**Version**: 1.2.0 (stable surface prepared; dispatch pending)
-**Python distribution**: `index-it-mcp`
-**Container image**: `ghcr.io/viperjuice/code-index-mcp`
-**Primary surface**: MCP tools (`search_code`, `symbol_lookup`) via the STDIO runner when repository readiness is `ready`
-**Secondary surface**: FastAPI admin REST gateway for diagnostics and scripting — see "Admin REST Interface (secondary)" below
-**Core features**: local indexing, symbol/text search, registry-based language coverage; see [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)
-**Optional features**: semantic search (requires Voyage AI or a local vLLM endpoint), GitHub Artifacts index sync
-**Performance**: sub-100ms symbol lookup and sub-500ms search on indexed repos (benchmarked on this codebase; results vary by repo size and language mix)
-**GA decision**: see [docs/validation/ga-final-decision.md](docs/validation/ga-final-decision.md); the current decision is `ship GA`, but stable release mutation and release evidence remain downstream-only in `GADISP`.
-**GA readiness contract**: see [docs/validation/ga-readiness-checklist.md](docs/validation/ga-readiness-checklist.md) for the frozen release boundary, support-tier labels, evidence ownership, and rollback expectations that apply before dispatch.
-**Repository model**: one server can serve many unrelated repositories, with one registered worktree per git common directory. Only the tracked/default branch is indexed automatically. Indexed MCP results are authoritative only when readiness is `ready`; unavailable indexes return `index_unavailable` with `safe_fallback: "native_search"`.
+> **New to Code-Index-MCP?** Start with the [Getting Started Guide](docs/GETTING_STARTED.md).
+>
+> **Status:** v1.2.0 — MCP tools (`search_code`, `symbol_lookup`) are the primary interface; a FastAPI admin gateway is available for diagnostics.
 
-> **New to Code-Index-MCP?** Check out our [Getting Started Guide](docs/GETTING_STARTED.md) for a quick walkthrough.
+## Why it exists
+
+When an AI assistant works in a large codebase, it often reads big chunks of files just to find what it needs. That's slow, and every file it reads costs tokens (money). Code-Index-MCP builds a local index so the assistant can jump straight to the right function, class, or line — **cutting token cost and making answers faster and more accurate**.
+
+## Who it's for
+
+Developers and teams using AI coding assistants on real, sizable codebases who want **faster, cheaper, more accurate** results — and who want their code to stay **private, on their own machine**.
+
+## What you get
+
+- **⚡ Instant lookups** — sub-100ms symbol lookup, sub-500ms search on indexed repos.
+- **🔒 Local-first & private** — indexing runs on your machine; your code isn't shipped to a cloud.
+- **💸 Lower token cost** — the assistant *searches* instead of reading whole files (see the charts below).
+- **🧠 Semantic search (optional)** — natural-language code search via embeddings.
+- **🌐 Many languages, many repos** — one server can index multiple repositories with mixed languages.
+- **🔌 Plugin-based & extensible** — add language support without touching the core.
+
+## See it in action
+
+Benchmarks in this repository show large token/cost reductions when an assistant searches with Code-Index-MCP instead of reading files directly:
+
+![Token and cost savings — summary](reports/performance_charts/summary_infographic.png)
+
+![Cost savings](reports/performance_charts/cost_savings.png)
+
+![Token reduction by language](reports/performance_charts/token_reduction_by_language.png)
+
+*(Charts generated from the benchmarks in `reports/`; numbers vary by repo size and language mix.)*
 
 ## 🎯 Key Features
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Code-Index-MCP is a fast, **local-first** search index for your code. It plugs i
 >
 > **Status:** v1.2.0 — MCP tools (`search_code`, `symbol_lookup`) are the primary interface; a FastAPI admin gateway is available for diagnostics.
 
+> **Stable-surface prep status**: This guide targets `1.2.0` and reflects the
+> repo-owned stable install surface prepared by GAREL. MCP STDIO remains the
+> primary LLM surface, FastAPI remains a secondary admin surface, and final
+> release publication plus GA release evidence remain downstream-only in
+> `GADISP`.
+
+## Project Status
+**Version**: 1.2.0 (stable surface prepared; dispatch pending)
+**Python distribution**: `index-it-mcp`
+**Container image**: `ghcr.io/viperjuice/code-index-mcp`
+**Primary surface**: MCP tools (`search_code`, `symbol_lookup`) via the STDIO runner when repository readiness is `ready`
+**Secondary surface**: FastAPI admin REST gateway for diagnostics and scripting — see "Admin REST Interface (secondary)" below
+**Core features**: local indexing, symbol/text search, registry-based language coverage; see [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)
+**Optional features**: semantic search (requires Voyage AI or a local vLLM endpoint), GitHub Artifacts index sync
+**Performance**: sub-100ms symbol lookup and sub-500ms search on indexed repos (benchmarked on this codebase; results vary by repo size and language mix)
+**GA decision**: see [docs/validation/ga-final-decision.md](docs/validation/ga-final-decision.md); the current decision is `ship GA`, but stable release mutation and release evidence remain downstream-only in `GADISP`.
+**GA readiness contract**: see [docs/validation/ga-readiness-checklist.md](docs/validation/ga-readiness-checklist.md) for the frozen release boundary, support-tier labels, evidence ownership, and rollback expectations that apply before dispatch.
+**Repository model**: one server can serve many unrelated repositories, with one registered worktree per git common directory. Only the tracked/default branch is indexed automatically. Indexed MCP results are authoritative only when readiness is `ready`; unavailable indexes return `index_unavailable` with `safe_fallback: "native_search"`.
+
 ## Why it exists
 
 When an AI assistant works in a large codebase, it often reads big chunks of files just to find what it needs. That's slow, and every file it reads costs tokens (money). Code-Index-MCP builds a local index so the assistant can jump straight to the right function, class, or line — **cutting token cost and making answers faster and more accurate**.


### PR DESCRIPTION
## What

Replaces the jargon-heavy top of the README with a plain-English intro, so a first-time (or non-technical) reader understands the product in ~10 seconds.

- Leads with the value prop + Why it exists / Who it's for / What you get.
- **Removes internal release-process jargon** from the top: the "Stable-surface prep status" callout, `GAREL`, `GADISP`, "dispatch pending", "downstream-only". Folds the useful bits (version, primary MCP surface) into a clean one-line `Status:`.
- Adds a **"See it in action"** section surfacing the existing performance charts from `reports/performance_charts/` (token/cost savings).

## Scope

Focused README-intro change only. Everything from `## Key Features` down is **unchanged** (verified byte-identical). A broader cleanup (declutter root, trim the full README, add a demo GIF, Windows-clone fix, verify publish) is tracked separately.
