### PR TITLE
docs(release): record v1.3.1 tag provenance in GA RC evidence

### DIFF
--- a/docs/validation/ga-rc-evidence.md
+++ b/docs/validation/ga-rc-evidence.md
@@ -2,6 +2,30 @@
 
 # GA RC Evidence
 
+## v1.3.1 Tag Provenance (2026-07-11)
+
+This section records the provenance of the current `v1.3.1` tag so the release
+metadata contract (`tests/test_release_metadata.py::test_release_tag_is_not_reused_locally`)
+can bind the tag to a documented commit. It supersedes, but does not delete, the
+historical `v1.2.0-rc8` GARECUT record retained below.
+
+- Tag: `v1.3.1`.
+- Tag commit: `934eb890144a285bc725a53cc61890bbc2bd643d`.
+- Source: merge of PR
+  [#72](https://github.com/ViperJuice/Code-Index-MCP/pull/72)
+  ("Complete comprehensive hardening v10 and prepare 1.3.1").
+- Underlying evidence: `docs/status/COMPREHENSIVE_HARDENING_V10.md` records the
+  eight-phase v10 hardening (authentication boundaries, repository selection,
+  readiness recovery, summarization contracts, bounded plugin workers, local
+  quality gates, and release preparation), locally verified for controlled beta.
+- Channel posture: `v1.3.1` is **prepared but unpublished** — no external release
+  dispatch, no PyPI publication, and Docker `latest` remains stable-only, matching
+  the `docs/SUPPORT_MATRIX.md` "prepared/not yet published" support facts.
+
+This provenance note is a metadata-only bookkeeping record binding the existing
+`v1.3.1` tag to commit `934eb890144a285bc725a53cc61890bbc2bd643d`; it does not
+itself dispatch or publish a release.
+
 ## Summary
 
 - Evidence captured: `2026-04-25T05:34:39Z`.


### PR DESCRIPTION
## Why

The required **Protected Evidence - Agent Gate** fails on `main` (and therefore on every open PR) because `tests/test_release_metadata.py::test_release_tag_is_not_reused_locally` asserts the `v1.3.1` tag's commit is documented in `docs/validation/ga-rc-evidence.md`, but that doc still only records `v1.2.0-rc8`.

The `v1.3.1` tag points at `934eb890144a285bc725a53cc61890bbc2bd643d` — the #72 "Complete comprehensive hardening v10 and prepare 1.3.1" merge — which was never recorded in the GA RC evidence.

## What

Adds a metadata-only **v1.3.1 Tag Provenance** section binding the tag to its commit and to the underlying hardening evidence (`docs/status/COMPREHENSIVE_HARDENING_V10.md`), preserving the historical `v1.2.0-rc8` record. No release dispatch, no publication — prepared/unpublished posture unchanged.

Unblocks the Protected Evidence gate for all pending PRs (including #74).

`tests/test_release_metadata.py` → 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
