### PR TITLE
roadmap: v12 — treesitter-chunker v4 accommodation + inference follow-ups

### DIFF
--- a/mcp_server/cli/tool_handlers.py
+++ b/mcp_server/cli/tool_handlers.py
@@ -1437,6 +1437,7 @@ async def handle_summarize_sample(
     import sqlite3 as _sqlite3
 
     from mcp_server.indexing.summarization import FileBatchSummarizer
+    from mcp_server.storage.sqlite_store import assert_chunk_scheme_readable
 
     repository = (arguments or {}).get("repository")
     paths_arg = (arguments or {}).get("paths")
@@ -1585,6 +1586,9 @@ async def handle_summarize_sample(
             continue
 
         with _sqlite3.connect(db_path) as _conn:
+            # Fail closed on scheme-dependent reads (CHUNKERSAFE Lane A): refuse to
+            # read code_chunks rows across an incompatible/rebuilding scheme.
+            assert_chunk_scheme_readable(_conn)
             chunk_rows = _conn.execute(
                 """SELECT c.chunk_id, c.line_start, c.line_end,
                           c.content, c.node_type, c.parent_chunk_id,

--- a/mcp_server/cli/tool_handlers.py
+++ b/mcp_server/cli/tool_handlers.py
@@ -45,6 +45,11 @@ _RECOVERABLE_REINDEX_STATES = frozenset(
         RepositoryReadinessState.CORRUPT_SQLITE,
         RepositoryReadinessState.MISSING_SCHEMA,
         RepositoryReadinessState.MISSING_PROVENANCE,
+        # CHUNKERSAFE Lane A: a scheme-mismatched or mid-rebuild index is a
+        # recoverable dead-end -- readiness tells the operator to reindex, so
+        # reindex must actually run the staged full rebuild for these states.
+        RepositoryReadinessState.SCHEME_MISMATCH,
+        RepositoryReadinessState.INDEX_REBUILDING,
     }
 )
 
@@ -667,13 +672,23 @@ async def handle_search_code(
 
         # Lazy summarization enqueue
         if lazy_summarizer and lazy_summarizer.can_summarize() and sqlite_store:
-            for item in result.results[:5]:
-                raw_file = item.file
-                raw_line = item.line or 1
-                if raw_file and raw_line:
-                    chunk_info = sqlite_store.find_chunk_at_line(raw_file, int(raw_line))
-                    if chunk_info:
-                        lazy_summarizer.enqueue(chunk_info)
+            # CHUNKERSAFE Lane A: find_chunk_at_line is a scheme-dependent
+            # code_chunks read; fail closed and skip summarization over an
+            # incompatible/rebuilding index rather than enqueue stale-scheme rows.
+            scheme_readable = True
+            try:
+                scheme_status, _sc_marker, _sc_target = sqlite_store.get_chunk_scheme_status()
+                scheme_readable = scheme_status in ("compatible", "empty")
+            except Exception:
+                scheme_readable = False
+            if scheme_readable:
+                for item in result.results[:5]:
+                    raw_file = item.file
+                    raw_line = item.line or 1
+                    if raw_file and raw_line:
+                        chunk_info = sqlite_store.find_chunk_at_line(raw_file, int(raw_line))
+                        if chunk_info:
+                            lazy_summarizer.enqueue(chunk_info)
 
         filtered_or_enriched = bool(
             source_type

--- a/mcp_server/dispatcher/dispatcher_enhanced.py
+++ b/mcp_server/dispatcher/dispatcher_enhanced.py
@@ -42,6 +42,7 @@ from ..storage.multi_repo_manager import MultiRepositoryManager
 from ..storage.sqlite_store import (
     SQLiteStore,
     _merge_chunk_source_metadata,
+    assert_chunk_scheme_readable,
     classify_sqlite_storage_failure,
 )
 from ..storage.two_phase import TwoPhaseCommitError, two_phase_commit
@@ -3268,6 +3269,9 @@ class EnhancedDispatcher:
         normalized_paths = sorted(Path(path).resolve(strict=False).as_posix() for path in paths)
         placeholders = ", ".join("?" for _ in normalized_paths)
         with sqlite3.connect(active_store.db_path) as conn:
+            # CHUNKERSAFE Lane A: fail closed before a scheme-dependent code_chunks
+            # read over an incompatible/rebuilding index.
+            assert_chunk_scheme_readable(conn)
             row = conn.execute(
                 f"""SELECT COUNT(*)
                     FROM code_chunks c

--- a/mcp_server/dispatcher/dispatcher_enhanced.py
+++ b/mcp_server/dispatcher/dispatcher_enhanced.py
@@ -3318,6 +3318,11 @@ class EnhancedDispatcher:
             metadata=shard.get("metadata") if isinstance(shard, dict) else None,
         )
         with sqlite_store._get_connection() as conn:
+            # Central chunk-scheme guard (CHUNKERSAFE Lane A): the dispatcher raw
+            # upsert bypasses SQLiteStore.store_chunk, so route it through the same
+            # check before any delete/insert. Stamps an empty index; raises
+            # ChunkSchemeMismatchError (refusing the write) on a scheme mismatch.
+            sqlite_store._assert_chunk_scheme_writable(conn, chunk_type="code")
             self._clear_file_index_rows(sqlite_store, file_id, conn=conn)
 
             for symbol in shard.get("symbols", []) if isinstance(shard, dict) else []:

--- a/mcp_server/gateway.py
+++ b/mcp_server/gateway.py
@@ -370,6 +370,10 @@ _RECOVERABLE_REINDEX_STATES = frozenset(
         RepositoryReadinessState.CORRUPT_SQLITE,
         RepositoryReadinessState.MISSING_SCHEMA,
         RepositoryReadinessState.MISSING_PROVENANCE,
+        # CHUNKERSAFE Lane A: scheme-mismatched / mid-rebuild indexes must be
+        # reindexable so a tripped guard is not a permanent dead-end.
+        RepositoryReadinessState.SCHEME_MISMATCH,
+        RepositoryReadinessState.INDEX_REBUILDING,
     }
 )
 

--- a/mcp_server/health/repository_readiness.py
+++ b/mcp_server/health/repository_readiness.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from mcp_server.storage.repo_identity import compute_repo_id
+from mcp_server.storage.sqlite_store import evaluate_chunk_scheme
 from mcp_server.utils.subprocess_env import get_full_env
 
 
@@ -30,6 +31,8 @@ class RepositoryReadinessState(str, Enum):
     CORRUPT_SQLITE = "corrupt_sqlite"
     MISSING_SCHEMA = "missing_schema"
     MISSING_PROVENANCE = "missing_provenance"
+    SCHEME_MISMATCH = "scheme_mismatch"
+    INDEX_REBUILDING = "index_rebuilding"
 
 
 class SemanticReadinessState(str, Enum):
@@ -169,6 +172,14 @@ def _inspect_index_uncached(index_path: Path) -> Optional[RepositoryReadinessSta
             ).fetchone()
             if not count or int(count[0]) == 0:
                 return RepositoryReadinessState.INDEX_EMPTY
+            # CHUNKERSAFE Lane A: a half-rebuilt or mixed-scheme code_chunks table
+            # passes the table-presence check but is not query-safe. Report a
+            # non-ready state so the guard trip is visible at the readiness surface.
+            scheme_status, _marker, _target = evaluate_chunk_scheme(conn)
+            if scheme_status == "rebuilding":
+                return RepositoryReadinessState.INDEX_REBUILDING
+            if scheme_status in ("mismatch", "missing_marker"):
+                return RepositoryReadinessState.SCHEME_MISMATCH
     except sqlite3.DatabaseError:
         return RepositoryReadinessState.CORRUPT_SQLITE
     return None
@@ -264,6 +275,18 @@ class ReadinessClassifier:
             elif db_state == RepositoryReadinessState.MISSING_SCHEMA:
                 state = RepositoryReadinessState.MISSING_SCHEMA
                 remediation = "Run reindex to quarantine the incomplete schema and rebuild it."
+            elif db_state == RepositoryReadinessState.INDEX_REBUILDING:
+                state = RepositoryReadinessState.INDEX_REBUILDING
+                remediation = (
+                    "A chunk-scheme rebuild is in progress; wait for it to finalize "
+                    "or resume reindex before querying code chunks."
+                )
+            elif db_state == RepositoryReadinessState.SCHEME_MISMATCH:
+                state = RepositoryReadinessState.SCHEME_MISMATCH
+                remediation = (
+                    "The chunk-identity scheme is incompatible with the installed "
+                    "chunker; run reindex to rebuild the index under the current scheme."
+                )
             elif staleness_reason in {"index_publication_pending", "partial_index_failure"}:
                 state = RepositoryReadinessState.MISSING_PROVENANCE
                 remediation = "Run reindex to quarantine the interrupted generation and rebuild it."

--- a/mcp_server/indexing/incremental_indexer.py
+++ b/mcp_server/indexing/incremental_indexer.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 from ..core.path_resolver import PathResolver
 from ..core.repo_context import RepoContext
 from ..dispatcher.dispatcher_enhanced import EnhancedDispatcher
-from ..storage.sqlite_store import SQLiteStore
+from ..storage.sqlite_store import SQLiteStore, assert_chunk_scheme_readable
 from ..storage.two_phase import two_phase_commit
 from ..utils.subprocess_env import get_full_env
 from .change_detector import FileChange
@@ -95,6 +95,9 @@ class IncrementalIndexer:
         repo_id = self._get_repository_id()
 
         with self.store._get_connection() as conn:
+            # CHUNKERSAFE Lane A: refuse to hand back chunk ids read across an
+            # incompatible/rebuilding code_chunks scheme (fail closed).
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 "SELECT id FROM files WHERE relative_path = ? AND repository_id = ?",
                 (relative_path, repo_id),

--- a/mcp_server/indexing/incremental_indexer.py
+++ b/mcp_server/indexing/incremental_indexer.py
@@ -29,6 +29,18 @@ from .lock_registry import lock_registry
 logger = logging.getLogger(__name__)
 
 
+def _escape_like(text: str) -> str:
+    """Escape SQL LIKE metacharacters so a literal chunk_id matches only itself.
+
+    Backslash is the ESCAPE char (see ``LIKE ? ESCAPE '\\'`` below), so it must be
+    escaped first; then the ``%`` and ``_`` wildcards are neutralised. Under v4's
+    collision-free ids a ``chunk_id`` may legitimately contain ``%``/``_``, which
+    would otherwise cause a ``chunk_id LIKE '<id>:part:%'`` query to mis-match
+    unrelated rows.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 @dataclass
 class IncrementalStats:
     """Statistics for incremental update operation."""
@@ -106,8 +118,10 @@ class IncrementalIndexer:
             if not chunk_ids:
                 return []
 
-            like_clauses = " OR ".join(["chunk_id LIKE ?"] * len(chunk_ids))
-            params = [f"{chunk_id}:part:%" for chunk_id in chunk_ids]
+            like_clauses = " OR ".join(
+                ["chunk_id LIKE ? ESCAPE '\\'"] * len(chunk_ids)
+            )
+            params = [f"{_escape_like(chunk_id)}:part:%" for chunk_id in chunk_ids]
             cursor = conn.execute(
                 f"SELECT chunk_id FROM semantic_points WHERE {like_clauses}",
                 params,

--- a/mcp_server/indexing/summarization.py
+++ b/mcp_server/indexing/summarization.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 import mcp.types as types
 
 from ..setup.semantic_preflight import EnrichmentModelResolution, resolve_enrichment_model
-from ..storage.sqlite_store import SQLiteStore
+from ..storage.sqlite_store import SQLiteStore, assert_chunk_scheme_readable
 
 logger = logging.getLogger(__name__)
 
@@ -1077,6 +1077,8 @@ class ComprehensiveChunkWriter(FileBatchSummarizer):
             Path(path).resolve(strict=False).as_posix() for path in (target_paths or []) if path
         }
         with sqlite3.connect(self.db_path) as conn:
+            # Fail closed on scheme-dependent reads (CHUNKERSAFE Lane A).
+            assert_chunk_scheme_readable(conn)
             where_clauses = ["cs.chunk_hash IS NULL"]
             params: list[Any] = []
             if normalized_paths:
@@ -1106,6 +1108,8 @@ class ComprehensiveChunkWriter(FileBatchSummarizer):
             Path(path).resolve(strict=False).as_posix() for path in (target_paths or []) if path
         }
         with sqlite3.connect(self.db_path) as conn:
+            # Fail closed on scheme-dependent reads (CHUNKERSAFE Lane A).
+            assert_chunk_scheme_readable(conn)
             where_clauses = ["cs.chunk_hash IS NULL"]
             params: list[Any] = []
             if normalized_paths:

--- a/mcp_server/storage/git_index_manager.py
+++ b/mcp_server/storage/git_index_manager.py
@@ -57,6 +57,12 @@ _RECOVERABLE_REBUILD_STATES = frozenset(
         RepositoryReadinessState.CORRUPT_SQLITE,
         RepositoryReadinessState.MISSING_SCHEMA,
         RepositoryReadinessState.MISSING_PROVENANCE,
+        # CHUNKERSAFE Lane A: the staged full rebuild builds a fresh stage DB
+        # (empty -> current scheme stamped on first write -> os.replace), which
+        # naturally yields a clean single-scheme index. Allow it to run for a
+        # scheme-mismatched or interrupted-rebuild index so recovery is possible.
+        RepositoryReadinessState.SCHEME_MISMATCH,
+        RepositoryReadinessState.INDEX_REBUILDING,
     }
 )
 _QUARANTINE_REBUILD_STATES = frozenset(
@@ -64,6 +70,10 @@ _QUARANTINE_REBUILD_STATES = frozenset(
         RepositoryReadinessState.CORRUPT_SQLITE,
         RepositoryReadinessState.MISSING_SCHEMA,
         RepositoryReadinessState.MISSING_PROVENANCE,
+        # Preserve the pre-rebuild bytes of a scheme-mismatched / half-rebuilt
+        # index for forensics before the atomic os.replace overwrites it.
+        RepositoryReadinessState.SCHEME_MISMATCH,
+        RepositoryReadinessState.INDEX_REBUILDING,
     }
 )
 

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -12,7 +12,7 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from ..core.errors import TransientArtifactError
 from ..core.path_resolver import PathResolver
@@ -134,6 +134,166 @@ def classify_sqlite_storage_failure(error: BaseException) -> Optional[Dict[str, 
             "readonly": True,
         }
     return None
+
+
+# ---------------------------------------------------------------------------
+# Chunk identity-scheme guard (CHUNKERSAFE Lane A)
+#
+# ``code_chunks`` rows (and the ``chunk_summaries`` / ``semantic_points`` /
+# remote Qdrant vectors keyed off their ids) are only coherent within a single
+# chunk-identity scheme.  Upstream ``treesitter-chunker`` may change the id
+# algorithm across a major (issue #76 / v4), which silently corrupts a mixed
+# index if un-reindexed rows from an older scheme survive.  These helpers persist
+# a per-DB scheme marker in ``index_config`` and provide the single fail-closed
+# check that every writer, deleter, and scheme-dependent reader routes through.
+# ---------------------------------------------------------------------------
+
+#: Legacy stable-id algorithm name, kept coherent with the hardcoded
+#: ``chunk_identity_algorithm`` in ``manifest_v2`` / ``artifact_upload`` and with
+#: the semantic-profile ``chunker_version`` contract.  The chunk-id algorithm was
+#: stable across chunker package majors 1-3, so pre-v4 chunkers map to this.
+LEGACY_CHUNK_ID_SCHEME = "treesitter_chunk_id_v1"
+
+#: ``index_config`` keys for the persisted scheme markers.
+CHUNK_SCHEME_MARKER_KEY = "chunk_identity_scheme"
+CHUNK_IDENTITY_ALGORITHM_KEY = "chunk_identity_algorithm"
+CHUNK_SCHEME_REBUILD_KEY = "chunk_scheme_rebuild_target"
+
+#: ``code_chunks.chunk_type`` value used for synthetic history/document rows that
+#: are NOT produced by the tree-sitter chunker and must survive a rebuild.
+PRESERVED_CHUNK_TYPE = "document"
+
+_SCHEME_READ_BLOCKING = frozenset({"mismatch", "missing_marker", "rebuilding"})
+_SCHEME_WRITE_BLOCKING = frozenset({"mismatch", "missing_marker"})
+
+
+class ChunkSchemeMismatchError(RuntimeError):
+    """Raised when a ``code_chunks`` operation would cross an id-scheme boundary.
+
+    A typed, actionable error: refusing the operation is the fail-closed behavior
+    that prevents a mixed-scheme (silently corrupt) index.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        expected: Optional[str] = None,
+        found: Optional[str] = None,
+        state: Optional[str] = None,
+        remediation: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.expected = expected
+        self.found = found
+        self.state = state
+        self.remediation = remediation or (
+            "Run an atomic chunk-scheme rebuild (reindex) before reading or writing "
+            "code chunks for this repository."
+        )
+
+
+def _chunker_major_version(chunker_module: Any) -> Optional[int]:
+    version = getattr(chunker_module, "__version__", None)
+    if not version:
+        try:
+            import importlib.metadata as _md
+
+            version = _md.version("treesitter-chunker")
+        except Exception:
+            version = None
+    if not version:
+        return None
+    match = re.match(r"\s*v?(\d+)", str(version))
+    return int(match.group(1)) if match else None
+
+
+def current_chunk_id_scheme() -> str:
+    """Return the id-scheme of the installed chunker.
+
+    Reuses the upstream identity contract: an explicit ``CHUNK_ID_SCHEME``
+    attribute wins; otherwise derive from the package major, staying coherent
+    with the legacy ``treesitter_chunk_id_v1`` algorithm for pre-v4 chunkers and
+    only diverging to ``treesitter_chunk_id_v{major}`` once a new major (>=4)
+    ships without advertising the attribute.  When the chunker cannot be imported
+    at all, default to the legacy scheme.
+    """
+    try:
+        import chunker
+    except Exception:
+        return LEGACY_CHUNK_ID_SCHEME
+    scheme = getattr(chunker, "CHUNK_ID_SCHEME", None)
+    if isinstance(scheme, str) and scheme.strip():
+        return scheme.strip()
+    major = _chunker_major_version(chunker)
+    if major is None or major < 4:
+        return LEGACY_CHUNK_ID_SCHEME
+    return f"treesitter_chunk_id_v{major}"
+
+
+def _scheme_read_config_value(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    try:
+        row = conn.execute(
+            "SELECT config_value FROM index_config WHERE config_key = ?", (key,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if row is None:
+        return None
+    return row[0]
+
+
+def _has_chunker_rows(conn: sqlite3.Connection) -> bool:
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM code_chunks WHERE chunk_type != ? LIMIT 1",
+            (PRESERVED_CHUNK_TYPE,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return row is not None
+
+
+def evaluate_chunk_scheme(
+    conn: sqlite3.Connection, target_scheme: Optional[str] = None
+) -> Tuple[str, Optional[str], str]:
+    """Classify the chunk-scheme compatibility of ``conn`` against ``target_scheme``.
+
+    Returns ``(status, marker, target)`` where ``status`` is one of:
+
+    - ``"compatible"`` - marker present and equal to target.
+    - ``"empty"``       - no marker and no chunker rows; safe to stamp on first build.
+    - ``"missing_marker"`` - no marker but chunker rows present (a legacy/unmarked
+      index of unknown scheme): treated as incompatible, fail closed.
+    - ``"mismatch"``    - marker present but different from target.
+    - ``"rebuilding"``  - an atomic rebuild is in progress and unfinalized.
+    """
+    target = target_scheme or current_chunk_id_scheme()
+    rebuild_target = _scheme_read_config_value(conn, CHUNK_SCHEME_REBUILD_KEY)
+    if rebuild_target is not None:
+        return ("rebuilding", rebuild_target, target)
+    marker = _scheme_read_config_value(conn, CHUNK_SCHEME_MARKER_KEY)
+    if marker is not None:
+        return ("compatible" if marker == target else "mismatch", marker, target)
+    if _has_chunker_rows(conn):
+        return ("missing_marker", None, target)
+    return ("empty", None, target)
+
+
+def assert_chunk_scheme_readable(
+    conn: sqlite3.Connection, target_scheme: Optional[str] = None
+) -> None:
+    """Fail closed on scheme-dependent reads over an incompatible/rebuilding index."""
+    status, marker, target = evaluate_chunk_scheme(conn, target_scheme)
+    if status in _SCHEME_READ_BLOCKING:
+        raise ChunkSchemeMismatchError(
+            f"code_chunks scheme is {status!r} (index marker={marker!r}, current "
+            f"scheme={target!r}); refusing scheme-dependent read until an atomic "
+            "rebuild completes.",
+            expected=target,
+            found=marker,
+            state=status,
+        )
 
 
 class SQLiteStore:
@@ -1077,6 +1237,281 @@ class SQLiteStore:
             return cursor.fetchone()[0]
 
     # Code Chunk operations
+    # ------------------------------------------------------------------
+    # Chunk identity-scheme marker + central guard (CHUNKERSAFE Lane A)
+    # ------------------------------------------------------------------
+    def _current_scheme(self) -> str:
+        return current_chunk_id_scheme()
+
+    def _set_config(
+        self,
+        conn: sqlite3.Connection,
+        key: str,
+        value: str,
+        description: Optional[str] = None,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO index_config (config_key, config_value, description) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT(config_key) DO UPDATE SET "
+            "config_value=excluded.config_value, "
+            "description=COALESCE(excluded.description, index_config.description), "
+            "updated_at=CURRENT_TIMESTAMP",
+            (key, value, description),
+        )
+
+    def _delete_config(self, conn: sqlite3.Connection, key: str) -> None:
+        conn.execute("DELETE FROM index_config WHERE config_key = ?", (key,))
+
+    def get_chunk_scheme_marker(self) -> Optional[str]:
+        """Return the persisted chunk-identity-scheme marker, or None if unmarked."""
+        with self._get_connection() as conn:
+            return _scheme_read_config_value(conn, CHUNK_SCHEME_MARKER_KEY)
+
+    def get_chunk_scheme_status(self) -> Tuple[str, Optional[str], str]:
+        """Return ``(status, marker, target)`` for the current scheme (see
+        :func:`evaluate_chunk_scheme`)."""
+        with self._get_connection() as conn:
+            return evaluate_chunk_scheme(conn, self._current_scheme())
+
+    def _stamp_scheme(self, conn: sqlite3.Connection, target: str) -> None:
+        """Persist the scheme marker, keeping it coherent with the manifest
+        ``chunk_identity_algorithm`` fingerprint."""
+        self._set_config(
+            conn,
+            CHUNK_SCHEME_MARKER_KEY,
+            target,
+            "Chunk identity scheme stamped on first build (CHUNKERSAFE)",
+        )
+        self._set_config(
+            conn,
+            CHUNK_IDENTITY_ALGORITHM_KEY,
+            target,
+            "Chunk identity algorithm reconciled with manifest_v2 contract",
+        )
+
+    def _assert_chunk_scheme_writable(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        chunk_type: str = "code",
+        target: Optional[str] = None,
+    ) -> None:
+        """Central write choke point: refuse chunker writes across a scheme
+        boundary; stamp the scheme on the first write into an empty index.
+
+        Synthetic ``document`` rows (history docs) are not chunker-derived and
+        bypass the guard entirely.
+        """
+        if chunk_type == PRESERVED_CHUNK_TYPE:
+            return
+        self._require_writable()
+        target = target or self._current_scheme()
+        status, marker, target = evaluate_chunk_scheme(conn, target)
+        if status in _SCHEME_WRITE_BLOCKING:
+            raise ChunkSchemeMismatchError(
+                f"code_chunks scheme is {status!r} (index marker={marker!r}, "
+                f"current scheme={target!r}); refusing chunker write until an "
+                "atomic rebuild completes.",
+                expected=target,
+                found=marker,
+                state=status,
+            )
+        if status == "empty":
+            self._stamp_scheme(conn, target)
+
+    def _assert_chunk_scheme_deletable(
+        self, conn: sqlite3.Connection, *, target: Optional[str] = None
+    ) -> None:
+        """Refuse scheme-dependent deletes over an incompatible index (a delete of
+        old-scheme rows before a mismatched store would destroy the coherent
+        index)."""
+        target = target or self._current_scheme()
+        status, marker, target = evaluate_chunk_scheme(conn, target)
+        if status in _SCHEME_WRITE_BLOCKING:
+            raise ChunkSchemeMismatchError(
+                f"code_chunks scheme is {status!r} (index marker={marker!r}, "
+                f"current scheme={target!r}); refusing chunk delete until an "
+                "atomic rebuild completes.",
+                expected=target,
+                found=marker,
+                state=status,
+            )
+
+    def _collect_stale_chunk_artifacts(
+        self, conn: sqlite3.Connection, profile_id: Optional[str]
+    ) -> Dict[str, Any]:
+        """Gather chunker-derived ids (preserving synthetic history/document rows)
+        across code_chunks, chunk_summaries, and semantic_points, so the rebuild
+        can delete locally and hand stale remote-vector ids to a semantic indexer.
+        """
+        preserved = [
+            row[0]
+            for row in conn.execute(
+                "SELECT chunk_id FROM code_chunks WHERE chunk_type = ?",
+                (PRESERVED_CHUNK_TYPE,),
+            ).fetchall()
+        ]
+
+        def _is_preserved(identifier: Optional[str]) -> bool:
+            if identifier is None:
+                return False
+            if identifier.startswith("history:"):
+                return True
+            for base in preserved:
+                if identifier == base or identifier.startswith(f"{base}:"):
+                    return True
+            return False
+
+        stale_chunk_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT chunk_id FROM code_chunks WHERE chunk_type != ?",
+                (PRESERVED_CHUNK_TYPE,),
+            ).fetchall()
+        ]
+
+        stale_summary_hashes = [
+            row[0]
+            for row in conn.execute("SELECT chunk_hash FROM chunk_summaries").fetchall()
+            if not _is_preserved(row[0])
+        ]
+
+        if profile_id is None:
+            point_rows = conn.execute(
+                "SELECT profile_id, chunk_id, point_id, collection FROM semantic_points"
+            ).fetchall()
+        else:
+            point_rows = conn.execute(
+                "SELECT profile_id, chunk_id, point_id, collection FROM semantic_points "
+                "WHERE profile_id = ?",
+                (profile_id,),
+            ).fetchall()
+        stale_points = [
+            {
+                "profile_id": row[0],
+                "chunk_id": row[1],
+                "point_id": row[2],
+                "collection": row[3],
+            }
+            for row in point_rows
+            if not _is_preserved(row[1])
+        ]
+        return {
+            "chunk_ids": stale_chunk_ids,
+            "summary_hashes": stale_summary_hashes,
+            "points": stale_points,
+        }
+
+    def begin_chunk_scheme_rebuild(
+        self, target_scheme: Optional[str] = None, *, profile_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Phase 1 of an atomic/resumable rebuild.
+
+        In a single transaction: collect the stale remote-vector ids, delete the
+        chunker-derived rows from ``code_chunks`` / ``chunk_summaries`` /
+        ``semantic_points`` (PRESERVING synthetic history/document rows), and mark
+        the DB ``rebuilding`` (which trips the guard/readiness).  The scheme marker
+        is NOT flipped here, so a crash after this commit leaves a blocked,
+        resumable state - never a half-populated "ready" index.
+
+        Returns the stale ids so a caller holding a semantic indexer can delete the
+        matching remote Qdrant vectors.
+        """
+        self._require_writable()
+        target = target_scheme or self._current_scheme()
+        with self._get_connection() as conn:
+            stale = self._collect_stale_chunk_artifacts(conn, profile_id)
+            self._set_config(
+                conn,
+                CHUNK_SCHEME_REBUILD_KEY,
+                target,
+                "Chunk-scheme rebuild in progress (CHUNKERSAFE)",
+            )
+            self._delete_chunker_rows(conn, stale)
+        return {"target_scheme": target, "profile_id": profile_id, **stale}
+
+    def finalize_chunk_scheme_rebuild(
+        self, target_scheme: Optional[str] = None
+    ) -> None:
+        """Phase 2: flip the scheme marker to ``target`` and clear the rebuilding
+        flag, in one transaction, only after repopulation is complete."""
+        self._require_writable()
+        target = target_scheme or self._current_scheme()
+        with self._get_connection() as conn:
+            self._stamp_scheme(conn, target)
+            self._delete_config(conn, CHUNK_SCHEME_REBUILD_KEY)
+
+    def _delete_chunker_rows(
+        self, conn: sqlite3.Connection, stale: Dict[str, Any]
+    ) -> None:
+        conn.execute(
+            "DELETE FROM code_chunks WHERE chunk_type != ?", (PRESERVED_CHUNK_TYPE,)
+        )
+        summary_hashes = stale.get("summary_hashes") or []
+        for start in range(0, len(summary_hashes), 500):
+            batch = summary_hashes[start : start + 500]
+            placeholders = ",".join("?" * len(batch))
+            conn.execute(
+                f"DELETE FROM chunk_summaries WHERE chunk_hash IN ({placeholders})",
+                batch,
+            )
+        points = stale.get("points") or []
+        for start in range(0, len(points), 500):
+            batch = points[start : start + 500]
+            placeholders = ",".join("?" * len(batch))
+            params: List[Any] = []
+            for point in batch:
+                params.extend([point["profile_id"], point["chunk_id"]])
+            clause = " OR ".join(["(profile_id = ? AND chunk_id = ?)"] * len(batch))
+            conn.execute(f"DELETE FROM semantic_points WHERE {clause}", params)
+
+    def rebuild_chunk_scheme(
+        self,
+        target_scheme: Optional[str] = None,
+        *,
+        profile_id: Optional[str] = None,
+        repopulate: Optional[Callable[[sqlite3.Connection], None]] = None,
+    ) -> Dict[str, Any]:
+        """Atomic chunk-scheme rebuild (public operator entry point).
+
+        Invalidates every chunker-derived row across ``code_chunks``,
+        ``chunk_summaries`` and ``semantic_points`` (PRESERVING synthetic
+        history/document rows) and returns the stale remote-vector ids for Qdrant
+        cleanup.
+
+        Atomicity:
+
+        - With ``repopulate`` supplied, invalidation, repopulation, and the scheme
+          marker flip all run in ONE transaction.  If ``repopulate`` raises, the
+          transaction rolls back and the old, coherent index survives untouched -
+          never a half-populated "ready" DB.
+        - Without ``repopulate``, this commits a blocked ``rebuilding`` state
+          (readiness reports non-``ready``, reads/writes fail closed) whose scheme
+          marker is only flipped by a later
+          :meth:`finalize_chunk_scheme_rebuild` - a crash in between is resumable.
+        """
+        self._require_writable()
+        target = target_scheme or self._current_scheme()
+        if repopulate is None:
+            return self.begin_chunk_scheme_rebuild(target, profile_id=profile_id)
+
+        with self._get_connection() as conn:
+            stale = self._collect_stale_chunk_artifacts(conn, profile_id)
+            self._set_config(
+                conn,
+                CHUNK_SCHEME_REBUILD_KEY,
+                target,
+                "Chunk-scheme rebuild in progress (CHUNKERSAFE)",
+            )
+            self._delete_chunker_rows(conn, stale)
+            # Repopulation runs inside the same transaction; a failure here rolls
+            # the whole rebuild back to the prior coherent index.
+            repopulate(conn)
+            self._stamp_scheme(conn, target)
+            self._delete_config(conn, CHUNK_SCHEME_REBUILD_KEY)
+        return {"target_scheme": target, "profile_id": profile_id, **stale}
+
     def store_chunk(
         self,
         file_id: int,
@@ -1104,6 +1539,7 @@ class SQLiteStore:
         """Store a code chunk with stable IDs and token counting."""
         serialized_metadata = _merge_chunk_source_metadata(metadata, content, line_start)
         with self._get_connection() as conn:
+            self._assert_chunk_scheme_writable(conn, chunk_type=chunk_type)
             cursor = conn.execute(
                 """INSERT INTO code_chunks
                    (file_id, symbol_id, content, content_start, content_end,
@@ -1213,21 +1649,39 @@ class SQLiteStore:
             return [dict(row) for row in cursor.fetchall()]
 
     def update_chunk_token_count(
-        self, chunk_id: str, token_count: int, token_model: str = "cl100k_base"
+        self,
+        chunk_id: str,
+        token_count: int,
+        token_model: str = "cl100k_base",
+        *,
+        file_id: Optional[int] = None,
     ) -> bool:
-        """Update token count for a chunk."""
+        """Update token count for a chunk.
+
+        ``chunk_id`` is only unique per ``(file_id, chunk_id)``; pass ``file_id``
+        to scope the update so a chunk id shared across files cannot collide.
+        """
         with self._get_connection() as conn:
-            cursor = conn.execute(
-                """UPDATE code_chunks
-                   SET token_count = ?, token_model = ?, updated_at = CURRENT_TIMESTAMP
-                   WHERE chunk_id = ?""",
-                (token_count, token_model, chunk_id),
-            )
+            if file_id is not None:
+                cursor = conn.execute(
+                    """UPDATE code_chunks
+                       SET token_count = ?, token_model = ?, updated_at = CURRENT_TIMESTAMP
+                       WHERE chunk_id = ? AND file_id = ?""",
+                    (token_count, token_model, chunk_id, file_id),
+                )
+            else:
+                cursor = conn.execute(
+                    """UPDATE code_chunks
+                       SET token_count = ?, token_model = ?, updated_at = CURRENT_TIMESTAMP
+                       WHERE chunk_id = ?""",
+                    (token_count, token_model, chunk_id),
+                )
             return cursor.rowcount > 0
 
     def delete_chunks_for_file(self, file_id: int) -> int:
         """Delete all chunks for a file. Returns number of chunks deleted."""
         with self._get_connection() as conn:
+            self._assert_chunk_scheme_deletable(conn)
             cursor = conn.execute("DELETE FROM code_chunks WHERE file_id = ?", (file_id,))
             return cursor.rowcount
 
@@ -1315,6 +1769,12 @@ class SQLiteStore:
             return 0
 
         with self._get_connection() as conn:
+            # Central guard: any non-document (chunker-derived) row in the batch
+            # must satisfy the scheme check before any write; stamps an empty index.
+            if any(
+                chunk.get("chunk_type", "code") != PRESERVED_CHUNK_TYPE for chunk in chunks
+            ):
+                self._assert_chunk_scheme_writable(conn, chunk_type="code")
             count = 0
             for chunk in chunks:
                 try:

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -5,6 +5,7 @@ This module provides a local storage implementation using SQLite with FTS5
 for efficient full-text search capabilities.
 """
 
+import functools
 import json
 import logging
 import re
@@ -167,6 +168,19 @@ _SCHEME_READ_BLOCKING = frozenset({"mismatch", "missing_marker", "rebuilding"})
 _SCHEME_WRITE_BLOCKING = frozenset({"mismatch", "missing_marker"})
 
 
+def _escape_like(text: str) -> str:
+    """Escape SQL LIKE metacharacters so a literal id matches only itself.
+
+    Canonical home for the helper (this module is imported by the indexing layer,
+    not vice-versa).  Backslash is the ``ESCAPE`` char (see ``LIKE ? ESCAPE '\\'``),
+    so it must be escaped first; then the ``%``/``_`` wildcards are neutralised.
+    Under collision-free (v4) ids a ``chunk_id`` may legitimately contain ``%``/``_``,
+    which would otherwise make a ``chunk_id LIKE '<id>:part:%'`` query mis-match
+    unrelated rows.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class ChunkSchemeMismatchError(RuntimeError):
     """Raised when a ``code_chunks`` operation would cross an id-scheme boundary.
 
@@ -208,6 +222,7 @@ def _chunker_major_version(chunker_module: Any) -> Optional[int]:
     return int(match.group(1)) if match else None
 
 
+@functools.lru_cache(maxsize=1)
 def current_chunk_id_scheme() -> str:
     """Return the id-scheme of the installed chunker.
 
@@ -217,6 +232,10 @@ def current_chunk_id_scheme() -> str:
     only diverging to ``treesitter_chunk_id_v{major}`` once a new major (>=4)
     ships without advertising the attribute.  When the chunker cannot be imported
     at all, default to the legacy scheme.
+
+    Result is cached for the process (``lru_cache``): the installed chunker
+    version cannot change without a restart, so this keeps the per-write hot path
+    off the ``importlib.metadata`` dist-info scan (I6).
     """
     try:
         import chunker
@@ -231,13 +250,29 @@ def current_chunk_id_scheme() -> str:
     return f"treesitter_chunk_id_v{major}"
 
 
+def _is_missing_schema_error(error: sqlite3.OperationalError) -> bool:
+    """True only for a structural "schema not present" error - a missing table or
+    column (a not-yet-created / older-schema index).
+
+    Every OTHER ``OperationalError`` - notably "database is locked"/"is busy"
+    under write contention - must NOT be swallowed: misreading a locked, *marked*
+    DB as absent would let the caller reclassify it as ``empty`` and silently
+    re-stamp the marker with the new scheme (I1, silent mixed-scheme corruption).
+    Those propagate so the caller fails loud instead of corrupting the marker.
+    """
+    message = str(error).lower()
+    return "no such table" in message or "no such column" in message
+
+
 def _scheme_read_config_value(conn: sqlite3.Connection, key: str) -> Optional[str]:
     try:
         row = conn.execute(
             "SELECT config_value FROM index_config WHERE config_key = ?", (key,)
         ).fetchone()
-    except sqlite3.OperationalError:
-        return None
+    except sqlite3.OperationalError as error:
+        if _is_missing_schema_error(error):
+            return None
+        raise
     if row is None:
         return None
     return row[0]
@@ -249,8 +284,10 @@ def _has_chunker_rows(conn: sqlite3.Connection) -> bool:
             "SELECT 1 FROM code_chunks WHERE chunk_type != ? LIMIT 1",
             (PRESERVED_CHUNK_TYPE,),
         ).fetchone()
-    except sqlite3.OperationalError:
-        return False
+    except sqlite3.OperationalError as error:
+        if _is_missing_schema_error(error):
+            return False
+        raise
     return row is not None
 
 
@@ -262,9 +299,15 @@ def evaluate_chunk_scheme(
     Returns ``(status, marker, target)`` where ``status`` is one of:
 
     - ``"compatible"`` - marker present and equal to target.
+    - ``"compatible_legacy"`` - no marker but chunker rows present AND the current
+      target is the legacy ``treesitter_chunk_id_v1`` scheme.  The chunk-id
+      algorithm was stable across chunker majors 1-3, so an existing unmarked
+      (v3-built) index genuinely IS v1: treat it as compatible and auto-stamp v1
+      on the next write, rather than bricking every legacy index (B1).
     - ``"empty"``       - no marker and no chunker rows; safe to stamp on first build.
-    - ``"missing_marker"`` - no marker but chunker rows present (a legacy/unmarked
-      index of unknown scheme): treated as incompatible, fail closed.
+    - ``"missing_marker"`` - no marker but chunker rows present AND the current
+      target is a *different* (>=v4) scheme: a real scheme change over an unmarked
+      index, treated as incompatible - fail closed.
     - ``"mismatch"``    - marker present but different from target.
     - ``"rebuilding"``  - an atomic rebuild is in progress and unfinalized.
     """
@@ -276,6 +319,8 @@ def evaluate_chunk_scheme(
     if marker is not None:
         return ("compatible" if marker == target else "mismatch", marker, target)
     if _has_chunker_rows(conn):
+        if target == LEGACY_CHUNK_ID_SCHEME:
+            return ("compatible_legacy", None, target)
         return ("missing_marker", None, target)
     return ("empty", None, target)
 
@@ -323,6 +368,7 @@ class SQLiteStore:
         self._init_database()
         self._run_migrations()
         self._ensure_semantic_points_table()
+        self._ensure_pending_vector_deletions_table()
         self._ensure_chunk_summary_audit_columns()
 
     def _require_writable(self) -> None:
@@ -373,6 +419,95 @@ class SQLiteStore:
                 CREATE INDEX IF NOT EXISTS idx_semantic_points_collection
                     ON semantic_points(collection);
                 """)
+
+    def _ensure_pending_vector_deletions_table(self) -> None:
+        """Durable crash-ledger of remote (Qdrant) vector ids awaiting deletion.
+
+        A scheme rebuild deletes local ``semantic_points`` rows in-transaction but
+        the matching *remote* vectors are cleaned up by the caller AFTER the
+        commit returns.  A crash in that window would orphan the remote vectors
+        forever, because the only record of them was the in-memory return value.
+        Persisting the stale ids here (in the same transaction as the local
+        delete) means the ledger survives a crash and a recovery pass can finish
+        the remote cleanup (I4).
+        """
+        with self._get_connection() as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS pending_vector_deletions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    profile_id TEXT NOT NULL,
+                    chunk_id TEXT NOT NULL,
+                    point_id INTEGER,
+                    collection TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_pending_vector_deletions_profile
+                    ON pending_vector_deletions(profile_id);
+                """)
+
+    def _record_pending_vector_deletions(
+        self, conn: sqlite3.Connection, points: List[Dict[str, Any]]
+    ) -> None:
+        """Persist stale remote-vector ids to the crash-ledger inside ``conn``'s
+        transaction, so they survive a crash before the caller's remote cleanup."""
+        if not points:
+            return
+        conn.executemany(
+            "INSERT INTO pending_vector_deletions "
+            "(profile_id, chunk_id, point_id, collection) VALUES (?, ?, ?, ?)",
+            [
+                (
+                    point.get("profile_id"),
+                    point.get("chunk_id"),
+                    point.get("point_id"),
+                    point.get("collection"),
+                )
+                for point in points
+            ],
+        )
+
+    def get_pending_vector_deletions(self) -> List[Dict[str, Any]]:
+        """Return the durable crash-ledger of remote-vector ids awaiting cleanup."""
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT id, profile_id, chunk_id, point_id, collection "
+                "FROM pending_vector_deletions ORDER BY id"
+            ).fetchall()
+        return [
+            {
+                "id": row[0],
+                "profile_id": row[1],
+                "chunk_id": row[2],
+                "point_id": row[3],
+                "collection": row[4],
+            }
+            for row in rows
+        ]
+
+    def clear_pending_vector_deletions(
+        self, ledger_ids: Optional[List[int]] = None
+    ) -> int:
+        """Clear ledger rows once their remote vectors are deleted.
+
+        With ``ledger_ids`` clears exactly those rows (the ids from
+        :meth:`get_pending_vector_deletions`); with ``None`` clears the whole
+        ledger.  Returns the number of rows removed.
+        """
+        with self._get_connection() as conn:
+            if ledger_ids is None:
+                cursor = conn.execute("DELETE FROM pending_vector_deletions")
+                return cursor.rowcount
+            removed = 0
+            for start in range(0, len(ledger_ids), 500):
+                batch = ledger_ids[start : start + 500]
+                placeholders = ",".join("?" * len(batch))
+                cursor = conn.execute(
+                    f"DELETE FROM pending_vector_deletions WHERE id IN ({placeholders})",
+                    batch,
+                )
+                removed += cursor.rowcount
+            return removed
 
     def _ensure_chunk_summary_audit_columns(self) -> None:
         """Ensure additive chunk summary audit columns exist."""
@@ -1308,6 +1443,24 @@ class SQLiteStore:
         self._require_writable()
         target = target or self._current_scheme()
         status, marker, target = evaluate_chunk_scheme(conn, target)
+        if status == "rebuilding":
+            # A rebuild is in-flight: ``marker`` is the persisted rebuild target.
+            # ONLY the explicitly-scoped rebuild writer (whose target equals that
+            # rebuild target) may commit rows during the begin->finalize window.
+            # An ordinary writer (target == current runtime scheme) that does not
+            # match would otherwise commit old-scheme rows that finalize then
+            # stamps as the new scheme - the exact mixed-scheme corruption the
+            # guard exists to prevent.
+            if target != marker:
+                raise ChunkSchemeMismatchError(
+                    f"code_chunks is rebuilding to {marker!r}; refusing a write "
+                    f"scoped to {target!r}. Only the rebuild writer (scheme_target="
+                    f"{marker!r}) may write until the rebuild is finalized.",
+                    expected=marker,
+                    found=target,
+                    state=status,
+                )
+            return
         if status in _SCHEME_WRITE_BLOCKING:
             raise ChunkSchemeMismatchError(
                 f"code_chunks scheme is {status!r} (index marker={marker!r}, "
@@ -1317,7 +1470,10 @@ class SQLiteStore:
                 found=marker,
                 state=status,
             )
-        if status == "empty":
+        if status in ("empty", "compatible_legacy"):
+            # First write into an empty index, or the first write into a legacy
+            # unmarked (v3-built == v1) index: durably stamp the scheme so the
+            # marker becomes authoritative (B1 auto-stamp).
             self._stamp_scheme(conn, target)
 
     def _assert_chunk_scheme_deletable(
@@ -1377,16 +1533,16 @@ class SQLiteStore:
             if not _is_preserved(row[0])
         ]
 
-        if profile_id is None:
-            point_rows = conn.execute(
-                "SELECT profile_id, chunk_id, point_id, collection FROM semantic_points"
-            ).fetchall()
-        else:
-            point_rows = conn.execute(
-                "SELECT profile_id, chunk_id, point_id, collection FROM semantic_points "
-                "WHERE profile_id = ?",
-                (profile_id,),
-            ).fetchall()
+        # The scheme marker is DB-wide, so a rebuild must invalidate EVERY
+        # profile's stale semantic-point mappings - not just ``profile_id``.
+        # Restricting to one profile would leave other profiles' old-scheme
+        # mappings (and their orphaned remote vectors) behind.  ``profile_id`` is
+        # retained only as documentation of the caller's primary profile; the
+        # per-point ``profile_id``/``collection`` is returned so remote cleanup can
+        # target the right collection for each.
+        point_rows = conn.execute(
+            "SELECT profile_id, chunk_id, point_id, collection FROM semantic_points"
+        ).fetchall()
         stale_points = [
             {
                 "profile_id": row[0],
@@ -1434,11 +1590,46 @@ class SQLiteStore:
     def finalize_chunk_scheme_rebuild(
         self, target_scheme: Optional[str] = None
     ) -> None:
-        """Phase 2: flip the scheme marker to ``target`` and clear the rebuilding
-        flag, in one transaction, only after repopulation is complete."""
+        """Phase 2: flip the scheme marker to the recorded rebuild target and clear
+        the rebuilding flag, in one transaction - but ONLY after validating that:
+
+        1. a rebuild is actually in progress (a recorded rebuild target exists);
+        2. the caller's ``target_scheme`` (if supplied) matches that recorded
+           target - never let a caller stamp a scheme the rebuild did not build;
+        3. repopulation actually happened (chunker rows are present) - refusing to
+           stamp an empty index as "ready", which would advertise a coherent index
+           over zero rows.
+
+        Without these checks, finalize is a no-op rubber stamp that can flip the
+        marker over an unpopulated (or wrong-scheme) DB.
+        """
         self._require_writable()
-        target = target_scheme or self._current_scheme()
         with self._get_connection() as conn:
+            recorded = _scheme_read_config_value(conn, CHUNK_SCHEME_REBUILD_KEY)
+            if recorded is None:
+                raise ChunkSchemeMismatchError(
+                    "finalize_chunk_scheme_rebuild called with no rebuild in "
+                    "progress (no recorded rebuild target).",
+                    state="not_rebuilding",
+                )
+            target = target_scheme or recorded
+            if target != recorded:
+                raise ChunkSchemeMismatchError(
+                    f"finalize target {target!r} does not match the recorded "
+                    f"rebuild target {recorded!r}; refusing to stamp a scheme the "
+                    "rebuild did not build.",
+                    expected=recorded,
+                    found=target,
+                    state="rebuild_target_mismatch",
+                )
+            if not _has_chunker_rows(conn):
+                raise ChunkSchemeMismatchError(
+                    f"refusing to finalize rebuild to {recorded!r}: no chunker rows "
+                    "were repopulated, so the index is empty. Repopulate before "
+                    "finalizing (or the old, coherent index is lost for nothing).",
+                    expected=recorded,
+                    state="rebuild_not_repopulated",
+                )
             self._stamp_scheme(conn, target)
             self._delete_config(conn, CHUNK_SCHEME_REBUILD_KEY)
 
@@ -1457,9 +1648,13 @@ class SQLiteStore:
                 batch,
             )
         points = stale.get("points") or []
+        # Persist the stale remote-vector ids to the durable crash-ledger BEFORE
+        # deleting their local mappings, in this same transaction: if the process
+        # dies before the caller cleans up remote Qdrant vectors, the ledger still
+        # names every orphan so recovery can finish the job (I4).
+        self._record_pending_vector_deletions(conn, points)
         for start in range(0, len(points), 500):
             batch = points[start : start + 500]
-            placeholders = ",".join("?" * len(batch))
             params: List[Any] = []
             for point in batch:
                 params.extend([point["profile_id"], point["chunk_id"]])
@@ -1535,11 +1730,22 @@ class SQLiteStore:
         depth: int = 0,
         chunk_index: int = 0,
         metadata: Optional[Dict] = None,
+        scheme_target: Optional[str] = None,
     ) -> int:
-        """Store a code chunk with stable IDs and token counting."""
+        """Store a code chunk with stable IDs and token counting.
+
+        ``scheme_target`` is the explicitly-scoped rebuild-writer escape hatch:
+        during a ``rebuilding`` window the guard only admits writes whose target
+        equals the persisted rebuild target, so a repopulation into a *different*
+        target scheme (e.g. a v4 rebuild running under a v1 runtime) must pass
+        ``scheme_target`` to identify itself as the rebuild writer.  Ordinary
+        callers leave it ``None`` (defaults to the current runtime scheme).
+        """
         serialized_metadata = _merge_chunk_source_metadata(metadata, content, line_start)
         with self._get_connection() as conn:
-            self._assert_chunk_scheme_writable(conn, chunk_type=chunk_type)
+            self._assert_chunk_scheme_writable(
+                conn, chunk_type=chunk_type, target=scheme_target
+            )
             cursor = conn.execute(
                 """INSERT INTO code_chunks
                    (file_id, symbol_id, content, content_start, content_end,
@@ -1606,6 +1812,7 @@ class SQLiteStore:
     def get_chunk_by_chunk_id(self, chunk_id: str, file_id: Optional[int] = None) -> Optional[Dict]:
         """Get chunk by chunk_id, optionally filtered by file_id."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             if file_id is not None:
                 cursor = conn.execute(
                     "SELECT * FROM code_chunks WHERE chunk_id = ? AND file_id = ?",
@@ -1619,6 +1826,7 @@ class SQLiteStore:
     def get_chunk_by_node_id(self, node_id: str, file_id: Optional[int] = None) -> Optional[Dict]:
         """Get chunk by node_id, optionally filtered by file_id."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             if file_id is not None:
                 cursor = conn.execute(
                     "SELECT * FROM code_chunks WHERE node_id = ? AND file_id = ?",
@@ -1632,6 +1840,7 @@ class SQLiteStore:
     def get_chunk_by_definition_id(self, definition_id: str) -> List[Dict]:
         """Get chunks by definition_id (may return multiple chunks)."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 "SELECT * FROM code_chunks WHERE definition_id = ?", (definition_id,)
             )
@@ -1640,6 +1849,7 @@ class SQLiteStore:
     def get_chunks_for_file(self, file_id: int) -> List[Dict]:
         """Get all chunks for a file, ordered by chunk_index."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 """SELECT * FROM code_chunks
                    WHERE file_id = ?
@@ -1662,6 +1872,10 @@ class SQLiteStore:
         to scope the update so a chunk id shared across files cannot collide.
         """
         with self._get_connection() as conn:
+            # Guard the chunker-derived write path: refuse a token-count update
+            # across a scheme boundary (cheap central check; also stamps a legacy
+            # unmarked index on first touch).
+            self._assert_chunk_scheme_writable(conn, chunk_type="code")
             if file_id is not None:
                 cursor = conn.execute(
                     """UPDATE code_chunks
@@ -1858,6 +2072,7 @@ class SQLiteStore:
     ) -> List[Dict[str, Any]]:
         """Return chunks whose stored source metadata matches the requested filters."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 """SELECT c.content, c.line_start, c.line_end, c.metadata,
                           COALESCE(f.path, f.relative_path, CAST(c.file_id AS TEXT)) AS file_path
@@ -2228,6 +2443,7 @@ class SQLiteStore:
             Dict with symbol, line_start, line_end, node_type or None
         """
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 """
                 SELECT cc.line_start, cc.line_end, cc.node_type, cc.content,
@@ -3118,11 +3334,15 @@ class SQLiteStore:
             if profile_id:
                 if source_chunk_ids:
                     like_clauses = " OR ".join(
-                        ["chunk_id = ? OR chunk_id LIKE ?"] * len(source_chunk_ids)
+                        ["chunk_id = ? OR chunk_id LIKE ? ESCAPE '\\'"]
+                        * len(source_chunk_ids)
                     )
                     params: List[Any] = [profile_id]
                     for chunk_id in source_chunk_ids:
-                        params.extend([chunk_id, f"{chunk_id}:part:%"])
+                        # Escape LIKE metacharacters: a collision-free (v4) chunk_id
+                        # may legitimately contain %/_ which would otherwise make the
+                        # ':part:%' sub-chunk match hit unrelated rows (I2).
+                        params.extend([chunk_id, f"{_escape_like(chunk_id)}:part:%"])
                     params.append(result["file_summary_chunk_id"])
                     vector_rows = conn.execute(
                         f"""SELECT chunk_id
@@ -3178,6 +3398,7 @@ class SQLiteStore:
     def get_missing_summaries(self, limit: int = 100) -> List[Dict[str, Any]]:
         """Find chunks that don't have summaries yet."""
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 """SELECT c.chunk_id, c.file_id, c.content_start, c.content_end, c.line_start, c.line_end, c.content, s.name as symbol
                    FROM code_chunks c
@@ -3281,6 +3502,7 @@ class SQLiteStore:
         ``symbol``, ``content``.
         """
         with self._get_connection() as conn:
+            assert_chunk_scheme_readable(conn)
             cursor = conn.execute(
                 """SELECT c.chunk_id, c.file_id, c.line_start, c.line_end,
                           c.content, s.name AS symbol, c.metadata

--- a/specs/phase-plans-v12.md
+++ b/specs/phase-plans-v12.md
@@ -6,17 +6,31 @@ This roadmap folds together two independent bodies of work:
 
 1. **A CRITICAL upstream dependency break + imminent major release (issue #76)** —
    `treesitter-chunker` is publishing **v4**, which redesigns
-   `chunk_id`/`node_id`/`definition_id` to be collision-free and deterministic and
-   may move import paths (interface consolidation) and re-pin the `tree_sitter`
+   `chunk_id`/`node_id`/`definition_id` to be collision-free and deterministic,
+   may move import paths (interface consolidation), and re-pins the `tree_sitter`
    ABI. As of 2026-07-12 PyPI's latest is `3.2.2`; **v4 is being pushed now**. The
    repo pins `treesitter-chunker>=3.1.0,<4` (`pyproject.toml:30`), whose `<4`
-   ceiling **excludes v4**, and is ABI-paired to 3.x's `tree_sitter>=0.24,<0.25`
-   (`pyproject.toml:32`). Two problems compound: (a) the `<4` pin blocks adoption,
-   and (b) the `ON CONFLICT(file_id, chunk_id)` upsert into SQLite `code_chunks`
-   (`dispatcher_enhanced.py` ~L3389-3396) assumes `chunk_id` is stable across runs,
-   so v4's new id scheme causes **silent data corruption** — orphaned/duplicated
-   `code_chunks` rows and stale summaries on re-index, with no exception raised.
-   We must accommodate v4: bump the pin + ABI, guard the id scheme, and rebuild.
+   ceiling **excludes v4**, jointly ABI-paired to `tree-sitter>=0.24,<0.25` and
+   `tree-sitter-language-pack>=0.9,<1.0` (`pyproject.toml:32-40`).
+
+   **The real corruption mechanism (corrected after review):** every live write
+   path is delete-then-store *per file* (`dispatcher_enhanced.py:3321`->`3469`;
+   plugins call `delete_chunks_for_file` then `store_chunk`), so same-file
+   orphan/duplicate rows do **not** occur. The hazard is **mixed-scheme rows
+   across files that are not re-indexed after the bump**, plus **cross-table
+   staleness**: `chunk_id` also keys `chunk_summaries` (`chunk_hash`),
+   `semantic_points` `(profile_id, chunk_id)->point_id`, and the remote Qdrant
+   points derived from it. A re-index under v4's scheme leaves the un-reindexed
+   files, their summaries, and their vectors keyed under the old scheme — a
+   silent, mixed-scheme index with dangling summaries/vectors and no exception.
+
+   `code_chunks` is written from **three** upsert sites, not one:
+   `sqlite_store.store_chunk` (`:1115`), `store_chunks_batch` (`:1334`), and the
+   dispatcher's raw `conn.execute` (`:3396`); the plugin path
+   (`python_plugin/plugin.py:244`, `plugin_semantic.py:208`,
+   `generic_treesitter_plugin.py:255`) writes via `store_chunk`, bypassing the
+   dispatcher entirely. `code_chunks` also holds non-chunker history/document
+   rows a source re-index cannot recreate.
 
 2. **The deferred follow-ups from the provider-neutral inference boundary**
    (issue #73, merged as PR #74 / `specs/phase-plans-v11.md`) plus the Fable
@@ -26,80 +40,56 @@ This roadmap folds together two independent bodies of work:
 
 Open GitHub issues as of 2026-07-12: **#76** (folded in below as the first,
 highest-priority phase). The inference follow-ups have no open issue; they are the
-tech debt recorded on issue #73 / PR #74.
-
-The #74 merge fully redacted the *new* rerank/search paths it introduced, wired
-deployment profiles into runtime, and shipped a provenance-bearing embedding and
-rerank contract. It deliberately left as follow-ups: (a) redaction of the
-*pre-existing* rerank/search log sites, (b) symmetry gaps in the deployment
-profile helpers, (c) two provider-provenance honesty gaps, (d) a reconcile
-diagnostic that conflates transient faults with shape mismatch, (e) an async
-endpoint-transport timeout that can leave a worker running, and (f) a true
-live-provider benchmark run (the rollout verdict is `dark_opt_in` only because no
-live embedding endpoint was reachable).
-
-Verified follow-up sites on `main` (`f6f4705`):
-
-- Raw exception bodies still logged on the legacy async reranker paths:
-  `reranker.py:368` (Cohere), `:510` (cross-encoder), `:641` (TF-IDF); and
-  `hybrid_search.py:402` (`Semantic search failed with error: {e}`).
-- Cross-document search builds/handles raw `topic` at
-  `dispatcher_enhanced.py:3917`; any log of that topic is a raw-body path.
-- `settings.py:1119` `learned_models_allowed` returns `True` for an *unknown*
-  explicit profile name — asymmetric with `commercial_egress_allowed:1089`,
-  which fails closed on unknown.
-- `reranker.py:1079` parses `MCP_RERANK_TIMEOUT_S` without the `>=1s` clamp the
-  dispatcher applies.
-- `embedding_providers.py:130` (`VoyageEmbeddingProvider.embed_with_provenance`)
-  reads `response.embeddings` (`:145`) with no arity check vs the requested
-  texts; the Cohere v2 rerank adapter presents a config `model_revision` where
-  the response supplies none.
-- `semantic_indexer.py:1585` `_existing_collection_shape_blocked` treats a
-  transient Qdrant read error the same as a real shape mismatch (`blocked`),
-  emitting a reindex-suggesting message on a retryable fault.
-- `run_inference_gate.py` probes and gates arms correctly but has no live
-  collection-provenance verification, so a live run's numbers are not yet
-  bindable to the frozen corpus.
+tech debt recorded on issue #73 / PR #74. This roadmap was reviewed by a
+cross-vendor advisor board (Sol/codex, Grok, Gemini, Fable); Phase 1 is rewritten
+to reflect their findings, and Phases 2-3 site citations were confirmed accurate.
 
 ## Architecture North Star
 
-Fail closed on a chunker identity-scheme change, and close the inference-boundary
-honesty and safety gaps at the edges:
+Fail closed on a chunker identity-scheme change at a single central choke point,
+and close the inference-boundary honesty and safety gaps at the edges:
 
 ```text
-persisted code_chunks               -> reconcile only when the chunker id-scheme matches;
-                                       otherwise refuse incremental upsert and rebuild
+persisted code_chunks/summaries/    -> written+read only when the persisted chunker
+  semantic_points/vectors              id-scheme matches the active one; else refuse
+                                       (reads AND writes) and rebuild atomically
 every rerank/search/hybrid log      -> ids/counts/lengths + redacted errors only
 every deployment-profile decision   -> fail closed on unknown/ambiguous profile
 every provenance field              -> reported | declared | unknown, never faked
 every endpoint transport timeout    -> caller unblocked AND worker cannot publish
-live benchmark numbers              -> bound to verified collection provenance
+live benchmark numbers              -> bound to collection-resident provenance
 ```
 
-The `chunk_id`/`node_id`/`definition_id` values are an upstream identity contract:
-Code-Index-MCP must persist the scheme it indexed under and refuse to silently
-merge rows produced by a different scheme.
+The `chunk_id`/`node_id`/`definition_id` scheme is an upstream identity contract.
+Code-Index-MCP already models it as `chunk_identity_algorithm`
+(`manifest_v2.py:99`, hardcoded `treesitter_chunk_id_v1` at
+`artifact_upload.py:191`) and `SemanticProfile.chunker_version`/
+`chunk_schema_version` (`semantic_profiles.py:36-37`). The scheme guard must reuse
+that contract, not invent a parallel marker, and keep the SQLite marker and the
+Qdrant/profile fingerprint coherent.
 
 ## Assumptions
 
 - `main` (`f6f4705`) is the implementation base; #74 is merged.
 - `treesitter-chunker` v4 is not yet on PyPI as of 2026-07-12 (latest `3.2.2`).
   The version-agnostic safety guard + rebuild migration land now; the actual v4
-  adoption (real pin bump to a published v4, live migration run, moved-import
-  verification) is gated on v4 publishing and is verified against the real v4 (or
-  a pinned pre-release) when available — not fabricated beforehand.
-- Adopting the id-scheme change requires a full `code_chunks` rebuild; incremental
-  upsert cannot bridge it (per issue #76). Upstream keeps re-export shims for the
-  moved graph import paths, and v4 re-pins the `tree_sitter` ABI (its exact
-  requirement is read from v4's metadata at adoption time).
-- The `utils/chunker_adapter.py` `CodeChunk`->symbol path is ID-agnostic and
-  unaffected; only the dispatcher `code_chunks` upsert path is exposed.
-- INFERPOLISH needs no external services (unit-testable with fakes).
-- INFERLIVEGATE requires a reachable embedding endpoint and a populated Qdrant
-  collection to produce real numbers; without them it stays `dark_opt_in` and
-  only the verification code + procedure land.
-- Learned reranking remains opt-in / not default-enabled until INFERLIVEGATE
-  produces a passing, provenance-bound run.
+  adoption (pin/ABI bump to a published v4, live migration run, moved-import and
+  API-shape verification) is gated on v4 publishing and verified against the real
+  v4 (or a pinned pre-release) — not fabricated beforehand.
+- The exposed surface is NOT "only the dispatcher upsert": three `code_chunks`
+  upsert sites plus the plugin `store_chunk` path write it, and reads
+  (`tool_handlers.py:1587`, `summarization.py:1079`) bypass any single writer.
+- Adopting the id-scheme change requires a full rebuild of `code_chunks` AND its
+  dependent stores (`chunk_summaries`, `semantic_points`, remote Qdrant vectors);
+  synthetic non-chunker rows in `code_chunks` must be preserved.
+- The `tree_sitter` ABI is a three-package joint window; a `>=3.2.2,<5` range is
+  unsatisfiable with a single static `tree-sitter`/`tree-sitter-language-pack`
+  pin (3.x needs `<0.25`, 4.x will need `>=0.25`), so adoption raises the floor to
+  `>=4,<5`.
+- `utils/chunker_adapter.py` is ID-agnostic, but it and the plugins depend on the
+  v4-mutable `CodeChunk` surface (`chunk.__dict__`, `byte_start`,
+  `parent_chunk_id`, metadata keys) and the `chunk_text` import; "unaffected" is
+  only true for id fields.
 
 ## Non-Goals
 
@@ -108,34 +98,47 @@ merge rows produced by a different scheme.
 - No new provider vendors; no roadmap for the separate v10 hardening work.
 - No redesign of chunk identity in this repo — the scheme is upstream's; this
   roadmap only persists, detects, and safely migrates it.
-- No release dispatch.
+- No raising of the shipped `treesitter-chunker` pin ceiling before a real v4
+  migration + API-contract run passes. No release dispatch.
 
 ## Cross-Cutting Principles
 
-- Refuse to reconcile persisted `code_chunks` across a chunker id-scheme change;
-  rebuild explicitly instead of silently upserting.
+- Enforce the chunker id-scheme match at a single central choke point covering
+  every `code_chunks` writer AND every scheme-dependent reader; refuse rather
+  than silently mix schemes.
+- A missing scheme marker over a non-empty scheme-dependent index is
+  `incompatible` (fail closed), not "assume match".
+- Rebuild invalidates every dependent store and flips the marker only in the same
+  transaction as completed repopulation; a crash leaves the old coherent index or
+  a blocked/resumable state, never a half-rebuilt "ready" one.
 - Never log a query, document, candidate body, or unredacted exception message.
-- Fail closed on unknown deployment-profile names, symmetrically across helpers.
-- A provider may only tag a provenance field `reported` when the server actually
-  supplied it; otherwise `declared` or `unknown`.
-- A timed-out async transport must not mutate shared reranker state after the
-  caller has returned.
-- Keep pre-existing green tests green; add a failing-at-base repro for each fix.
+- Fail closed on unknown deployment-profile names, symmetrically.
+- A provider may only tag a provenance field `reported` when the server supplied
+  it; live benchmark numbers bind to collection-resident provenance.
+- Keep the pre-existing green suite green; capture a failing-at-base repro for
+  each fix before implementing it.
 
 ## Top Interface-Freeze Gates
 
-- IF-0-CHUNKERSAFE-1 - Chunk identity-scheme guard: the persisted index records
-  the chunker identity scheme it was written under; on re-index a scheme mismatch
-  refuses incremental `code_chunks` upsert and requires an explicit rebuild, so a
-  chunker id-scheme change can never silently orphan/duplicate rows or leave
-  dangling summaries.
-- IF-0-CHUNKERSAFE-2 - v4 adoption + ABI + graph-import safety: the
-  `treesitter-chunker` pin admits v4 and is re-paired to v4's required
-  `tree_sitter` ABI; a smoke check proves the graph import shims
-  (`chunker.core.chunk_file`, `chunker.graph.xref.build_xref`,
-  `chunker.graph.cut.graph_cut`) still resolve under v4; and the live v4
-  adoption/migration is verified against a real published v4 (or a pinned
-  pre-release) before the ceiling is raised in a shipped release.
+- IF-0-CHUNKERSAFE-1 - Central id-scheme guard + coherent rebuild: the chunker
+  identity scheme (reusing `chunk_identity_algorithm` / `chunker_version`) is
+  persisted per-DB and enforced at a single choke point across ALL `code_chunks`
+  writers (`sqlite_store.store_chunk`/`store_chunks_batch`, the dispatcher raw
+  SQL, the plugin path) and all scheme-dependent readers; a mismatch or a
+  missing-marker-over-nonempty-index refuses reads and writes and requires a
+  rebuild. The rebuild atomically invalidates `code_chunks` + `chunk_summaries` +
+  `semantic_points` + remote Qdrant vectors keyed by old ids, preserves synthetic
+  non-chunker rows, and flips the marker only on successful repopulation;
+  readiness reports non-`ready`/`rebuilding` while tripped.
+- IF-0-CHUNKERSAFE-2 - v4 adoption, ABI window, import + API contract: the pin
+  floor is raised to a real published v4 (`>=4,<5`) and the `tree_sitter` /
+  `tree-sitter-language-pack` / `tree-sitter-languages` joint window is re-solved
+  at the resolver level (`uv lock` succeeds with v4 + the full grammar matrix); a
+  grep-derived smoke check proves EVERY `chunker` import used in `mcp_server/`
+  resolves under v4 (incl. `chunk_text`, `CodeChunk`, `graph_cut`); the
+  dispatcher's silent zero-chunk fallback is promoted to a loud diagnostic; and a
+  real-v4 functional contract test covers the call shapes and `CodeChunk`
+  attribute/metadata surface the callers depend on.
 - IF-0-INFERPOLISH-1 - Redaction completeness: no raw query/document/candidate
   body or unredacted exception message reaches any rerank, hybrid, or search log
   path (extends #74's redaction to the legacy/pre-existing sites).
@@ -148,11 +151,13 @@ merge rows produced by a different scheme.
   none; Voyage `embed_with_provenance` rejects an arity mismatch; a timed-out
   endpoint transport cannot publish `last_outcome`/`last_diagnostics` after the
   caller returned (per-call generation guard).
-- IF-0-INFERLIVEGATE-1 - Provenance-bound live gate: a live provider run verifies
-  the live Qdrant collection's indexed commit, corpus checksum, profile
-  fingerprint, and provider revision against the frozen corpus before its metrics
-  count; the verdict records those bindings, and only a passing bound run may move
-  reranking off `dark_opt_in`.
+- IF-0-INFERLIVEGATE-1 - Collection-resident provenance-bound gate: the semantic
+  index PRODUCER persists an immutable collection/run manifest binding collection
+  identity, corpus checksum, indexed commit, profile fingerprint, provider
+  revision, and point-set id; a live provider run counts an arm's metrics only
+  when the queried live collection's resident provenance verifies against the
+  frozen corpus, and only a passing bound run may move reranking off
+  `dark_opt_in`.
 
 ## Phases
 
@@ -160,79 +165,108 @@ merge rows produced by a different scheme.
 
 **Objective**
 
-Accommodate the imminent `treesitter-chunker` v4 safely (issue #76): raise the
-`<4` pin ceiling and re-pair the `tree_sitter` ABI to v4's requirement; persist
-the chunker identity scheme the index was built under and refuse to incrementally
-reconcile `code_chunks` across a scheme change; provide a tested rebuild
-migration; keep the graph imports resilient to v4's interface consolidation; and
-verify the live adoption against a real published v4 before raising the ceiling in
-a shipped release. CRITICAL — v4's new id scheme is silent data corruption on the
-currently-exposed pin. The version-agnostic safety guard lands now; the live v4
-adoption is gated on v4 publishing.
+Accommodate the imminent `treesitter-chunker` v4 safely (issue #76): persist the
+chunker identity scheme (reusing the existing `chunk_identity_algorithm` /
+`chunker_version` contract), enforce it at a single central choke point across
+every `code_chunks` writer and every scheme-dependent reader, provide an atomic
+rebuild that invalidates all dependent stores, and — gated on v4 publishing —
+raise the pin/ABI window and verify the moved imports and `CodeChunk` API surface
+against a real v4. CRITICAL: a mixed-scheme index is silent data corruption.
 
 **Exit criteria**
 
-- [ ] The persisted index records a chunker identity-scheme marker
-      (chunker version + scheme id) alongside `code_chunks`; the marker is written
-      on index and read on re-index.
-- [ ] On re-index, a scheme-marker mismatch does NOT run the
-      `ON CONFLICT(file_id, chunk_id)` incremental upsert
-      (`dispatcher_enhanced.py` ~L3363-3446); it fails closed with an actionable
-      diagnostic and requires an explicit `code_chunks` rebuild.
-- [ ] A tested rebuild migration drops and repopulates `code_chunks` (and
-      invalidates dependent summaries read at `cli/tool_handlers.py:1589-1608`)
-      when adopting the new scheme; no orphaned or duplicated rows survive, and
-      no stale summary keys dangle.
-- [ ] The `pyproject.toml` pin admits v4 (raise the `<4` ceiling, e.g.
-      `>=3.2.2,<5`) and is re-paired to v4's required `tree_sitter` ABI (replace
-      the 3.x `tree_sitter>=0.24,<0.25` note/constraint with v4's), read from v4's
-      own metadata — not guessed. A test asserts the pin admits v4 and the ABI
-      constraint matches v4's requirement.
-- [ ] Live v4 adoption is verified against a real published v4 (or a pinned
-      pre-release): a `code_chunks` build under v4 followed by a re-index shows the
-      scheme-guard + rebuild path engaging with zero orphaned/dangling rows. If v4
-      is not yet available, this criterion is explicitly deferred with the guard,
-      prepared pin, and import resilience already landed — no fabricated run.
-- [ ] A smoke check verifies the graph import shims
-      (`chunker.core.chunk_file`, `chunker.graph.xref.build_xref`,
-      `chunker.graph.cut.graph_cut`, imported under try/except at
-      `mcp_server/graph/xref_adapter.py:14-15` and
-      `mcp_server/utils/semantic_indexer.py:17`) still load after the bump, so a
-      moved path is caught instead of silently degrading graph features to
-      "unavailable" (the degradation messages live at `gateway.py:2875/2986/3030`).
-- [ ] `utils/chunker_adapter.py` is confirmed (by test) ID-agnostic and
-      unaffected.
+Lane A (version-agnostic, lands now):
+
+- [ ] A per-DB chunker identity-scheme marker is persisted (in `index_config` or
+      equivalent) using a defined `scheme_id` (e.g.
+      `getattr(chunker, "CHUNK_ID_SCHEME", f"treesitter_chunk_id_v{major}")`) and
+      reconciled with `chunk_identity_algorithm` (`manifest_v2.py:99`) and the
+      semantic-profile `chunker_version`/`compatibility_fingerprint` so the SQLite
+      marker and the Qdrant/profile fingerprint stay coherent.
+- [ ] The scheme match is enforced at a single central choke point covering ALL
+      writers — `sqlite_store.store_chunk` (`:1115`), `store_chunks_batch`
+      (`:1334`), the dispatcher raw upsert (`:3396`), and the plugin
+      `delete_chunks_for_file`+`store_chunk` path — and all scheme-dependent
+      readers (`tool_handlers.py:1587`, `summarization.py:1079`). Compatibility is
+      established when the repository context is opened.
+- [ ] A missing marker over a non-empty scheme-dependent index is treated as
+      `incompatible` (fail closed on reads AND writes) until an explicit rebuild;
+      an empty index stamps the current scheme on first successful build. A
+      v3-unmarked -> current-scheme fixture test proves no read/delete/upsert
+      occurs while incompatible.
+- [ ] A rebuild migration invalidates `code_chunks` **and** `chunk_summaries`
+      **and** `semantic_points` **and** the remote Qdrant vectors keyed by old
+      `chunk_id`/`:part:`/`:file-summary` ids (reusing `delete_stale_vectors` /
+      `cleanup_stale_semantic_artifacts`), scoped by repository/profile, while
+      PRESERVING synthetic non-chunker rows in `code_chunks`. No orphaned/dangling
+      summary, mapping, or vector survives (asserted by SQL/point-count tests).
+- [ ] The rebuild is atomic/resumable: the scheme marker flips in the same
+      transaction as completed repopulation; `repository_readiness` reports
+      non-`ready`/`rebuilding` while the guard is tripped (not table-presence-only
+      `ready`); an interrupted-rebuild test leaves the old coherent index or a
+      blocked/resumable state, never a half-populated "ready" DB.
+- [ ] `update_chunk_token_count` and any other `chunk_id`-only writes are scoped
+      by `file_id`; `:part:` `LIKE` matching escapes/asserts the id charset so v4
+      ids containing `%`/`_` cannot mis-match.
+
+Lane B (gated on v4 publishing; deferral is tracked, not silent):
+
+- [ ] `pyproject.toml` raises the pin floor to a real published v4 (`>=4,<5`) and
+      re-solves the `tree_sitter`/`tree-sitter-language-pack`/`tree-sitter-languages`
+      joint window; the test is resolver-level (`uv lock` succeeds with v4 + the
+      full grammar matrix), not a specifier-string assertion.
+- [ ] A grep-derived smoke check proves EVERY `chunker` import in `mcp_server/`
+      resolves under v4 — `chunk_text` (`dispatcher_enhanced.py:3363`, plugins),
+      `chunk_file` (`xref_adapter.py:14`, `semantic_indexer.py:17`), `CodeChunk`
+      (`chunker_adapter.py:8`), `build_xref`, `graph_cut`
+      (`graph/context_selector.py:21`) — and the dispatcher's silent
+      `shard_chunks=[]` zero-chunk fallback (`:3362-3368`) is promoted to a loud
+      diagnostic / fail-closed signal.
+- [ ] A real-v4 functional contract test covers the call shapes callers depend on
+      (`chunk.__dict__`, `chunk.chunk_id/node_id/definition_id/parent_chunk_id/
+      byte_start/byte_end/start_line/end_line/node_type/metadata`, metadata keys
+      `name/signature/exports/docstring/kind`) and asserts nonempty chunks +
+      working xref/graph-cut; a `CodeChunk` shape-contract test guards field
+      renames/slots.
+- [ ] If v4 is not yet available, Lane B is deferred to a tracked follow-up
+      artifact (issue/phase `CHUNKERV4LIVE`) with an owner — not an open-ended
+      "deferred" checkbox. Lane A ships without raising the shipped pin ceiling.
 
 **Scope notes**
 
-Decompose into **2 lanes**: Lane A (version-agnostic, lands now) - scheme marker
-+ fail-closed guard + rebuild migration in the dispatcher `code_chunks` path and
-`storage/sqlite_store.py` schema; Lane B (v4 adoption, gated on v4 publish) - the
-`pyproject.toml` pin-ceiling + `tree_sitter` ABI re-pair, graph-import resilience
-(adopt v4's canonical paths, tolerate the re-export shims) + smoke check, the
-chunker-adapter-unaffected assertion, the live-v4 migration verification, and
-docs. Adopting the new scheme requires a full `code_chunks` rebuild; never
-silently incremental-upsert across it. Lane A is safe to land immediately and
-protects any 3.2.x or v4 scheme change; Lane B's live verification waits for v4 to
-publish. Coordinate the exact `dispatcher_enhanced.py` region (the `code_chunks`
-upsert ~L3389-3396) so INFERPOLISH (which owns the rerank/search-log region of
-the same file) does not overlap.
+Decompose into **2 lanes**: Lane A (version-agnostic, lands now) - central scheme
+guard + marker + atomic rebuild across all writers/readers and dependent stores.
+Lane B (v4 adoption, gated on v4 publish) - pin/ABI joint-window re-solve,
+grep-derived import smoke + loud zero-chunk fallback, and the real-v4 API contract
+test. Prefer unifying the three duplicated upsert SQL blocks behind the storage
+choke point before adding the guard, so the check lives in one place. Coordinate
+the `dispatcher_enhanced.py` regions so INFERPOLISH (rerank/search-log region) does
+not overlap the `code_chunks` region.
 
 **Non-goals**
 
-- No redesign of chunk identity (that is upstream's contract).
-- No change to the ID-agnostic `chunker_adapter.py` symbol path.
+- No redesign of chunk identity (upstream's contract).
+- No change to the ID-agnostic parts of `chunker_adapter.py`.
 
 **Key files**
 
 - `pyproject.toml`
-- `mcp_server/dispatcher/dispatcher_enhanced.py` (`code_chunks` upsert region)
-- `mcp_server/storage/sqlite_store.py` (schema + scheme marker + migration)
-- `mcp_server/graph/xref_adapter.py`, `mcp_server/utils/semantic_indexer.py`
-  (graph import shims; `gateway.py` holds the graph-unavailable messages)
-- `mcp_server/cli/tool_handlers.py` (chunk readback)
-- `mcp_server/utils/chunker_adapter.py` (confirm unaffected)
+- `mcp_server/storage/sqlite_store.py` (upserts `:1115`/`:1334`, `index_config`,
+  `semantic_points`, `chunk_summaries`, `update_chunk_token_count`, migration)
+- `mcp_server/dispatcher/dispatcher_enhanced.py` (`code_chunks` upsert `:3396`,
+  `_clear_file_index_rows`, `chunk_text` fallback `:3362-3368`)
+- `mcp_server/plugins/python_plugin/plugin.py`,
+  `mcp_server/plugins/python_plugin/plugin_semantic.py`,
+  `mcp_server/plugins/generic_treesitter_plugin.py` (direct `store_chunk` path)
+- `mcp_server/graph/xref_adapter.py`, `mcp_server/graph/context_selector.py`,
+  `mcp_server/utils/semantic_indexer.py`, `mcp_server/utils/chunker_adapter.py`
+  (chunker imports + `CodeChunk` surface)
+- `mcp_server/indexing/incremental_indexer.py` (`:part:` LIKE derivation),
+  `mcp_server/health/repository_readiness.py` (rebuilding state),
+  `mcp_server/artifacts/manifest_v2.py`, `mcp_server/artifacts/semantic_profiles.py`
+  (identity contract reconciliation)
 - `tests/test_chunker_identity_migration.py` (new),
+  `tests/test_chunker_v4_contract.py` (new; Lane B),
   `tests/test_chunker_graph_imports_smoke.py` (new)
 
 **Depends on**
@@ -241,21 +275,23 @@ the same file) does not overlap.
 
 **Produces**
 
-- IF-0-CHUNKERSAFE-1 - Chunk identity-scheme guard.
-- IF-0-CHUNKERSAFE-2 - Adoption + graph-import safety.
+- IF-0-CHUNKERSAFE-1 - Central id-scheme guard + coherent rebuild.
+- IF-0-CHUNKERSAFE-2 - v4 adoption, ABI window, import + API contract.
 
 **Spec closeout policy**
 
 - schema: spec_delta_closeout.v1
 - expected_decision: no_spec_delta
-- target_surfaces: `mcp_server/dispatcher/dispatcher_enhanced.py`,
-  `mcp_server/storage/sqlite_store.py`, `pyproject.toml`, `mcp_server/gateway.py`
-- evidence_paths: scheme-mismatch fail-closed + rebuild-migration + graph-import
-  smoke test output
+- target_surfaces: `mcp_server/storage/sqlite_store.py`,
+  `mcp_server/dispatcher/dispatcher_enhanced.py`, the plugin store paths,
+  `pyproject.toml`
+- evidence_paths: central-guard fail-closed, cross-store rebuild, interrupted-
+  rebuild, and (Lane B) resolver + import + API-contract test output
 - redaction_posture: metadata_only
-- blocker_class: contract_bug if an id-scheme change can still incrementally
-  upsert `code_chunks`, if the rebuild migration leaves orphaned/dangling rows,
-  or if a moved graph import path degrades silently.
+- blocker_class: contract_bug if any `code_chunks` writer or scheme-dependent
+  reader can act across a scheme mismatch, if the rebuild leaves dangling
+  summaries/mappings/vectors or drops synthetic rows, if a half-rebuilt index
+  reads `ready`, or if a v4 import/API move degrades silently.
 
 ### Phase 2 - Inference Boundary Polish (INFERPOLISH)
 
@@ -271,34 +307,24 @@ transport timeouts leak-safe.
 - [ ] No raw exception body is logged on the legacy async reranker paths
       (`reranker.py:368/510/641`) or the hybrid semantic-failure path
       (`hybrid_search.py:402`); all go through the existing redactor.
-- [ ] No raw `topic`/query body is logged on the cross-document / search paths
-      (audit `dispatcher_enhanced.py:3917` and siblings); log lengths/ids only.
+- [ ] No raw `topic`/query body is logged on the cross-document / search paths;
+      log lengths/ids only.
 - [ ] `learned_models_allowed` fails closed on an unknown explicit
       `MCP_DEPLOYMENT_PROFILE`; `EndpointReranker` timeout parse clamps to `>=1s`.
 - [ ] Cohere v2 adapter reports `model_revision` as `None`/`unknown` when the
-      response lacks one (never a config value tagged as provider-reported);
-      `VoyageEmbeddingProvider.embed_with_provenance` raises on an arity mismatch
-      between requested texts and returned embeddings.
+      response lacks one; `VoyageEmbeddingProvider.embed_with_provenance` raises
+      on an arity mismatch.
 - [ ] A timed-out endpoint transport cannot mutate shared reranker diagnostics
-      after the bridge raised `TimeoutError` (per-call generation guard); the
-      leaked worker is logged, not silently swallowed.
+      after the bridge raised `TimeoutError` (per-call generation guard).
 - [ ] `_existing_collection_shape_blocked` distinguishes a transient Qdrant read
-      error (retryable, non-`blocked`) from a real shape mismatch; the diagnostic
-      text matches the actual cause.
+      error (retryable) from a real shape mismatch; the diagnostic matches cause.
 
 **Scope notes**
 
-Decompose into **3 file-disjoint lanes**:
-- Lane A - rerank/search logging + async safety + timeout clamp + Cohere
-  revision: `mcp_server/indexer/reranker.py`,
-  `mcp_server/indexer/hybrid_search.py`,
-  `mcp_server/dispatcher/dispatcher_enhanced.py`,
-  `mcp_server/dispatcher/cross_repo_coordinator.py`.
-- Lane B - provider + indexer honesty: `mcp_server/utils/embedding_providers.py`
-  (Voyage arity), `mcp_server/utils/semantic_indexer.py` (reconcile transient
-  vs blocked).
-- Lane C - profile symmetry: `mcp_server/config/settings.py`
-  (`learned_models_allowed` fail-closed).
+Decompose into **3 file-disjoint lanes**: Lane A - `reranker.py`,
+`hybrid_search.py`, `dispatcher_enhanced.py` (rerank/search-log region),
+`cross_repo_coordinator.py`; Lane B - `embedding_providers.py`,
+`semantic_indexer.py`; Lane C - `settings.py`.
 
 **Non-goals**
 
@@ -306,20 +332,21 @@ Decompose into **3 file-disjoint lanes**:
 
 **Key files**
 
-- `mcp_server/indexer/reranker.py`
-- `mcp_server/indexer/hybrid_search.py`
-- `mcp_server/dispatcher/dispatcher_enhanced.py`
-- `mcp_server/dispatcher/cross_repo_coordinator.py`
-- `mcp_server/utils/embedding_providers.py`
-- `mcp_server/utils/semantic_indexer.py`
-- `mcp_server/config/settings.py`
+- `mcp_server/indexer/reranker.py`, `mcp_server/indexer/hybrid_search.py`,
+  `mcp_server/dispatcher/dispatcher_enhanced.py`,
+  `mcp_server/dispatcher/cross_repo_coordinator.py`,
+  `mcp_server/utils/embedding_providers.py`, `mcp_server/utils/semantic_indexer.py`,
+  `mcp_server/config/settings.py`
 - `tests/test_reranker_outcomes.py`, `tests/test_rerank_consumer_migration.py`,
   `tests/test_endpoint_reranker.py`, `tests/test_embedding_provider_provenance.py`,
   `tests/test_deployment_profiles.py`, `tests/test_embedding_provenance.py`
 
 **Depends on**
 
-- CHUNKERSAFE (sequenced after it so edits to the shared dispatcher file are serialized — disjoint regions, the code_chunks upsert vs rerank/search logging — and the data-integrity fix lands first; otherwise logically independent).
+- CHUNKERSAFE (Lane A only — the version-agnostic guard; this phase does not wait
+  on the v4-publish-gated Lane B, and is sequenced after Lane A so edits to
+  `dispatcher_enhanced.py` are serialized, disjoint regions: the `code_chunks`
+  upsert vs rerank/search logging).
 
 **Produces**
 
@@ -338,38 +365,42 @@ Decompose into **3 file-disjoint lanes**:
   profile fails open, if a config value is reported as provider-origin, or if a
   timed-out worker can still publish reranker state.
 
-### Phase 3 - Provenance-Bound Live Rollout Gate (INFERLIVEGATE)
+### Phase 3 - Collection-Resident Provenance-Bound Live Rollout Gate (INFERLIVEGATE)
 
 **Objective**
 
-Make the INFERGATE benchmark able to produce trustworthy live numbers: verify the
-live collection's provenance against the frozen corpus before counting metrics,
-run the real dense/hybrid/reranked arms when services are reachable, and record a
+Make the INFERGATE benchmark able to produce trustworthy live numbers: have the
+semantic index PRODUCER persist collection-resident provenance, verify a live
+collection's provenance against the frozen corpus before counting metrics, run the
+real dense/hybrid/reranked arms when services are reachable, and record a
 provenance-bound verdict that can (only then) move reranking off `dark_opt_in`.
 
 **Exit criteria**
 
-- [ ] The gate verifies a live Qdrant collection's indexed commit, corpus
-      checksum, profile fingerprint, and provider revision against the frozen
-      corpus/`MANIFEST.json` before any arm's metrics are counted; a mismatch
-      records the arm `not_run` with a provenance-mismatch reason.
+- [ ] The semantic index producer persists an immutable collection/run manifest
+      binding collection identity, complete corpus checksum, indexed commit,
+      profile fingerprint, provider revision, and point-set/build id — not only
+      the local `.index_metadata.json` (`semantic_indexer.py:1256-1304`) the
+      benchmark cannot bind to the queried points.
+- [ ] The gate counts an arm's metrics only when the live Qdrant collection's
+      resident provenance verifies against the frozen corpus/`MANIFEST.json`; a
+      missing/stale/mixed-run/tampered binding records the arm `not_run` with a
+      provenance-mismatch reason (tested for each case).
 - [ ] When embedding + Qdrant + rerank endpoints are reachable AND provenance
-      verifies, the dense/hybrid/hybrid_rerank arms run on real retrieved
-      document content and produce metrics bound to the verified collection.
-- [ ] The verdict artifact binds indexed-commit + corpus/threshold checksums +
-      provider revision + code commit; holdout remains unused for tuning.
+      verifies, the arms run on real retrieved document content and produce
+      metrics bound to the verified collection; holdout stays unused for tuning.
 - [ ] `INFERENCE_ROLLOUT.md` / `SUPPORT_MATRIX.md` are updated only from a
       passing, provenance-bound run; absent live infra the verdict stays
-      `dark_opt_in` and the phase lands the verification code + a documented
-      run procedure rather than fabricated numbers.
+      `dark_opt_in` and the phase lands the producer manifest + verification code
+      + run procedure rather than fabricated numbers.
 
 **Scope notes**
 
-Decompose into **2 lanes**: Lane A - live-collection provenance verification in
-`run_inference_gate.py` + real-content arms; then Lane B - verdict binding +
-`INFERENCE_ROLLOUT.md`/`SUPPORT_MATRIX.md` reducer and the operator run
-procedure. This phase must not flip any default without a passing bound run and
-an explicit operator decision.
+Decompose into **2 lanes**: Lane A - collection-resident provenance in the
+producer (`semantic_indexer.py`) + verification in `run_inference_gate.py` +
+real-content arms; then Lane B - verdict binding + `INFERENCE_ROLLOUT.md`/
+`SUPPORT_MATRIX.md` reducer + operator run procedure. No default flip without a
+passing bound run.
 
 **Non-goals**
 
@@ -377,10 +408,10 @@ an explicit operator decision.
 
 **Key files**
 
+- `mcp_server/utils/semantic_indexer.py` (collection-resident provenance producer)
 - `benchmarks/retrieval_eval/runs/inferbound-v10/run_inference_gate.py`
 - `mcp_server/benchmarks/retrieval_eval_harness.py`
-- `docs/status/INFERENCE_ROLLOUT.md`
-- `docs/SUPPORT_MATRIX.md`
+- `docs/status/INFERENCE_ROLLOUT.md`, `docs/SUPPORT_MATRIX.md`
 - `tests/test_retrieval_benchmark_harness.py`,
   `tests/docs/test_inference_rollout_report.py`
 
@@ -388,9 +419,12 @@ an explicit operator decision.
 
 - INFERPOLISH (reuses the completed redaction + honest provenance on the arms).
 
+This phase and the chunker phase's Lane B both touch `semantic_indexer.py`, but
+Lane B is externally gated (v4 publish), so they do not run concurrently.
+
 **Produces**
 
-- IF-0-INFERLIVEGATE-1 - Provenance-bound live gate.
+- IF-0-INFERLIVEGATE-1 - Collection-resident provenance-bound gate.
 
 **Spec closeout policy**
 
@@ -399,37 +433,40 @@ an explicit operator decision.
 - target_surfaces: future roadmap if a passing run proposes default-enablement
 - evidence_paths: `docs/status/INFERENCE_ROLLOUT.md` + gate run artifact
 - redaction_posture: metadata_only
-- blocker_class: contract_bug if metrics can count without verified collection
-  provenance, or if the verdict flips a default without a passing bound run.
+- blocker_class: contract_bug if metrics can count without verified
+  collection-resident provenance, or if the verdict flips a default without a
+  passing bound run.
 
 ## Phase Dependency DAG
 
 ```text
 CHUNKERSAFE ──► INFERPOLISH ──► INFERLIVEGATE
- (wave 1, 2 lanes)  (wave 2, 3 lanes)   (wave 3, 2 lanes)
+ (wave 1)          (wave 2)         (wave 3)
+   Lane A: version-agnostic guard (lands now)   INFERPOLISH depends on Lane A only
+   Lane B: v4 adoption (gated on v4 publish; tracked as CHUNKERV4LIVE if deferred)
 ```
 
-CHUNKERSAFE is CRITICAL and lands first (independent subsystem; also owns the
-`code_chunks` region of `dispatcher_enhanced.py`). INFERPOLISH follows to
-serialize edits to that file, then INFERLIVEGATE consumes the polished providers.
+CHUNKERSAFE Lane A is CRITICAL and lands first. INFERPOLISH depends only on Lane A
+(not the externally gated Lane B) and reopens the rerank/search-log region of the
+shared dispatcher file after Lane A finishes the `code_chunks` region.
+INFERLIVEGATE consumes the polished providers; it and CHUNKERSAFE Lane B both
+touch `semantic_indexer.py` but never run concurrently (Lane B is gated).
 
 ## Execution Notes
 
-- CHUNKERSAFE is the priority: v4's new id scheme is silent data corruption on
-  the currently-exposed pin, so it lands first and can ship as its own PR. Its
-  Lane A (version-agnostic scheme guard + rebuild migration) is safe to land
-  immediately; Lane B (raise the `<4` ceiling to admit v4, re-pair the
-  `tree_sitter` ABI, and verify the live v4 migration) is gated on v4 publishing
-  (PyPI latest is `3.2.2` as of 2026-07-12). Do not raise the shipped pin ceiling
-  before a real v4 (or pinned pre-release) migration run passes. The guard must
-  refuse silent incremental upsert across any scheme change regardless of timing.
-- INFERPOLISH's 3 lanes are file-disjoint and run concurrently; it is pure
-  hygiene/honesty with no default changes and can land as its own PR. It reopens
-  the rerank/search-log region of `dispatcher_enhanced.py` after CHUNKERSAFE has
-  finished the `code_chunks` region of the same file.
+- CHUNKERSAFE Lane A is the priority: a mixed-scheme index across un-reindexed
+  files is silent data corruption. It lands first and can ship as its own PR. The
+  guard must be central (one choke point across all writers + readers), the
+  rebuild must clear all dependent stores atomically, and the missing-marker case
+  must fail closed.
+- CHUNKERSAFE Lane B is gated on v4 publishing (PyPI latest is `3.2.2` as of
+  2026-07-12). Do not raise the shipped pin ceiling before a real v4 (or pinned
+  pre-release) migration + import + API-contract run passes; if v4 is not out,
+  track the deferral as `CHUNKERV4LIVE`.
+- INFERPOLISH's 3 lanes are file-disjoint and run concurrently once Lane A lands.
 - INFERLIVEGATE is infra-gated: without a reachable embedding endpoint + a
-  populated, provenance-matching collection, it lands the verification code and
-  a run procedure and leaves the verdict `dark_opt_in`. Do not fabricate numbers.
+  populated, provenance-matching collection, it lands the producer manifest +
+  verification code + run procedure and leaves the verdict `dark_opt_in`.
 - Keep the pre-existing green suite green; capture a failing-at-base repro for
   each fix before implementing it.
 

--- a/specs/phase-plans-v12.md
+++ b/specs/phase-plans-v12.md
@@ -1,0 +1,453 @@
+# Phase roadmap v12
+
+## Context
+
+This roadmap folds together two independent bodies of work:
+
+1. **A CRITICAL upstream dependency break + imminent major release (issue #76)** —
+   `treesitter-chunker` is publishing **v4**, which redesigns
+   `chunk_id`/`node_id`/`definition_id` to be collision-free and deterministic and
+   may move import paths (interface consolidation) and re-pin the `tree_sitter`
+   ABI. As of 2026-07-12 PyPI's latest is `3.2.2`; **v4 is being pushed now**. The
+   repo pins `treesitter-chunker>=3.1.0,<4` (`pyproject.toml:30`), whose `<4`
+   ceiling **excludes v4**, and is ABI-paired to 3.x's `tree_sitter>=0.24,<0.25`
+   (`pyproject.toml:32`). Two problems compound: (a) the `<4` pin blocks adoption,
+   and (b) the `ON CONFLICT(file_id, chunk_id)` upsert into SQLite `code_chunks`
+   (`dispatcher_enhanced.py` ~L3389-3396) assumes `chunk_id` is stable across runs,
+   so v4's new id scheme causes **silent data corruption** — orphaned/duplicated
+   `code_chunks` rows and stale summaries on re-index, with no exception raised.
+   We must accommodate v4: bump the pin + ABI, guard the id scheme, and rebuild.
+
+2. **The deferred follow-ups from the provider-neutral inference boundary**
+   (issue #73, merged as PR #74 / `specs/phase-plans-v11.md`) plus the Fable
+   cross-vendor CR nice-to-haves — redaction completeness, profile-gating
+   symmetry, provenance honesty, reconcile diagnostics, async cancellation
+   safety, and a provenance-bound live benchmark.
+
+Open GitHub issues as of 2026-07-12: **#76** (folded in below as the first,
+highest-priority phase). The inference follow-ups have no open issue; they are the
+tech debt recorded on issue #73 / PR #74.
+
+The #74 merge fully redacted the *new* rerank/search paths it introduced, wired
+deployment profiles into runtime, and shipped a provenance-bearing embedding and
+rerank contract. It deliberately left as follow-ups: (a) redaction of the
+*pre-existing* rerank/search log sites, (b) symmetry gaps in the deployment
+profile helpers, (c) two provider-provenance honesty gaps, (d) a reconcile
+diagnostic that conflates transient faults with shape mismatch, (e) an async
+endpoint-transport timeout that can leave a worker running, and (f) a true
+live-provider benchmark run (the rollout verdict is `dark_opt_in` only because no
+live embedding endpoint was reachable).
+
+Verified follow-up sites on `main` (`f6f4705`):
+
+- Raw exception bodies still logged on the legacy async reranker paths:
+  `reranker.py:368` (Cohere), `:510` (cross-encoder), `:641` (TF-IDF); and
+  `hybrid_search.py:402` (`Semantic search failed with error: {e}`).
+- Cross-document search builds/handles raw `topic` at
+  `dispatcher_enhanced.py:3917`; any log of that topic is a raw-body path.
+- `settings.py:1119` `learned_models_allowed` returns `True` for an *unknown*
+  explicit profile name — asymmetric with `commercial_egress_allowed:1089`,
+  which fails closed on unknown.
+- `reranker.py:1079` parses `MCP_RERANK_TIMEOUT_S` without the `>=1s` clamp the
+  dispatcher applies.
+- `embedding_providers.py:130` (`VoyageEmbeddingProvider.embed_with_provenance`)
+  reads `response.embeddings` (`:145`) with no arity check vs the requested
+  texts; the Cohere v2 rerank adapter presents a config `model_revision` where
+  the response supplies none.
+- `semantic_indexer.py:1585` `_existing_collection_shape_blocked` treats a
+  transient Qdrant read error the same as a real shape mismatch (`blocked`),
+  emitting a reindex-suggesting message on a retryable fault.
+- `run_inference_gate.py` probes and gates arms correctly but has no live
+  collection-provenance verification, so a live run's numbers are not yet
+  bindable to the frozen corpus.
+
+## Architecture North Star
+
+Fail closed on a chunker identity-scheme change, and close the inference-boundary
+honesty and safety gaps at the edges:
+
+```text
+persisted code_chunks               -> reconcile only when the chunker id-scheme matches;
+                                       otherwise refuse incremental upsert and rebuild
+every rerank/search/hybrid log      -> ids/counts/lengths + redacted errors only
+every deployment-profile decision   -> fail closed on unknown/ambiguous profile
+every provenance field              -> reported | declared | unknown, never faked
+every endpoint transport timeout    -> caller unblocked AND worker cannot publish
+live benchmark numbers              -> bound to verified collection provenance
+```
+
+The `chunk_id`/`node_id`/`definition_id` values are an upstream identity contract:
+Code-Index-MCP must persist the scheme it indexed under and refuse to silently
+merge rows produced by a different scheme.
+
+## Assumptions
+
+- `main` (`f6f4705`) is the implementation base; #74 is merged.
+- `treesitter-chunker` v4 is not yet on PyPI as of 2026-07-12 (latest `3.2.2`).
+  The version-agnostic safety guard + rebuild migration land now; the actual v4
+  adoption (real pin bump to a published v4, live migration run, moved-import
+  verification) is gated on v4 publishing and is verified against the real v4 (or
+  a pinned pre-release) when available — not fabricated beforehand.
+- Adopting the id-scheme change requires a full `code_chunks` rebuild; incremental
+  upsert cannot bridge it (per issue #76). Upstream keeps re-export shims for the
+  moved graph import paths, and v4 re-pins the `tree_sitter` ABI (its exact
+  requirement is read from v4's metadata at adoption time).
+- The `utils/chunker_adapter.py` `CodeChunk`->symbol path is ID-agnostic and
+  unaffected; only the dispatcher `code_chunks` upsert path is exposed.
+- INFERPOLISH needs no external services (unit-testable with fakes).
+- INFERLIVEGATE requires a reachable embedding endpoint and a populated Qdrant
+  collection to produce real numbers; without them it stays `dark_opt_in` and
+  only the verification code + procedure land.
+- Learned reranking remains opt-in / not default-enabled until INFERLIVEGATE
+  produces a passing, provenance-bound run.
+
+## Non-Goals
+
+- No change to the frozen benchmark dataset, thresholds, or the #73 contracts.
+- No default-enablement of semantic/reranked search from INFERPOLISH.
+- No new provider vendors; no roadmap for the separate v10 hardening work.
+- No redesign of chunk identity in this repo — the scheme is upstream's; this
+  roadmap only persists, detects, and safely migrates it.
+- No release dispatch.
+
+## Cross-Cutting Principles
+
+- Refuse to reconcile persisted `code_chunks` across a chunker id-scheme change;
+  rebuild explicitly instead of silently upserting.
+- Never log a query, document, candidate body, or unredacted exception message.
+- Fail closed on unknown deployment-profile names, symmetrically across helpers.
+- A provider may only tag a provenance field `reported` when the server actually
+  supplied it; otherwise `declared` or `unknown`.
+- A timed-out async transport must not mutate shared reranker state after the
+  caller has returned.
+- Keep pre-existing green tests green; add a failing-at-base repro for each fix.
+
+## Top Interface-Freeze Gates
+
+- IF-0-CHUNKERSAFE-1 - Chunk identity-scheme guard: the persisted index records
+  the chunker identity scheme it was written under; on re-index a scheme mismatch
+  refuses incremental `code_chunks` upsert and requires an explicit rebuild, so a
+  chunker id-scheme change can never silently orphan/duplicate rows or leave
+  dangling summaries.
+- IF-0-CHUNKERSAFE-2 - v4 adoption + ABI + graph-import safety: the
+  `treesitter-chunker` pin admits v4 and is re-paired to v4's required
+  `tree_sitter` ABI; a smoke check proves the graph import shims
+  (`chunker.core.chunk_file`, `chunker.graph.xref.build_xref`,
+  `chunker.graph.cut.graph_cut`) still resolve under v4; and the live v4
+  adoption/migration is verified against a real published v4 (or a pinned
+  pre-release) before the ceiling is raised in a shipped release.
+- IF-0-INFERPOLISH-1 - Redaction completeness: no raw query/document/candidate
+  body or unredacted exception message reaches any rerank, hybrid, or search log
+  path (extends #74's redaction to the legacy/pre-existing sites).
+- IF-0-INFERPOLISH-2 - Profile-gating symmetry + timeout clamp:
+  `learned_models_allowed` fails closed on an unknown explicit profile (mirroring
+  `commercial_egress_allowed`); `EndpointReranker`'s timeout env parse clamps to
+  the same `>=1s` floor the dispatcher uses.
+- IF-0-INFERPOLISH-3 - Provenance honesty + async cancellation safety: the Cohere
+  v2 adapter reports `model_revision=None`/`unknown` when the response supplies
+  none; Voyage `embed_with_provenance` rejects an arity mismatch; a timed-out
+  endpoint transport cannot publish `last_outcome`/`last_diagnostics` after the
+  caller returned (per-call generation guard).
+- IF-0-INFERLIVEGATE-1 - Provenance-bound live gate: a live provider run verifies
+  the live Qdrant collection's indexed commit, corpus checksum, profile
+  fingerprint, and provider revision against the frozen corpus before its metrics
+  count; the verdict records those bindings, and only a passing bound run may move
+  reranking off `dark_opt_in`.
+
+## Phases
+
+### Phase 1 - Treesitter-Chunker v4 Accommodation And Identity-Scheme Safety (CHUNKERSAFE)
+
+**Objective**
+
+Accommodate the imminent `treesitter-chunker` v4 safely (issue #76): raise the
+`<4` pin ceiling and re-pair the `tree_sitter` ABI to v4's requirement; persist
+the chunker identity scheme the index was built under and refuse to incrementally
+reconcile `code_chunks` across a scheme change; provide a tested rebuild
+migration; keep the graph imports resilient to v4's interface consolidation; and
+verify the live adoption against a real published v4 before raising the ceiling in
+a shipped release. CRITICAL — v4's new id scheme is silent data corruption on the
+currently-exposed pin. The version-agnostic safety guard lands now; the live v4
+adoption is gated on v4 publishing.
+
+**Exit criteria**
+
+- [ ] The persisted index records a chunker identity-scheme marker
+      (chunker version + scheme id) alongside `code_chunks`; the marker is written
+      on index and read on re-index.
+- [ ] On re-index, a scheme-marker mismatch does NOT run the
+      `ON CONFLICT(file_id, chunk_id)` incremental upsert
+      (`dispatcher_enhanced.py` ~L3363-3446); it fails closed with an actionable
+      diagnostic and requires an explicit `code_chunks` rebuild.
+- [ ] A tested rebuild migration drops and repopulates `code_chunks` (and
+      invalidates dependent summaries read at `cli/tool_handlers.py:1589-1608`)
+      when adopting the new scheme; no orphaned or duplicated rows survive, and
+      no stale summary keys dangle.
+- [ ] The `pyproject.toml` pin admits v4 (raise the `<4` ceiling, e.g.
+      `>=3.2.2,<5`) and is re-paired to v4's required `tree_sitter` ABI (replace
+      the 3.x `tree_sitter>=0.24,<0.25` note/constraint with v4's), read from v4's
+      own metadata — not guessed. A test asserts the pin admits v4 and the ABI
+      constraint matches v4's requirement.
+- [ ] Live v4 adoption is verified against a real published v4 (or a pinned
+      pre-release): a `code_chunks` build under v4 followed by a re-index shows the
+      scheme-guard + rebuild path engaging with zero orphaned/dangling rows. If v4
+      is not yet available, this criterion is explicitly deferred with the guard,
+      prepared pin, and import resilience already landed — no fabricated run.
+- [ ] A smoke check verifies the graph import shims
+      (`chunker.core.chunk_file`, `chunker.graph.xref.build_xref`,
+      `chunker.graph.cut.graph_cut`, imported under try/except at
+      `mcp_server/graph/xref_adapter.py:14-15` and
+      `mcp_server/utils/semantic_indexer.py:17`) still load after the bump, so a
+      moved path is caught instead of silently degrading graph features to
+      "unavailable" (the degradation messages live at `gateway.py:2875/2986/3030`).
+- [ ] `utils/chunker_adapter.py` is confirmed (by test) ID-agnostic and
+      unaffected.
+
+**Scope notes**
+
+Decompose into **2 lanes**: Lane A (version-agnostic, lands now) - scheme marker
++ fail-closed guard + rebuild migration in the dispatcher `code_chunks` path and
+`storage/sqlite_store.py` schema; Lane B (v4 adoption, gated on v4 publish) - the
+`pyproject.toml` pin-ceiling + `tree_sitter` ABI re-pair, graph-import resilience
+(adopt v4's canonical paths, tolerate the re-export shims) + smoke check, the
+chunker-adapter-unaffected assertion, the live-v4 migration verification, and
+docs. Adopting the new scheme requires a full `code_chunks` rebuild; never
+silently incremental-upsert across it. Lane A is safe to land immediately and
+protects any 3.2.x or v4 scheme change; Lane B's live verification waits for v4 to
+publish. Coordinate the exact `dispatcher_enhanced.py` region (the `code_chunks`
+upsert ~L3389-3396) so INFERPOLISH (which owns the rerank/search-log region of
+the same file) does not overlap.
+
+**Non-goals**
+
+- No redesign of chunk identity (that is upstream's contract).
+- No change to the ID-agnostic `chunker_adapter.py` symbol path.
+
+**Key files**
+
+- `pyproject.toml`
+- `mcp_server/dispatcher/dispatcher_enhanced.py` (`code_chunks` upsert region)
+- `mcp_server/storage/sqlite_store.py` (schema + scheme marker + migration)
+- `mcp_server/graph/xref_adapter.py`, `mcp_server/utils/semantic_indexer.py`
+  (graph import shims; `gateway.py` holds the graph-unavailable messages)
+- `mcp_server/cli/tool_handlers.py` (chunk readback)
+- `mcp_server/utils/chunker_adapter.py` (confirm unaffected)
+- `tests/test_chunker_identity_migration.py` (new),
+  `tests/test_chunker_graph_imports_smoke.py` (new)
+
+**Depends on**
+
+- (none) - starts first; the critical data-integrity fix, ahead of the inference follow-ups.
+
+**Produces**
+
+- IF-0-CHUNKERSAFE-1 - Chunk identity-scheme guard.
+- IF-0-CHUNKERSAFE-2 - Adoption + graph-import safety.
+
+**Spec closeout policy**
+
+- schema: spec_delta_closeout.v1
+- expected_decision: no_spec_delta
+- target_surfaces: `mcp_server/dispatcher/dispatcher_enhanced.py`,
+  `mcp_server/storage/sqlite_store.py`, `pyproject.toml`, `mcp_server/gateway.py`
+- evidence_paths: scheme-mismatch fail-closed + rebuild-migration + graph-import
+  smoke test output
+- redaction_posture: metadata_only
+- blocker_class: contract_bug if an id-scheme change can still incrementally
+  upsert `code_chunks`, if the rebuild migration leaves orphaned/dangling rows,
+  or if a moved graph import path degrades silently.
+
+### Phase 2 - Inference Boundary Polish (INFERPOLISH)
+
+**Objective**
+
+Close the CR nice-to-haves and deferred hygiene items with no behavior change to
+the happy path: complete log redaction, make profile gating symmetric, make
+provider provenance honest, fix the reconcile diagnostic, and make endpoint
+transport timeouts leak-safe.
+
+**Exit criteria**
+
+- [ ] No raw exception body is logged on the legacy async reranker paths
+      (`reranker.py:368/510/641`) or the hybrid semantic-failure path
+      (`hybrid_search.py:402`); all go through the existing redactor.
+- [ ] No raw `topic`/query body is logged on the cross-document / search paths
+      (audit `dispatcher_enhanced.py:3917` and siblings); log lengths/ids only.
+- [ ] `learned_models_allowed` fails closed on an unknown explicit
+      `MCP_DEPLOYMENT_PROFILE`; `EndpointReranker` timeout parse clamps to `>=1s`.
+- [ ] Cohere v2 adapter reports `model_revision` as `None`/`unknown` when the
+      response lacks one (never a config value tagged as provider-reported);
+      `VoyageEmbeddingProvider.embed_with_provenance` raises on an arity mismatch
+      between requested texts and returned embeddings.
+- [ ] A timed-out endpoint transport cannot mutate shared reranker diagnostics
+      after the bridge raised `TimeoutError` (per-call generation guard); the
+      leaked worker is logged, not silently swallowed.
+- [ ] `_existing_collection_shape_blocked` distinguishes a transient Qdrant read
+      error (retryable, non-`blocked`) from a real shape mismatch; the diagnostic
+      text matches the actual cause.
+
+**Scope notes**
+
+Decompose into **3 file-disjoint lanes**:
+- Lane A - rerank/search logging + async safety + timeout clamp + Cohere
+  revision: `mcp_server/indexer/reranker.py`,
+  `mcp_server/indexer/hybrid_search.py`,
+  `mcp_server/dispatcher/dispatcher_enhanced.py`,
+  `mcp_server/dispatcher/cross_repo_coordinator.py`.
+- Lane B - provider + indexer honesty: `mcp_server/utils/embedding_providers.py`
+  (Voyage arity), `mcp_server/utils/semantic_indexer.py` (reconcile transient
+  vs blocked).
+- Lane C - profile symmetry: `mcp_server/config/settings.py`
+  (`learned_models_allowed` fail-closed).
+
+**Non-goals**
+
+- No default-enablement; no contract or dataset changes.
+
+**Key files**
+
+- `mcp_server/indexer/reranker.py`
+- `mcp_server/indexer/hybrid_search.py`
+- `mcp_server/dispatcher/dispatcher_enhanced.py`
+- `mcp_server/dispatcher/cross_repo_coordinator.py`
+- `mcp_server/utils/embedding_providers.py`
+- `mcp_server/utils/semantic_indexer.py`
+- `mcp_server/config/settings.py`
+- `tests/test_reranker_outcomes.py`, `tests/test_rerank_consumer_migration.py`,
+  `tests/test_endpoint_reranker.py`, `tests/test_embedding_provider_provenance.py`,
+  `tests/test_deployment_profiles.py`, `tests/test_embedding_provenance.py`
+
+**Depends on**
+
+- CHUNKERSAFE (sequenced after it so edits to the shared dispatcher file are serialized — disjoint regions, the code_chunks upsert vs rerank/search logging — and the data-integrity fix lands first; otherwise logically independent).
+
+**Produces**
+
+- IF-0-INFERPOLISH-1 - Redaction completeness.
+- IF-0-INFERPOLISH-2 - Profile-gating symmetry + timeout clamp.
+- IF-0-INFERPOLISH-3 - Provenance honesty + async cancellation safety.
+
+**Spec closeout policy**
+
+- schema: spec_delta_closeout.v1
+- expected_decision: no_spec_delta
+- target_surfaces: the rerank/search/provider/settings modules above
+- evidence_paths: redaction + symmetry + provenance + async-safety test output
+- redaction_posture: metadata_only
+- blocker_class: contract_bug if any raw body still reaches a log, if an unknown
+  profile fails open, if a config value is reported as provider-origin, or if a
+  timed-out worker can still publish reranker state.
+
+### Phase 3 - Provenance-Bound Live Rollout Gate (INFERLIVEGATE)
+
+**Objective**
+
+Make the INFERGATE benchmark able to produce trustworthy live numbers: verify the
+live collection's provenance against the frozen corpus before counting metrics,
+run the real dense/hybrid/reranked arms when services are reachable, and record a
+provenance-bound verdict that can (only then) move reranking off `dark_opt_in`.
+
+**Exit criteria**
+
+- [ ] The gate verifies a live Qdrant collection's indexed commit, corpus
+      checksum, profile fingerprint, and provider revision against the frozen
+      corpus/`MANIFEST.json` before any arm's metrics are counted; a mismatch
+      records the arm `not_run` with a provenance-mismatch reason.
+- [ ] When embedding + Qdrant + rerank endpoints are reachable AND provenance
+      verifies, the dense/hybrid/hybrid_rerank arms run on real retrieved
+      document content and produce metrics bound to the verified collection.
+- [ ] The verdict artifact binds indexed-commit + corpus/threshold checksums +
+      provider revision + code commit; holdout remains unused for tuning.
+- [ ] `INFERENCE_ROLLOUT.md` / `SUPPORT_MATRIX.md` are updated only from a
+      passing, provenance-bound run; absent live infra the verdict stays
+      `dark_opt_in` and the phase lands the verification code + a documented
+      run procedure rather than fabricated numbers.
+
+**Scope notes**
+
+Decompose into **2 lanes**: Lane A - live-collection provenance verification in
+`run_inference_gate.py` + real-content arms; then Lane B - verdict binding +
+`INFERENCE_ROLLOUT.md`/`SUPPORT_MATRIX.md` reducer and the operator run
+procedure. This phase must not flip any default without a passing bound run and
+an explicit operator decision.
+
+**Non-goals**
+
+- No fabricated live numbers; no default flip without a passing bound run.
+
+**Key files**
+
+- `benchmarks/retrieval_eval/runs/inferbound-v10/run_inference_gate.py`
+- `mcp_server/benchmarks/retrieval_eval_harness.py`
+- `docs/status/INFERENCE_ROLLOUT.md`
+- `docs/SUPPORT_MATRIX.md`
+- `tests/test_retrieval_benchmark_harness.py`,
+  `tests/docs/test_inference_rollout_report.py`
+
+**Depends on**
+
+- INFERPOLISH (reuses the completed redaction + honest provenance on the arms).
+
+**Produces**
+
+- IF-0-INFERLIVEGATE-1 - Provenance-bound live gate.
+
+**Spec closeout policy**
+
+- schema: spec_delta_closeout.v1
+- expected_decision: roadmap_amendment
+- target_surfaces: future roadmap if a passing run proposes default-enablement
+- evidence_paths: `docs/status/INFERENCE_ROLLOUT.md` + gate run artifact
+- redaction_posture: metadata_only
+- blocker_class: contract_bug if metrics can count without verified collection
+  provenance, or if the verdict flips a default without a passing bound run.
+
+## Phase Dependency DAG
+
+```text
+CHUNKERSAFE ──► INFERPOLISH ──► INFERLIVEGATE
+ (wave 1, 2 lanes)  (wave 2, 3 lanes)   (wave 3, 2 lanes)
+```
+
+CHUNKERSAFE is CRITICAL and lands first (independent subsystem; also owns the
+`code_chunks` region of `dispatcher_enhanced.py`). INFERPOLISH follows to
+serialize edits to that file, then INFERLIVEGATE consumes the polished providers.
+
+## Execution Notes
+
+- CHUNKERSAFE is the priority: v4's new id scheme is silent data corruption on
+  the currently-exposed pin, so it lands first and can ship as its own PR. Its
+  Lane A (version-agnostic scheme guard + rebuild migration) is safe to land
+  immediately; Lane B (raise the `<4` ceiling to admit v4, re-pair the
+  `tree_sitter` ABI, and verify the live v4 migration) is gated on v4 publishing
+  (PyPI latest is `3.2.2` as of 2026-07-12). Do not raise the shipped pin ceiling
+  before a real v4 (or pinned pre-release) migration run passes. The guard must
+  refuse silent incremental upsert across any scheme change regardless of timing.
+- INFERPOLISH's 3 lanes are file-disjoint and run concurrently; it is pure
+  hygiene/honesty with no default changes and can land as its own PR. It reopens
+  the rerank/search-log region of `dispatcher_enhanced.py` after CHUNKERSAFE has
+  finished the `code_chunks` region of the same file.
+- INFERLIVEGATE is infra-gated: without a reachable embedding endpoint + a
+  populated, provenance-matching collection, it lands the verification code and
+  a run procedure and leaves the verdict `dark_opt_in`. Do not fabricate numbers.
+- Keep the pre-existing green suite green; capture a failing-at-base repro for
+  each fix before implementing it.
+
+## Verification
+
+- `phase-loop validate-roadmap specs/phase-plans-v12.md`
+- `uv run --no-sync pytest tests/test_chunker_identity_migration.py tests/test_chunker_graph_imports_smoke.py -q --no-cov`
+- `uv run --no-sync pytest tests/test_reranker_outcomes.py tests/test_rerank_consumer_migration.py tests/test_endpoint_reranker.py -q --no-cov`
+- `uv run --no-sync pytest tests/test_embedding_provider_provenance.py tests/test_embedding_provenance.py tests/test_deployment_profiles.py -q --no-cov`
+- `uv run --no-sync pytest tests/test_retrieval_benchmark_harness.py tests/docs/test_inference_rollout_report.py -q --no-cov`
+
+automation:
+  status: ready
+  next_skill: claude-plan-phase
+  next_command: claude-plan-phase specs/phase-plans-v12.md CHUNKERSAFE
+  next_model_hint: claude-opus-4-8
+  next_effort_hint: medium
+  human_required: false
+  verification_status: not_run
+  artifact: specs/phase-plans-v12.md
+  next_phase: CHUNKERSAFE

--- a/tests/test_chunker_graph_imports_smoke.py
+++ b/tests/test_chunker_graph_imports_smoke.py
@@ -1,0 +1,270 @@
+"""Grep-derived smoke tests for the ``chunker`` (treesitter-chunker) surface.
+
+Two disjoint CHUNKERSAFE Lane A checks live here:
+
+1. ``test_all_chunker_imports_resolve`` — at *runtime* greps ``mcp_server/`` for
+   every ``chunker`` import site (``from chunker... import ...`` / ``import
+   chunker...``), derives the (module, symbol) pairs from what it finds (nothing
+   is hand-enumerated), and asserts each one imports/resolves under the installed
+   ``treesitter-chunker``. This catches a v4 interface-consolidation move that
+   relocates a symbol/module out from under an import, which would otherwise
+   degrade silently. Failure is hard (ImportError / resolves-to-None -> assert),
+   never a soft skip.
+
+2. ``test_part_like_query_escapes_metacharacters`` — proves the ``:part:`` LIKE
+   query in ``IncrementalIndexer._get_chunk_ids_for_path`` matches only a
+   chunk_id's own ``:part:`` rows even when the id contains SQL LIKE
+   metacharacters (``%`` / ``_``), which v4's collision-free ids may contain.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MCP_SERVER_DIR = REPO_ROOT / "mcp_server"
+
+# ``from <module> import <names>`` where module is chunker or a chunker submodule.
+_FROM_RE = re.compile(
+    r"^\s*from\s+(chunker(?:\.[A-Za-z0-9_.]+)?)\s+import\s+(.+?)\s*$"
+)
+# ``import <module>`` (optionally ``as alias``) where module is chunker/submodule.
+_IMPORT_RE = re.compile(
+    r"^\s*import\s+(chunker(?:\.[A-Za-z0-9_.]+)?)(?:\s+as\s+[A-Za-z0-9_]+)?\s*$"
+)
+
+
+def _grep_chunker_import_lines() -> List[str]:
+    """Grep mcp_server/ for every chunker import line.
+
+    Uses ``grep`` at runtime (per spec) rather than a static/hand-maintained
+    list. Returns the raw matching source lines.
+    """
+    result = subprocess.run(
+        [
+            "grep",
+            "-rhE",
+            r"(from[[:space:]]+chunker([.][A-Za-z0-9_.]+)?[[:space:]]+import|^[[:space:]]*import[[:space:]]+chunker)",
+            str(MCP_SERVER_DIR),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # grep exit code 1 == "no matches"; that is itself a failure for this repo.
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"grep failed (rc={result.returncode}): {result.stderr.strip()}"
+        )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _parse_import_targets(lines: List[str]) -> List[Tuple[str, str]]:
+    """Derive (module, symbol) pairs from grepped import lines.
+
+    ``symbol`` is ``""`` for a bare ``import chunker.x`` (module-only resolution).
+    ``import X as Y`` binds are reduced to their real (pre-``as``) name.
+    """
+    pairs: set[Tuple[str, str]] = set()
+    for line in lines:
+        m = _FROM_RE.match(line)
+        if m:
+            module = m.group(1)
+            names = m.group(2)
+            # Strip a trailing inline comment, if any.
+            names = names.split("#", 1)[0]
+            # Defensive: drop wrapping parens for single-line grouped imports.
+            names = names.strip().strip("()")
+            for raw in names.split(","):
+                raw = raw.strip()
+                if not raw or raw == "*":
+                    continue
+                # ``name as alias`` -> real name is the pre-``as`` token.
+                symbol = re.split(r"\s+as\s+", raw)[0].strip()
+                if symbol:
+                    pairs.add((module, symbol))
+            continue
+        m = _IMPORT_RE.match(line)
+        if m:
+            pairs.add((m.group(1), ""))
+    return sorted(pairs)
+
+
+def test_grep_finds_chunker_imports():
+    """Sanity: the runtime grep must actually find import sites.
+
+    Guards against a silently-empty grep (wrong path / broken pattern) that would
+    make the resolution test vacuously pass.
+    """
+    lines = _grep_chunker_import_lines()
+    pairs = _parse_import_targets(lines)
+    # Not hand-enumerated, but a broken grep would yield 0; the repo has many.
+    assert len(pairs) >= 6, f"grep derived too few chunker imports: {pairs}"
+
+
+def test_all_chunker_imports_resolve():
+    """Every grepped chunker import must resolve under installed treesitter-chunker.
+
+    Hard failure (assert) on ImportError or a resolves-to-None symbol; no soft
+    "unavailable" path.
+    """
+    pairs = _parse_import_targets(_grep_chunker_import_lines())
+    assert pairs, "no chunker imports discovered by grep"
+
+    failures: List[str] = []
+    for module_name, symbol in pairs:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:  # ImportError and anything raised at import
+            failures.append(f"import {module_name!r} failed: {exc!r}")
+            continue
+        if not symbol:
+            continue
+        if not hasattr(module, symbol):
+            failures.append(f"{module_name}.{symbol} is missing")
+            continue
+        if getattr(module, symbol) is None:
+            failures.append(f"{module_name}.{symbol} resolved to None")
+
+    assert not failures, (
+        "chunker import surface degraded (v4 interface move?):\n  "
+        + "\n  ".join(failures)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CHUNKERSAFE Lane A item 2: :part: LIKE metacharacter escaping.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def like_indexer(tmp_path: Path):
+    from mcp_server.core.path_resolver import PathResolver
+    from mcp_server.core.repo_context import RepoContext
+    from mcp_server.indexing.incremental_indexer import IncrementalIndexer
+    from mcp_server.storage.sqlite_store import SQLiteStore
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+
+    store = SQLiteStore(
+        str(tmp_path / "code_index.db"), path_resolver=PathResolver(repo_path)
+    )
+    repo_id = store.create_repository(str(repo_path), "test-repo")
+    ctx = RepoContext(
+        repo_id=repo_id,
+        sqlite_store=store,
+        workspace_root=repo_path,
+        tracked_branch="main",
+        registry_entry=SimpleNamespace(repository_id=repo_id, path=repo_path),
+    )
+    indexer = IncrementalIndexer(
+        store=store,
+        dispatcher=None,
+        repo_path=repo_path,
+        semantic_indexer=None,
+        ctx=ctx,
+    )
+    indexer._get_repository_id = lambda: repo_id  # type: ignore[method-assign]
+    return repo_path, store, indexer, repo_id
+
+
+def test_part_like_query_escapes_metacharacters(like_indexer):
+    """A chunk_id containing % / _ matches only its own :part: rows.
+
+    Under an unescaped ``chunk_id LIKE '<id>:part:%'`` query, a ``%`` in the id
+    matches any run of characters and ``_`` matches any single character, so a
+    chunk id like ``a%b`` would wrongly harvest an unrelated file's
+    ``aXYZb:part:1`` semantic point. With ESCAPE-clause metacharacter escaping,
+    only literal matches survive.
+    """
+    repo_path, store, indexer, repo_id = like_indexer
+
+    # Target file whose chunk ids contain LIKE metacharacters.
+    target_file = repo_path / "target.py"
+    target_file.write_text("x = 1\n")
+    target_id = store.store_file(repo_id, target_file, language="python")
+    store.store_chunk(
+        file_id=target_id,
+        content="x = 1",
+        content_start=0,
+        content_end=5,
+        line_start=1,
+        line_end=1,
+        chunk_id="a%b",  # contains the '%' multi-char wildcard
+        node_id="node-a",
+        treesitter_file_id="ts-a",
+    )
+    store.store_chunk(
+        file_id=target_id,
+        content="x = 1",
+        content_start=0,
+        content_end=5,
+        line_start=1,
+        line_end=1,
+        chunk_id="c_d",  # contains the '_' single-char wildcard
+        node_id="node-c",
+        treesitter_file_id="ts-c",
+    )
+
+    # A DIFFERENT file whose semantic points would be caught by the unescaped
+    # wildcards ('a' + any + 'b', 'c' + one char + 'd') but must NOT be returned.
+    other_file = repo_path / "other.py"
+    other_file.write_text("y = 2\n")
+    other_id = store.store_file(repo_id, other_file, language="python")
+    store.store_chunk(
+        file_id=other_id,
+        content="y = 2",
+        content_start=0,
+        content_end=5,
+        line_start=1,
+        line_end=1,
+        chunk_id="aZZb",
+        node_id="node-z",
+        treesitter_file_id="ts-z",
+    )
+
+    # Own :part: rows for the target chunks (should be returned).
+    store.upsert_semantic_point(
+        profile_id="test-profile",
+        chunk_id="a%b:part:1:2",
+        point_id=7001,
+        collection="code-index",
+    )
+    store.upsert_semantic_point(
+        profile_id="test-profile",
+        chunk_id="c_d:part:1:2",
+        point_id=7002,
+        collection="code-index",
+    )
+    # Foreign :part: rows that ONLY an unescaped LIKE would mis-match.
+    store.upsert_semantic_point(
+        profile_id="test-profile",
+        chunk_id="aZZb:part:1:2",  # matched by unescaped 'a%b:part:%'
+        point_id=7003,
+        collection="code-index",
+    )
+    store.upsert_semantic_point(
+        profile_id="test-profile",
+        chunk_id="cXd:part:1:2",  # matched by unescaped 'c_d:part:%'
+        point_id=7004,
+        collection="code-index",
+    )
+
+    resolved = indexer._get_chunk_ids_for_path("target.py")
+
+    # Base chunk ids for the target file are always present.
+    assert "a%b" in resolved
+    assert "c_d" in resolved
+    # Its own :part: rows are harvested.
+    assert "a%b:part:1:2" in resolved
+    assert "c_d:part:1:2" in resolved
+    # The foreign rows must NOT leak in (this is the escape bug this test guards).
+    assert "aZZb:part:1:2" not in resolved
+    assert "cXd:part:1:2" not in resolved

--- a/tests/test_chunker_identity_migration.py
+++ b/tests/test_chunker_identity_migration.py
@@ -188,40 +188,103 @@ def test_mismatch_refuses_plugin_path(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# 3. Missing marker over non-empty index fails closed on read AND write
+# 3. Unmarked non-empty index: legacy-compatible (B1) vs new-scheme fail-closed
 # --------------------------------------------------------------------------- #
-def test_missing_marker_over_nonempty_index_fails_closed(tmp_path):
+def test_unmarked_v1_index_is_compatible_and_autostamps(tmp_path):
+    """B1: an existing (v3-built) index has no marker, but the chunk-id algorithm
+    was stable across chunker majors 1-3, so under a v1 runtime it genuinely IS
+    v1.  Treat it as compatible, allow read+write, and auto-stamp the marker -
+    never brick every legacy index by refusing it as a scheme mismatch."""
     store = _make_store(tmp_path)
     file_id = _make_file(store)
     _store_code_chunk(store, file_id, "c1")
-    _clear_marker(store)  # v3-unmarked legacy fixture
+    _clear_marker(store)  # legacy/unmarked fixture; runtime scheme is v1
 
+    with store._get_connection() as conn:
+        status, marker, target = evaluate_chunk_scheme(conn)
+    assert status == "compatible_legacy"
+    assert marker is None
+    assert target == current_chunk_id_scheme() == "treesitter_chunk_id_v1"
+
+    # Read is allowed (a genuinely-compatible legacy index must not fail closed).
+    with sqlite3.connect(store.db_path) as raw:
+        assert_chunk_scheme_readable(raw)  # does not raise
+    assert store.get_chunks_for_file(file_id)  # store-level read allowed
+
+    # Write is allowed AND durably auto-stamps the marker as v1.
+    _store_code_chunk(store, file_id, "c2")
+    assert store.get_chunk_scheme_marker() == "treesitter_chunk_id_v1"
+    status, marker, _ = store.get_chunk_scheme_status()
+    assert status == "compatible"
+
+
+def test_unmarked_index_under_new_scheme_fails_closed(tmp_path, monkeypatch):
+    """A real scheme change (>=v4) over an unmarked index IS a genuine mismatch:
+    ``missing_marker`` - fail closed on read, write, and delete."""
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")  # stamps v1
+    _clear_marker(store)
+
+    _force_scheme(monkeypatch, "treesitter_chunk_id_v4")
     with store._get_connection() as conn:
         status, marker, _ = evaluate_chunk_scheme(conn)
     assert status == "missing_marker"
     assert marker is None
 
     before = _count_chunks(store)
-
-    # Write fails closed.
     with pytest.raises(ChunkSchemeMismatchError):
         _store_code_chunk(store, file_id, "c2")
-    # Delete fails closed.
     with pytest.raises(ChunkSchemeMismatchError):
         store.delete_chunks_for_file(file_id)
-    # Read fails closed.
     with sqlite3.connect(store.db_path) as raw:
         with pytest.raises(ChunkSchemeMismatchError):
             assert_chunk_scheme_readable(raw)
-
     assert _count_chunks(store) == before  # no read/delete/upsert mutated the index
+
+
+def test_store_level_read_fails_closed_under_mismatch(tmp_path):
+    """Fix #2: store-level readers route through the central read guard, so a
+    direct get_chunk over a scheme-mismatched DB fails closed - not only at the
+    tool-layer perimeter."""
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+    _insert_summary(store, "c1", file_id)
+    # Simulate a foreign-scheme (v4-built) index read by this (v1) runtime.
+    with store._get_connection() as conn:
+        conn.execute(
+            "UPDATE index_config SET config_value = ? WHERE config_key = ?",
+            (FOREIGN_SCHEME, CHUNK_SCHEME_MARKER_KEY),
+        )
+    with store._get_connection() as conn:
+        status, _marker, _ = evaluate_chunk_scheme(conn)
+    assert status == "mismatch"
+
+    for reader in (
+        lambda: store.get_chunk_by_chunk_id("c1", file_id=file_id),
+        lambda: store.get_chunk_by_node_id("node-c1"),
+        lambda: store.get_chunk_by_definition_id("def-1"),
+        lambda: store.get_chunks_for_file(file_id),
+        lambda: store.get_missing_summaries(),
+        lambda: store.find_best_chunk_for_file(file_id, ["f"]),
+        lambda: store.find_chunk_at_line("/repo/a.py", 1),
+    ):
+        with pytest.raises(ChunkSchemeMismatchError):
+            reader()
 
 
 def test_readiness_reports_scheme_mismatch_not_ready(tmp_path):
     store = _make_store(tmp_path)
     file_id = _make_file(store)
     _store_code_chunk(store, file_id, "c1")
-    _clear_marker(store)
+    # A foreign-scheme marker (v4-built index under a v1 runtime) is a genuine
+    # mismatch that readiness must surface as non-ready.
+    with store._get_connection() as conn:
+        conn.execute(
+            "UPDATE index_config SET config_value = ? WHERE config_key = ?",
+            (FOREIGN_SCHEME, CHUNK_SCHEME_MARKER_KEY),
+        )
 
     state = repository_readiness._inspect_index_uncached(
         __import__("pathlib").Path(store.db_path)
@@ -292,24 +355,139 @@ def test_rebuild_invalidates_dependent_stores_and_preserves_synthetic(tmp_path):
     assert store.get_chunk_scheme_marker() == current_chunk_id_scheme()
 
 
+def _rebuild_write(store: SQLiteStore, file_id: int, chunk_id: str, target: str) -> int:
+    """The explicitly-scoped rebuild writer: writes rows tagged with the rebuild's
+    target scheme so they are admitted during the ``rebuilding`` window."""
+    return store.store_chunk(
+        file_id=file_id,
+        content="x\n",
+        content_start=0,
+        content_end=1,
+        line_start=1,
+        line_end=1,
+        chunk_id=chunk_id,
+        node_id=f"node-{chunk_id}",
+        treesitter_file_id="t",
+        scheme_target=target,
+    )
+
+
 def test_rebuild_flips_marker_only_after_repopulation(tmp_path):
     store = _make_store(tmp_path)
-    _seed_for_rebuild(store)
+    code_file, _hist = _seed_for_rebuild(store)
     marker_before = store.get_chunk_scheme_marker()
 
-    # Phase 1 only: invalidate + enter rebuilding, marker NOT yet flipped.
+    # Phase 1: invalidate + enter rebuilding to a NEW scheme; marker NOT flipped.
     store.begin_chunk_scheme_rebuild(FOREIGN_SCHEME, profile_id="profile-a")
     with store._get_connection() as conn:
         status, _marker, _target = evaluate_chunk_scheme(conn, FOREIGN_SCHEME)
     assert status == "rebuilding"
     assert store.get_chunk_scheme_marker() == marker_before  # unchanged
 
-    # Phase 2: finalize flips the marker and clears the rebuilding flag.
+    # An ordinary (old-scheme) writer must NOT commit rows during the rebuild
+    # window - only the explicitly-scoped rebuild writer may (fix #3).
+    with pytest.raises(ChunkSchemeMismatchError):
+        _store_code_chunk(store, code_file, "wrong-scheme")  # target = v1 runtime
+
+    # Repopulate with the rebuild writer (scheme_target == the rebuild target).
+    _rebuild_write(store, code_file, "rebuilt-1", FOREIGN_SCHEME)
+
+    # Phase 2: finalize now flips the marker and clears the rebuilding flag.
     store.finalize_chunk_scheme_rebuild(FOREIGN_SCHEME)
     assert store.get_chunk_scheme_marker() == FOREIGN_SCHEME
     with store._get_connection() as conn:
         status, marker, _ = evaluate_chunk_scheme(conn, FOREIGN_SCHEME)
     assert status == "compatible"
+
+
+def test_finalize_refuses_empty_or_mismatched_target(tmp_path):
+    """Fix #3: finalize is not a rubber stamp - it refuses to flip the marker when
+    no repopulation happened or the caller's target != the recorded rebuild
+    target."""
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)
+    store.begin_chunk_scheme_rebuild(FOREIGN_SCHEME, profile_id="profile-a")
+
+    # No repopulation yet -> finalize must refuse (would stamp an empty index).
+    with pytest.raises(ChunkSchemeMismatchError) as empty_exc:
+        store.finalize_chunk_scheme_rebuild(FOREIGN_SCHEME)
+    assert empty_exc.value.state == "rebuild_not_repopulated"
+    assert store.get_chunk_scheme_marker() != FOREIGN_SCHEME  # still not flipped
+
+    # Repopulate, then a finalize whose target != recorded rebuild target refuses.
+    resumed = _make_file(store, "resumed.py")
+    _rebuild_write(store, resumed, "rebuilt-1", FOREIGN_SCHEME)
+    with pytest.raises(ChunkSchemeMismatchError) as mismatch_exc:
+        store.finalize_chunk_scheme_rebuild("treesitter_chunk_id_v9_other")
+    assert mismatch_exc.value.state == "rebuild_target_mismatch"
+
+    # Correct target with repopulation present -> finalizes.
+    store.finalize_chunk_scheme_rebuild(FOREIGN_SCHEME)
+    assert store.get_chunk_scheme_marker() == FOREIGN_SCHEME
+
+    # A second finalize (no rebuild in progress) refuses.
+    with pytest.raises(ChunkSchemeMismatchError) as done_exc:
+        store.finalize_chunk_scheme_rebuild(FOREIGN_SCHEME)
+    assert done_exc.value.state == "not_rebuilding"
+
+
+def test_rebuild_invalidates_all_profiles_semantic_mappings(tmp_path):
+    """Fix #4: the scheme marker is DB-wide, so a rebuild must invalidate EVERY
+    profile's stale semantic-point mappings, not just the caller's profile."""
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)  # profile-a mappings (101, 102) + document (900)
+    # A second profile with its own chunker + preserved-document mappings.
+    store.upsert_semantic_point("profile-b", "code-chunk-1", 201, "col-b")
+    store.upsert_semantic_point("profile-b", "history:issue", 901, "col-b")
+
+    result = store.rebuild_chunk_scheme(profile_id="profile-a")  # begin (no repopulate)
+
+    with store._get_connection() as conn:
+        remaining = {
+            (r[0], r[1])
+            for r in conn.execute("SELECT profile_id, chunk_id FROM semantic_points")
+        }
+    # Both profiles' chunker mappings gone; both profiles' document mapping kept.
+    assert ("profile-a", "code-chunk-1") not in remaining
+    assert ("profile-b", "code-chunk-1") not in remaining
+    assert ("profile-a", "history:issue") in remaining
+    assert ("profile-b", "history:issue") in remaining
+
+    # Returned stale points span BOTH profiles (with their collections) so remote
+    # cleanup can target the right collection for each.
+    returned = {(p["profile_id"], p["point_id"], p["collection"]) for p in result["points"]}
+    assert ("profile-a", 101, "col-a") in returned
+    assert ("profile-a", 102, "col-a") in returned
+    assert ("profile-b", 201, "col-b") in returned
+
+
+def test_rebuild_persists_pending_vector_deletions_ledger(tmp_path):
+    """Fix #7 (I4): stale remote-vector ids are persisted to a durable crash-ledger
+    inside the invalidation transaction, so a crash before the caller's remote
+    cleanup cannot orphan them."""
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)
+    store.upsert_semantic_point("profile-b", "code-chunk-2", 202, "col-b")
+
+    assert store.get_pending_vector_deletions() == []
+
+    store.begin_chunk_scheme_rebuild(profile_id="profile-a")
+
+    ledger = store.get_pending_vector_deletions()
+    point_ids = {row["point_id"] for row in ledger}
+    # Every chunker point (all profiles) recorded; preserved document point kept.
+    assert {101, 102, 202}.issubset(point_ids)
+    assert 900 not in point_ids
+
+    # Ledger survives the local semantic_points delete (rows gone, ledger stays).
+    with store._get_connection() as conn:
+        remaining = {r[0] for r in conn.execute("SELECT point_id FROM semantic_points")}
+    assert remaining == {900}
+
+    # Clearing after remote cleanup drains the ledger.
+    cleared = store.clear_pending_vector_deletions()
+    assert cleared == len(ledger)
+    assert store.get_pending_vector_deletions() == []
 
 
 # --------------------------------------------------------------------------- #
@@ -381,3 +559,36 @@ def test_update_chunk_token_count_scoped_by_file_id(tmp_path):
     chunk_b = store.get_chunk_by_chunk_id(shared_chunk_id, file_id=file_b)
     assert chunk_a["token_count"] == 42
     assert chunk_b["token_count"] is None  # sibling file untouched
+
+
+# --------------------------------------------------------------------------- #
+# 7. Lock-contention must fail loud, not be misread as an empty index (I1)
+# --------------------------------------------------------------------------- #
+def test_scheme_probe_reraises_non_schema_operational_error():
+    """Fix #5 (I1): a lock/contention ``OperationalError`` must propagate, not be
+    swallowed as 'absent' - swallowing it would let a marked, locked DB be
+    reclassified ``empty`` and silently re-stamped with a new scheme.  Only a
+    genuine missing-table/column (schema-not-present) is treated as absent."""
+
+    class _LockedConn:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    with pytest.raises(sqlite3.OperationalError):
+        sqlite_store_module._has_chunker_rows(_LockedConn())
+    with pytest.raises(sqlite3.OperationalError):
+        sqlite_store_module._scheme_read_config_value(_LockedConn(), "k")
+
+    class _NoTableConn:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("no such table: code_chunks")
+
+    # A genuinely-absent schema is still treated as absent (no raise).
+    assert sqlite_store_module._has_chunker_rows(_NoTableConn()) is False
+
+    class _NoColumnConn:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("no such column: chunk_type")
+
+    # An older/minimal schema (table present, column absent) is absent, not corrupt.
+    assert sqlite_store_module._has_chunker_rows(_NoColumnConn()) is False

--- a/tests/test_chunker_identity_migration.py
+++ b/tests/test_chunker_identity_migration.py
@@ -1,0 +1,383 @@
+"""CHUNKERSAFE Lane A - chunker identity-scheme guard + atomic rebuild.
+
+These tests pin the version-agnostic data-integrity contract: a single central
+choke point refuses every ``code_chunks`` write/delete and every
+scheme-dependent read across an id-scheme boundary, a missing marker over a
+non-empty index fails closed, and an atomic rebuild coherently invalidates the
+dependent stores (summaries, semantic point mappings, remote vector ids) while
+preserving synthetic history/document rows and flipping the marker only after
+repopulation.
+
+They fail at base because the guard, marker, typed error, and rebuild entry
+points do not exist there (ImportError on the symbols below).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from mcp_server.health import repository_readiness
+from mcp_server.health.repository_readiness import RepositoryReadinessState
+from mcp_server.storage import sqlite_store as sqlite_store_module
+from mcp_server.storage.sqlite_store import (
+    CHUNK_SCHEME_MARKER_KEY,
+    ChunkSchemeMismatchError,
+    SQLiteStore,
+    assert_chunk_scheme_readable,
+    current_chunk_id_scheme,
+    evaluate_chunk_scheme,
+)
+
+FOREIGN_SCHEME = "treesitter_chunk_id_v4_foreign"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _make_store(tmp_path) -> SQLiteStore:
+    return SQLiteStore(str(tmp_path / "code_index.db"))
+
+
+def _make_file(store: SQLiteStore, name: str = "a.py") -> int:
+    repo_id = store.create_repository(str(name) + "-repo-root", f"repo-{name}")
+    return store.store_file(
+        repository_id=repo_id,
+        path=f"/repo/{name}",
+        relative_path=name,
+        language="python",
+    )
+
+
+def _store_code_chunk(store: SQLiteStore, file_id: int, chunk_id: str, index: int = 0) -> int:
+    return store.store_chunk(
+        file_id=file_id,
+        content=f"def f_{chunk_id}():\n    return 1\n",
+        content_start=0,
+        content_end=20,
+        line_start=1,
+        line_end=2,
+        chunk_id=chunk_id,
+        node_id=f"node-{chunk_id}",
+        treesitter_file_id="tsfile",
+        language="python",
+        chunk_index=index,
+    )
+
+
+def _store_document_chunk(store: SQLiteStore, file_id: int, chunk_id: str) -> int:
+    """Synthetic non-chunker row (history/document), must survive a rebuild."""
+    return store.store_chunk(
+        file_id=file_id,
+        content="# history document\n",
+        content_start=0,
+        content_end=18,
+        line_start=1,
+        line_end=1,
+        chunk_id=chunk_id,
+        node_id=chunk_id,
+        treesitter_file_id="history",
+        chunk_type="document",
+        language="history",
+    )
+
+
+def _insert_summary(store: SQLiteStore, chunk_hash: str, file_id: int) -> None:
+    with store._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO chunk_summaries (chunk_hash, file_id, chunk_start, chunk_end, "
+            "summary_text) VALUES (?, ?, 0, 1, ?)",
+            (chunk_hash, file_id, f"summary of {chunk_hash}"),
+        )
+
+
+def _clear_marker(store: SQLiteStore) -> None:
+    """Simulate a legacy / v3-unmarked index: chunker rows present, no marker."""
+    with store._get_connection() as conn:
+        conn.execute(
+            "DELETE FROM index_config WHERE config_key = ?", (CHUNK_SCHEME_MARKER_KEY,)
+        )
+
+
+def _force_scheme(monkeypatch, value: str) -> None:
+    monkeypatch.setattr(sqlite_store_module, "current_chunk_id_scheme", lambda: value)
+
+
+def _count_chunks(store: SQLiteStore) -> int:
+    with store._get_connection() as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM code_chunks").fetchone()[0])
+
+
+# --------------------------------------------------------------------------- #
+# 1. Empty index stamps the scheme on first build
+# --------------------------------------------------------------------------- #
+def test_empty_index_stamps_scheme_on_first_build(tmp_path):
+    store = _make_store(tmp_path)
+    assert store.get_chunk_scheme_marker() is None
+
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+
+    assert store.get_chunk_scheme_marker() == current_chunk_id_scheme()
+    status, marker, target = store.get_chunk_scheme_status()
+    assert status == "compatible"
+    assert marker == target == current_chunk_id_scheme()
+
+
+def test_document_rows_do_not_stamp_or_trip_the_guard(tmp_path, monkeypatch):
+    """Synthetic document rows bypass the chunker guard entirely."""
+    store = _make_store(tmp_path)
+    file_id = _make_file(store, "hist.md")
+    _store_document_chunk(store, file_id, "history:issue")
+    # No chunker rows -> still unmarked (document writes never stamp).
+    assert store.get_chunk_scheme_marker() is None
+    # Even under a foreign scheme, a document write is allowed.
+    _force_scheme(monkeypatch, FOREIGN_SCHEME)
+    _store_document_chunk(store, file_id, "history:comment")
+    assert store.get_chunk_scheme_marker() is None
+
+
+# --------------------------------------------------------------------------- #
+# 2. Scheme mismatch refuses store_chunk AND dispatcher path AND plugin path
+# --------------------------------------------------------------------------- #
+def test_mismatch_refuses_store_chunk(tmp_path, monkeypatch):
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")  # stamps current scheme
+    before = _count_chunks(store)
+
+    _force_scheme(monkeypatch, FOREIGN_SCHEME)
+    with pytest.raises(ChunkSchemeMismatchError) as excinfo:
+        _store_code_chunk(store, file_id, "c2")
+    assert excinfo.value.state == "mismatch"
+    assert excinfo.value.expected == FOREIGN_SCHEME
+    assert _count_chunks(store) == before  # no upsert occurred
+
+
+def test_mismatch_refuses_dispatcher_raw_path(tmp_path, monkeypatch):
+    """The dispatcher raw upsert routes through store._assert_chunk_scheme_writable
+    before any delete/insert (dispatcher_enhanced.py _persist_index_shard)."""
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+
+    _force_scheme(monkeypatch, FOREIGN_SCHEME)
+    with store._get_connection() as conn:
+        with pytest.raises(ChunkSchemeMismatchError):
+            # Exact call the dispatcher makes before _clear_file_index_rows.
+            store._assert_chunk_scheme_writable(conn, chunk_type="code")
+
+
+def test_mismatch_refuses_plugin_path(tmp_path, monkeypatch):
+    """Plugins call delete_chunks_for_file + store_chunk directly; both are
+    guarded, so no delete or upsert happens under a scheme mismatch."""
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+    before = _count_chunks(store)
+
+    _force_scheme(monkeypatch, FOREIGN_SCHEME)
+    # Plugin step 1: delete old chunks -> must refuse (would destroy coherent rows).
+    with pytest.raises(ChunkSchemeMismatchError):
+        store.delete_chunks_for_file(file_id)
+    # Plugin step 2: store new chunk -> must refuse.
+    with pytest.raises(ChunkSchemeMismatchError):
+        _store_code_chunk(store, file_id, "c2")
+    assert _count_chunks(store) == before  # nothing deleted, nothing written
+
+
+# --------------------------------------------------------------------------- #
+# 3. Missing marker over non-empty index fails closed on read AND write
+# --------------------------------------------------------------------------- #
+def test_missing_marker_over_nonempty_index_fails_closed(tmp_path):
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+    _clear_marker(store)  # v3-unmarked legacy fixture
+
+    with store._get_connection() as conn:
+        status, marker, _ = evaluate_chunk_scheme(conn)
+    assert status == "missing_marker"
+    assert marker is None
+
+    before = _count_chunks(store)
+
+    # Write fails closed.
+    with pytest.raises(ChunkSchemeMismatchError):
+        _store_code_chunk(store, file_id, "c2")
+    # Delete fails closed.
+    with pytest.raises(ChunkSchemeMismatchError):
+        store.delete_chunks_for_file(file_id)
+    # Read fails closed.
+    with sqlite3.connect(store.db_path) as raw:
+        with pytest.raises(ChunkSchemeMismatchError):
+            assert_chunk_scheme_readable(raw)
+
+    assert _count_chunks(store) == before  # no read/delete/upsert mutated the index
+
+
+def test_readiness_reports_scheme_mismatch_not_ready(tmp_path):
+    store = _make_store(tmp_path)
+    file_id = _make_file(store)
+    _store_code_chunk(store, file_id, "c1")
+    _clear_marker(store)
+
+    state = repository_readiness._inspect_index_uncached(
+        __import__("pathlib").Path(store.db_path)
+    )
+    assert state == RepositoryReadinessState.SCHEME_MISMATCH
+
+
+# --------------------------------------------------------------------------- #
+# 4. Atomic rebuild: cross-store cleanup + preserve synthetic rows + returns ids
+# --------------------------------------------------------------------------- #
+def _seed_for_rebuild(store: SQLiteStore):
+    code_file = _make_file(store, "code.py")
+    hist_file = _make_file(store, "hist.md")
+
+    _store_code_chunk(store, code_file, "code-chunk-1", index=0)
+    _store_code_chunk(store, code_file, "code-chunk-2", index=1)
+    _store_document_chunk(store, hist_file, "history:issue")
+
+    # Summaries for both chunker chunks and the preserved document chunk.
+    _insert_summary(store, "code-chunk-1", code_file)
+    _insert_summary(store, "code-chunk-2", code_file)
+    _insert_summary(store, "history:issue", hist_file)
+
+    # Semantic point mappings (chunker + document).
+    store.upsert_semantic_point("profile-a", "code-chunk-1", 101, "col-a")
+    store.upsert_semantic_point("profile-a", "code-chunk-2", 102, "col-a")
+    store.upsert_semantic_point("profile-a", "history:issue", 900, "col-a")
+    return code_file, hist_file
+
+
+def test_rebuild_invalidates_dependent_stores_and_preserves_synthetic(tmp_path):
+    store = _make_store(tmp_path)
+    code_file, hist_file = _seed_for_rebuild(store)
+
+    def repopulate(conn):
+        conn.execute(
+            "INSERT INTO code_chunks (file_id, content, content_start, content_end, "
+            "line_start, line_end, chunk_id, node_id, treesitter_file_id, chunk_type) "
+            "VALUES (?, 'x', 0, 1, 1, 1, 'new-chunk-1', 'n', 't', 'code')",
+            (code_file,),
+        )
+
+    result = store.rebuild_chunk_scheme(profile_id="profile-a", repopulate=repopulate)
+
+    with store._get_connection() as conn:
+        chunk_ids = {r[0] for r in conn.execute("SELECT chunk_id FROM code_chunks")}
+        summary_hashes = {r[0] for r in conn.execute("SELECT chunk_hash FROM chunk_summaries")}
+        point_ids = {r[0] for r in conn.execute("SELECT point_id FROM semantic_points")}
+
+    # Old chunker rows gone; repopulated row present; synthetic document preserved.
+    assert "code-chunk-1" not in chunk_ids
+    assert "code-chunk-2" not in chunk_ids
+    assert "new-chunk-1" in chunk_ids
+    assert "history:issue" in chunk_ids
+
+    # Chunker summaries removed, document summary preserved (no dangling rows).
+    assert summary_hashes == {"history:issue"}
+
+    # Chunker point mappings removed, document mapping preserved.
+    assert point_ids == {900}
+
+    # Stale remote-vector ids returned for Qdrant cleanup (chunker only).
+    returned_points = {p["point_id"] for p in result["points"]}
+    assert returned_points == {101, 102}
+    assert set(result["chunk_ids"]) == {"code-chunk-1", "code-chunk-2"}
+
+    # Marker flipped to current scheme after repopulation.
+    assert store.get_chunk_scheme_marker() == current_chunk_id_scheme()
+
+
+def test_rebuild_flips_marker_only_after_repopulation(tmp_path):
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)
+    marker_before = store.get_chunk_scheme_marker()
+
+    # Phase 1 only: invalidate + enter rebuilding, marker NOT yet flipped.
+    store.begin_chunk_scheme_rebuild(FOREIGN_SCHEME, profile_id="profile-a")
+    with store._get_connection() as conn:
+        status, _marker, _target = evaluate_chunk_scheme(conn, FOREIGN_SCHEME)
+    assert status == "rebuilding"
+    assert store.get_chunk_scheme_marker() == marker_before  # unchanged
+
+    # Phase 2: finalize flips the marker and clears the rebuilding flag.
+    store.finalize_chunk_scheme_rebuild(FOREIGN_SCHEME)
+    assert store.get_chunk_scheme_marker() == FOREIGN_SCHEME
+    with store._get_connection() as conn:
+        status, marker, _ = evaluate_chunk_scheme(conn, FOREIGN_SCHEME)
+    assert status == "compatible"
+
+
+# --------------------------------------------------------------------------- #
+# 5. Interrupted rebuild: old-coherent OR blocked/resumable, never ready
+# --------------------------------------------------------------------------- #
+def test_interrupted_rebuild_rolls_back_to_old_coherent_index(tmp_path):
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)
+
+    class Boom(RuntimeError):
+        pass
+
+    def repopulate(conn):
+        raise Boom("crash mid-rebuild")
+
+    with pytest.raises(Boom):
+        store.rebuild_chunk_scheme(profile_id="profile-a", repopulate=repopulate)
+
+    # Old, coherent index survives untouched (rows + marker), no rebuild flag.
+    with store._get_connection() as conn:
+        chunk_ids = {r[0] for r in conn.execute("SELECT chunk_id FROM code_chunks")}
+        status, _marker, _ = evaluate_chunk_scheme(conn)
+    assert {"code-chunk-1", "code-chunk-2", "history:issue"}.issubset(chunk_ids)
+    assert status == "compatible"
+
+
+def test_interrupted_rebuild_leaves_blocked_resumable_non_ready(tmp_path):
+    from pathlib import Path
+
+    store = _make_store(tmp_path)
+    _seed_for_rebuild(store)
+
+    # Phase 1 commits, then the process "crashes" before finalize.
+    store.begin_chunk_scheme_rebuild(profile_id="profile-a")
+
+    # Readiness is non-ready (rebuilding), not table-presence 'ready'.
+    state = repository_readiness._inspect_index_uncached(Path(store.db_path))
+    assert state == RepositoryReadinessState.INDEX_REBUILDING
+
+    # Reads fail closed while rebuilding.
+    with sqlite3.connect(store.db_path) as raw:
+        with pytest.raises(ChunkSchemeMismatchError):
+            assert_chunk_scheme_readable(raw)
+
+    # Resumable: repopulate then finalize -> ready/compatible.
+    file_id = _make_file(store, "resumed.py")
+    _store_code_chunk(store, file_id, "resumed-1")  # allowed during rebuilding
+    store.finalize_chunk_scheme_rebuild()
+    state = repository_readiness._inspect_index_uncached(Path(store.db_path))
+    assert state is None  # healthy
+
+
+# --------------------------------------------------------------------------- #
+# 6. update_chunk_token_count is scoped by file_id (no cross-file collision)
+# --------------------------------------------------------------------------- #
+def test_update_chunk_token_count_scoped_by_file_id(tmp_path):
+    store = _make_store(tmp_path)
+    file_a = _make_file(store, "a.py")
+    file_b = _make_file(store, "b.py")
+
+    shared_chunk_id = "dup-chunk"
+    _store_code_chunk(store, file_a, shared_chunk_id)
+    _store_code_chunk(store, file_b, shared_chunk_id)
+
+    updated = store.update_chunk_token_count(shared_chunk_id, 42, file_id=file_a)
+    assert updated is True
+
+    chunk_a = store.get_chunk_by_chunk_id(shared_chunk_id, file_id=file_a)
+    chunk_b = store.get_chunk_by_chunk_id(shared_chunk_id, file_id=file_b)
+    assert chunk_a["token_count"] == 42
+    assert chunk_b["token_count"] is None  # sibling file untouched

--- a/tests/test_chunker_scheme_recovery.py
+++ b/tests/test_chunker_scheme_recovery.py
@@ -1,0 +1,405 @@
+"""CHUNKERSAFE Lane A - scheme-mismatch recovery is NOT a dead-end.
+
+The Lane A guard makes a chunker-scheme-mismatched (or mid-rebuild) index report
+readiness ``SCHEME_MISMATCH`` / ``INDEX_REBUILDING`` and fail closed on
+reads/writes.  The review panel found the recovery path was broken: readiness
+told the operator to "run reindex", but reindex/rebuild REFUSED those exact
+states, so a tripped index was a permanent dead-end.
+
+These tests pin the recovery contract that was missing when the dead-end shipped:
+
+* the two tripped states are recoverable through both the ``handle_reindex``
+  guard set and the staged full-rebuild guard set (regression guard on the fix);
+* the REAL staged full-rebuild tool path (``git_index_manager.rebuild_repository_index``
+  -- what ``handle_reindex`` invokes) actually runs for a ``SCHEME_MISMATCH``
+  index, quarantines the old bytes, and republishes a clean single-scheme index
+  stamped with the CURRENT scheme, ready, with no dangling summaries/points; and
+* the in-place ``begin_chunk_scheme_rebuild`` -> reindex -> ``finalize`` path
+  preserves synthetic history/document rows, drops the chunker-derived
+  summaries/semantic points (no dangling rows), and returns the stale Qdrant
+  point ids a caller feeds to ``delete_stale_vectors`` /
+  ``cleanup_stale_semantic_artifacts``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server.cli import tool_handlers as tool_handlers_module
+from mcp_server.gateway import _RECOVERABLE_REINDEX_STATES as GATEWAY_RECOVERABLE
+from mcp_server.health import repository_readiness
+from mcp_server.health.repository_readiness import (
+    ReadinessClassifier,
+    RepositoryReadinessState,
+)
+from mcp_server.storage.git_index_manager import (
+    GitAwareIndexManager,
+    _QUARANTINE_REBUILD_STATES,
+    _RECOVERABLE_REBUILD_STATES,
+)
+from mcp_server.storage.multi_repo_manager import RepositoryInfo
+from mcp_server.storage.sqlite_store import (
+    CHUNK_SCHEME_MARKER_KEY,
+    ChunkSchemeMismatchError,
+    SQLiteStore,
+    assert_chunk_scheme_readable,
+    current_chunk_id_scheme,
+    evaluate_chunk_scheme,
+)
+
+TOOL_RECOVERABLE = tool_handlers_module._RECOVERABLE_REINDEX_STATES
+
+# A scheme value the installed chunker will never emit -> forces a mismatch.
+FOREIGN_SCHEME = "treesitter_chunk_id_recovery_foreign"
+
+
+# --------------------------------------------------------------------------- #
+# Seed helpers (active index built under one scheme, with dependent artifacts)
+# --------------------------------------------------------------------------- #
+def _store_code_chunk(store: SQLiteStore, file_id: int, chunk_id: str, index: int = 0) -> None:
+    store.store_chunk(
+        file_id=file_id,
+        content=f"def f_{index}():\n    return {index}\n",
+        content_start=0,
+        content_end=20,
+        line_start=1,
+        line_end=2,
+        chunk_id=chunk_id,
+        node_id=f"node-{chunk_id}",
+        treesitter_file_id="tsfile",
+        language="python",
+        chunk_index=index,
+    )
+
+
+def _store_document_chunk(store: SQLiteStore, file_id: int, chunk_id: str) -> None:
+    """Synthetic (non-chunker) history/document row that must survive a rebuild."""
+    store.store_chunk(
+        file_id=file_id,
+        content="# history document\n",
+        content_start=0,
+        content_end=18,
+        line_start=1,
+        line_end=1,
+        chunk_id=chunk_id,
+        node_id=chunk_id,
+        treesitter_file_id="history",
+        chunk_type="document",
+        language="history",
+    )
+
+
+def _insert_summary(store: SQLiteStore, chunk_hash: str, file_id: int) -> None:
+    with store._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO chunk_summaries (chunk_hash, file_id, chunk_start, chunk_end, "
+            "summary_text) VALUES (?, ?, 0, 1, ?)",
+            (chunk_hash, file_id, f"summary of {chunk_hash}"),
+        )
+
+
+def _seed_active_index(index_path: Path, repo_path: Path) -> None:
+    """Build a code_chunks index (marker stamped to the current scheme) with
+    chunk summaries and semantic point mappings, plus a preserved synthetic row.
+    """
+    store = SQLiteStore(str(index_path))
+    repo_row = store.ensure_repository_row(repo_path, name="test-repo")
+    code_file = store.store_file(
+        repo_row, path=repo_path / "hello.py", relative_path="hello.py", language="python"
+    )
+    hist_file = store.store_file(
+        repo_row, path=repo_path / "history.md", relative_path="history.md", language="history"
+    )
+    _store_code_chunk(store, code_file, "code-chunk-1", index=0)  # stamps current scheme
+    _store_code_chunk(store, code_file, "code-chunk-2", index=1)
+    _store_document_chunk(store, hist_file, "history:issue")
+
+    _insert_summary(store, "code-chunk-1", code_file)
+    _insert_summary(store, "code-chunk-2", code_file)
+    _insert_summary(store, "history:issue", hist_file)
+
+    store.upsert_semantic_point("profile-a", "code-chunk-1", 101, "col-a")
+    store.upsert_semantic_point("profile-a", "code-chunk-2", 102, "col-a")
+    store.upsert_semantic_point("profile-a", "history:issue", 900, "col-a")
+
+    assert store.get_chunk_scheme_marker() == current_chunk_id_scheme()
+    store.close()
+
+
+def _force_scheme_mismatch(index_path: Path) -> None:
+    """Rewrite the persisted marker to a foreign scheme so the index reads as a
+    genuine cross-scheme mismatch against the installed chunker."""
+    with sqlite3.connect(str(index_path)) as conn:
+        conn.execute(
+            "UPDATE index_config SET config_value = ? WHERE config_key = ?",
+            (FOREIGN_SCHEME, CHUNK_SCHEME_MARKER_KEY),
+        )
+    ReadinessClassifier.clear_index_inspection_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Git + registry harness for the REAL staged full-rebuild tool path
+# --------------------------------------------------------------------------- #
+def _make_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True
+    )
+    (repo / "hello.py").write_text("def hello():\n    return 1\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def _head_commit(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _make_repo_info(repo: Path, commit: str) -> RepositoryInfo:
+    index_dir = repo.parent / "index"
+    index_dir.mkdir(exist_ok=True)
+    return RepositoryInfo(
+        repository_id="recovery-repo",
+        name="test-repo",
+        path=repo,
+        index_path=index_dir / "current.db",
+        language_stats={},
+        total_files=1,
+        total_symbols=0,
+        indexed_at=datetime.now(),
+        current_commit=commit,
+        last_indexed_commit=commit,
+        tracked_branch="main",
+        current_branch="main",
+    )
+
+
+class _RecoveryDispatcher:
+    """Minimal dispatcher for the staged full rebuild.
+
+    ``_full_index`` only calls ``index_directory``.  It writes a real chunker row
+    into the FRESH stage DB (stamping the CURRENT scheme on first write) plus a
+    synthetic history/document row, mirroring a full reindex that re-materializes
+    both the code chunks and the history/doc stage.
+    """
+
+    def index_directory(self, ctx, path, recursive=True):
+        store = ctx.sqlite_store
+        row_id = store.ensure_repository_row(Path(path), name="test-repo")
+        file_id = store.store_file(
+            row_id, path=Path(path) / "hello.py", relative_path="hello.py", language="python"
+        )
+        store.store_chunk(
+            file_id=file_id,
+            content="def hello():\n    return 1\n",
+            content_start=0,
+            content_end=24,
+            line_start=1,
+            line_end=2,
+            chunk_id="rebuilt-chunk-1",
+            node_id="node-rebuilt-1",
+            treesitter_file_id="tsfile",
+            language="python",
+            chunk_index=0,
+        )
+        store.store_chunk(
+            file_id=file_id,
+            content="# history\n",
+            content_start=0,
+            content_end=10,
+            line_start=1,
+            line_end=1,
+            chunk_id="history:issue",
+            node_id="history:issue",
+            treesitter_file_id="history",
+            chunk_type="document",
+            language="history",
+        )
+        return {"indexed_files": 1, "failed_files": 0, "errors": []}
+
+
+def _make_manager(repo_info: RepositoryInfo, commit: str):
+    registry = MagicMock()
+    registry.get_repository.return_value = repo_info
+    registry.update_git_state.return_value = {"commit": commit, "branch": "main"}
+    registry.update_indexed_commit.return_value = commit
+
+    def _update_staleness(_repo_id, reason):
+        repo_info.staleness_reason = reason
+        return True
+
+    registry.update_staleness_reason.side_effect = _update_staleness
+    manager = GitAwareIndexManager(registry, _RecoveryDispatcher())
+    manager._resolve_ctx = MagicMock(return_value=None)
+    return manager, registry
+
+
+# --------------------------------------------------------------------------- #
+# 1. Regression guard: the tripped states are recoverable in every guard set
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "state",
+    [
+        RepositoryReadinessState.SCHEME_MISMATCH,
+        RepositoryReadinessState.INDEX_REBUILDING,
+    ],
+)
+def test_tripped_states_are_recoverable_everywhere(state):
+    # handle_reindex (CLI) and the HTTP gateway both admit these for recovery.
+    assert state in TOOL_RECOVERABLE
+    assert state in GATEWAY_RECOVERABLE
+    # The staged full rebuild runs for them and preserves the old bytes first.
+    assert state in _RECOVERABLE_REBUILD_STATES
+    assert state in _QUARANTINE_REBUILD_STATES
+
+
+# --------------------------------------------------------------------------- #
+# 2. E2E: a SCHEME_MISMATCH index is refused, then recovered by the REAL tool
+# --------------------------------------------------------------------------- #
+def test_scheme_mismatch_is_refused_then_recovered_by_staged_rebuild(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    commit = _head_commit(repo)
+    repo_info = _make_repo_info(repo, commit)
+    index_path = repo_info.index_path
+
+    _seed_active_index(index_path, repo)
+    _force_scheme_mismatch(index_path)
+
+    # --- readiness reports the tripped state (not a healthy 'ready') ---
+    readiness = ReadinessClassifier.classify_registered(repo_info)
+    assert readiness.state == RepositoryReadinessState.SCHEME_MISMATCH
+    assert not readiness.ready
+    assert "reindex" in (readiness.remediation or "").lower()
+
+    # --- reads AND writes fail closed under the mismatch ---
+    with sqlite3.connect(str(index_path)) as raw:
+        with pytest.raises(ChunkSchemeMismatchError):
+            assert_chunk_scheme_readable(raw)
+    guarded = SQLiteStore(str(index_path))
+    with pytest.raises(ChunkSchemeMismatchError):
+        _store_code_chunk(guarded, 1, "should-not-write")
+    guarded.close()
+
+    # --- the readiness remediation is now actionable (the dead-end fix) ---
+    assert readiness.state in _RECOVERABLE_REBUILD_STATES
+
+    # --- invoke the REAL reindex/rebuild tool path ---
+    manager, registry = _make_manager(repo_info, commit)
+    result = manager.rebuild_repository_index(repo_info.repository_id)
+
+    assert result.action == "full_index", result.error
+    # It ran *because* of the mismatch, and preserved the old bytes for forensics.
+    assert result.readiness["previous_state"] == "scheme_mismatch"
+    quarantine_path = Path(result.readiness["quarantine_path"])
+    assert quarantine_path.exists()
+
+    # --- the republished index is clean, ready, and single-scheme (current) ---
+    ReadinessClassifier.clear_index_inspection_cache()
+    assert ReadinessClassifier.classify_registered(repo_info).ready is True
+
+    recovered = SQLiteStore(str(index_path))
+    assert recovered.get_chunk_scheme_marker() == current_chunk_id_scheme()
+    status, marker, target = recovered.get_chunk_scheme_status()
+    assert status == "compatible"
+    assert marker == target == current_chunk_id_scheme()
+    recovered.close()
+
+    with sqlite3.connect(str(index_path)) as conn:
+        chunk_ids = {r[0] for r in conn.execute("SELECT chunk_id FROM code_chunks")}
+        summary_hashes = {r[0] for r in conn.execute("SELECT chunk_hash FROM chunk_summaries")}
+        point_chunk_ids = {r[0] for r in conn.execute("SELECT chunk_id FROM semantic_points")}
+
+    # Fresh single-scheme rows only; the stale old-scheme chunk ids are gone.
+    assert "rebuilt-chunk-1" in chunk_ids
+    assert "code-chunk-1" not in chunk_ids and "code-chunk-2" not in chunk_ids
+    # Synthetic history/document row is present after recovery.
+    assert "history:issue" in chunk_ids
+    # No dangling summaries / semantic points survived the republish.
+    assert summary_hashes <= chunk_ids
+    assert point_chunk_ids <= chunk_ids
+    assert "code-chunk-1" not in summary_hashes and "code-chunk-1" not in point_chunk_ids
+
+    # The recovered index reads without tripping the guard.
+    with sqlite3.connect(str(index_path)) as raw:
+        assert_chunk_scheme_readable(raw)  # does not raise
+
+    # Provenance was recorded for the rebuilt commit.
+    registry.update_indexed_commit.assert_called_once_with(
+        repo_info.repository_id, commit, branch="main"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. In-place rebuild: preserve synthetic rows, drop chunker artifacts, return
+#    the stale Qdrant point ids for delete_stale_vectors/cleanup.
+# --------------------------------------------------------------------------- #
+def test_inplace_rebuild_preserves_synthetic_and_returns_stale_vector_ids(tmp_path):
+    index_path = tmp_path / "code_index.db"
+    store = SQLiteStore(str(index_path))
+    repo_row = store.ensure_repository_row(tmp_path, name="test-repo")
+    code_file = store.store_file(
+        repo_row, path=tmp_path / "a.py", relative_path="a.py", language="python"
+    )
+    hist_file = store.store_file(
+        repo_row, path=tmp_path / "h.md", relative_path="h.md", language="history"
+    )
+    _store_code_chunk(store, code_file, "code-chunk-1", index=0)
+    _store_code_chunk(store, code_file, "code-chunk-2", index=1)
+    _store_document_chunk(store, hist_file, "history:issue")
+    _insert_summary(store, "code-chunk-1", code_file)
+    _insert_summary(store, "code-chunk-2", code_file)
+    _insert_summary(store, "history:issue", hist_file)
+    store.upsert_semantic_point("profile-a", "code-chunk-1", 101, "col-a")
+    store.upsert_semantic_point("profile-a", "code-chunk-2", 102, "col-a")
+    store.upsert_semantic_point("profile-a", "history:issue", 900, "col-a")
+
+    # Phase 1: invalidate + enter the blocked, resumable 'rebuilding' state.
+    stale = store.begin_chunk_scheme_rebuild(profile_id="profile-a")
+
+    # The stale remote-vector ids handed to delete_stale_vectors /
+    # cleanup_stale_semantic_artifacts cover the chunker points only.
+    assert set(stale["chunk_ids"]) == {"code-chunk-1", "code-chunk-2"}
+    assert {p["point_id"] for p in stale["points"]} == {101, 102}
+    assert all(p["chunk_id"].startswith("code-chunk") for p in stale["points"])
+
+    # While rebuilding, readiness is non-ready and reads fail closed.
+    state = repository_readiness._inspect_index_uncached(index_path)
+    assert state == RepositoryReadinessState.INDEX_REBUILDING
+    with sqlite3.connect(str(index_path)) as raw:
+        with pytest.raises(ChunkSchemeMismatchError):
+            assert_chunk_scheme_readable(raw)
+
+    # Phase 2: repopulate under the rebuild target, then finalize.
+    _store_code_chunk(store, code_file, "code-chunk-1-v2", index=0)
+    store.finalize_chunk_scheme_rebuild()
+
+    # Recovered: ready, current marker, chunker artifacts gone, synthetic kept.
+    assert repository_readiness._inspect_index_uncached(index_path) is None
+    assert store.get_chunk_scheme_marker() == current_chunk_id_scheme()
+    with store._get_connection() as conn:
+        chunk_ids = {r[0] for r in conn.execute("SELECT chunk_id FROM code_chunks")}
+        summary_hashes = {r[0] for r in conn.execute("SELECT chunk_hash FROM chunk_summaries")}
+        point_ids = {r[0] for r in conn.execute("SELECT point_id FROM semantic_points")}
+        status, _marker, _target = evaluate_chunk_scheme(conn)
+
+    assert status == "compatible"
+    assert "code-chunk-1-v2" in chunk_ids
+    assert "code-chunk-1" not in chunk_ids and "code-chunk-2" not in chunk_ids
+    # Synthetic history/document row + its dependent artifacts survive untouched.
+    assert "history:issue" in chunk_ids
+    assert summary_hashes == {"history:issue"}  # chunker summaries dropped, no dangling
+    assert point_ids == {900}  # chunker point mappings dropped, no dangling
+    store.close()

--- a/tests/test_repository_readiness.py
+++ b/tests/test_repository_readiness.py
@@ -50,6 +50,8 @@ def test_readiness_state_values_are_exact():
         "corrupt_sqlite",
         "missing_schema",
         "missing_provenance",
+        "scheme_mismatch",
+        "index_rebuilding",
     }
 
 


### PR DESCRIPTION
Phased roadmap (`specs/phase-plans-v12.md`, validated — 3 phases) folding in the open issue **#76** (CRITICAL `treesitter-chunker` v4 id-scheme break) plus the deferred inference-boundary follow-ups from #73/#74.

## Phases (serial DAG: CHUNKERSAFE → INFERPOLISH → INFERLIVEGATE)

1. **CHUNKERSAFE** (Phase 1, CRITICAL — issue #76) — accommodate the imminent `treesitter-chunker` v4.
   - *Lane A (now, version-agnostic):* persist a chunker identity-scheme marker; on re-index a scheme mismatch refuses the `ON CONFLICT(file_id, chunk_id)` incremental upsert and forces an explicit `code_chunks` rebuild (guards against silent corruption from v4's new collision-free ids).
   - *Lane B (gated on v4 publish):* raise the `<4` pin ceiling to admit v4, re-pair the `tree_sitter` ABI to v4's requirement, keep the graph imports (`chunk_file`/`build_xref`/`graph_cut`) resilient to v4's interface consolidation, and verify the live migration against a real v4 — no fabricated run; the shipped pin ceiling is not raised until that passes.
2. **INFERPOLISH** — redaction completeness, profile-gating symmetry, provenance honesty, async-cancellation safety, reconcile diagnostics (the #73/#74 CR nice-to-haves).
3. **INFERLIVEGATE** — provenance-bound live benchmark; moves reranking off `dark_opt_in` only with a passing, provenance-verified run.

This PR lands the roadmap; CHUNKERSAFE implementation follows (Lane A now, Lane B when v4 publishes). INFERPOLISH/INFERLIVEGATE are subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
