### PR TITLE
CHUNKERSAFE Lane B: adopt treesitter-chunker v4

### DIFF
--- a/mcp_server/utils/treesitter_wrapper.py
+++ b/mcp_server/utils/treesitter_wrapper.py
@@ -1,7 +1,7 @@
 """Thin wrapper for parsing files with Tree-sitter.
 
 This wrapper only exposes a minimal interface required by the tests.  It
-loads the prebuilt Python grammar distributed with ``tree_sitter_languages``
+loads the prebuilt Python grammar distributed with ``tree_sitter_language_pack``
 and provides a helper to parse a file and return the root node of the parsed
 tree as an S-expression string.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,16 +27,13 @@ dependencies = [
     "mcp>=1.0.0",
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
-    "treesitter-chunker>=3.1.0,<4",
-    # Legacy tree-sitter deps (for backward compatibility during migration)
-    # ABI-paired with treesitter-chunker 3.x: chunker pins tree_sitter>=0.24,<0.25
-    # and tree-sitter-language-pack>=0.9,<1.0 (pre-compiled grammars must match the
-    # tree_sitter ABI). language-pack 0.13.0+ requires tree_sitter>=0.25, which would
-    # break chunker, so the joint window is 0.9.x. Dedicated c/cpp plugins load grammars
-    # from tree-sitter-language-pack and work under 0.9.0.
-    "tree-sitter>=0.24,<0.25",
-    "tree-sitter-language-pack>=0.9,<1.0",
-    "tree-sitter-languages>=1.7.0; sys_platform=='linux'",
+    "treesitter-chunker>=4,<5",
+    # ABI-paired with treesitter-chunker 4.x: chunker requires tree_sitter>=0.25,<0.26
+    # and tree-sitter-language-pack>=0.9,<0.10 (pre-compiled grammars must match the
+    # tree_sitter ABI). v4 moved the joint window up to the tree_sitter 0.25.x ABI
+    # (3.x was tree_sitter 0.24.x). Grammars load from tree-sitter-language-pack.
+    "tree-sitter>=0.25,<0.26",
+    "tree-sitter-language-pack>=0.9,<0.10",
     "jedi>=0.19.0",
     "watchdog>=3.0.0",
     "click>=8.1.0",

--- a/tests/test_chunker_identity_migration.py
+++ b/tests/test_chunker_identity_migration.py
@@ -190,21 +190,28 @@ def test_mismatch_refuses_plugin_path(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------- #
 # 3. Unmarked non-empty index: legacy-compatible (B1) vs new-scheme fail-closed
 # --------------------------------------------------------------------------- #
-def test_unmarked_v1_index_is_compatible_and_autostamps(tmp_path):
+def test_unmarked_v1_index_is_compatible_and_autostamps(tmp_path, monkeypatch):
     """B1: an existing (v3-built) index has no marker, but the chunk-id algorithm
     was stable across chunker majors 1-3, so under a v1 runtime it genuinely IS
     v1.  Treat it as compatible, allow read+write, and auto-stamp the marker -
-    never brick every legacy index by refusing it as a scheme mismatch."""
+    never brick every legacy index by refusing it as a scheme mismatch.
+
+    Forces the v1 runtime scheme so the behavior is asserted regardless of the
+    installed chunker major (under a real v4 runtime this path correctly does not
+    fire - see test_unmarked_index_under_new_scheme_fails_closed)."""
+    _force_scheme(monkeypatch, "treesitter_chunk_id_v1")  # legacy v1 runtime
     store = _make_store(tmp_path)
     file_id = _make_file(store)
     _store_code_chunk(store, file_id, "c1")
-    _clear_marker(store)  # legacy/unmarked fixture; runtime scheme is v1
+    _clear_marker(store)  # legacy/unmarked fixture
 
     with store._get_connection() as conn:
         status, marker, target = evaluate_chunk_scheme(conn)
     assert status == "compatible_legacy"
     assert marker is None
-    assert target == current_chunk_id_scheme() == "treesitter_chunk_id_v1"
+    # target reflects the forced v1 runtime (the directly-imported
+    # current_chunk_id_scheme() bypasses the module-attr patch under a real v4 env).
+    assert target == "treesitter_chunk_id_v1"
 
     # Read is allowed (a genuinely-compatible legacy index must not fail closed).
     with sqlite3.connect(store.db_path) as raw:

--- a/tests/test_chunker_v4_contract.py
+++ b/tests/test_chunker_v4_contract.py
@@ -1,0 +1,107 @@
+"""Real-v4 functional contract test for treesitter-chunker (CHUNKERSAFE Lane B).
+
+Pins the treesitter-chunker v4 surface the Code-Index-MCP callers depend on, so a
+future v4.x change that moves an import, renames a ``CodeChunk`` field, or
+reshapes chunk metadata fails here instead of silently degrading indexing.
+
+Skips cleanly when the installed chunker is not v4 (e.g. a 3.x dev environment),
+so the suite stays green on both sides of the adoption.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+chunker = pytest.importorskip("chunker")
+
+
+def _chunker_major() -> int:
+    try:
+        from importlib.metadata import version
+
+        return int(version("treesitter-chunker").split(".")[0])
+    except Exception:  # pragma: no cover - defensive
+        return 0
+
+
+pytestmark = pytest.mark.skipif(
+    _chunker_major() < 4,
+    reason="real-v4 contract test requires treesitter-chunker>=4",
+)
+
+# The exact call sites the dispatcher/plugins/graph use.
+from chunker import CodeChunk, chunk_text  # noqa: E402
+
+_PY_SRC = (
+    "def foo(x):\n"
+    "    '''Docstring.'''\n"
+    "    return x + 1\n"
+    "\n"
+    "class Bar:\n"
+    "    def baz(self):\n"
+    "        return 2\n"
+)
+
+
+def test_chunk_text_returns_nonempty_chunks():
+    chunks = chunk_text(_PY_SRC, "python")
+    assert chunks, "v4 chunk_text produced no chunks"
+    assert all(isinstance(c, CodeChunk) for c in chunks)
+
+
+def test_codechunk_attribute_contract():
+    """Every attribute the dispatcher (chunk.__dict__) and plugins read must exist."""
+    chunk = chunk_text(_PY_SRC, "python")[0]
+    # dispatcher_enhanced.py persists chunk.__dict__
+    assert hasattr(chunk, "__dict__")
+    for attr in (
+        "chunk_id",
+        "node_id",
+        "definition_id",
+        "parent_chunk_id",
+        "byte_start",
+        "byte_end",
+        "start_line",
+        "end_line",
+        "node_type",
+        "metadata",
+    ):
+        assert hasattr(chunk, attr), f"v4 CodeChunk lost attribute {attr!r}"
+    assert isinstance(chunk.chunk_id, str) and chunk.chunk_id
+    assert isinstance(chunk.byte_start, int) and isinstance(chunk.byte_end, int)
+    assert isinstance(chunk.metadata, dict)
+
+
+def test_v4_metadata_shape_is_adapter_compatible():
+    """v4 nests the symbol name under metadata['signature']['name']; the
+    version-tolerant chunker_adapter must still recover a symbol name + signature."""
+    from mcp_server.utils.chunker_adapter import ChunkerAdapter
+
+    adapter = ChunkerAdapter()
+    func_chunk = next(
+        c for c in chunk_text(_PY_SRC, "python") if c.node_type == "function_definition"
+    )
+    name = adapter._get_symbol_name(func_chunk)
+    assert name == "foo", f"adapter failed to recover v4 symbol name (got {name!r})"
+    sig = adapter._get_signature(func_chunk)
+    assert sig, "adapter recovered no signature from v4 metadata"
+
+
+def test_graph_imports_resolve_and_are_callable():
+    """xref/graph-cut imports (used by the graph features) still resolve under v4."""
+    from chunker.core import chunk_file  # noqa: F401
+    from chunker.graph.cut import graph_cut
+    from chunker.graph.xref import build_xref
+
+    assert callable(build_xref)
+    assert callable(graph_cut)
+
+
+def test_lane_a_guard_derives_v4_scheme():
+    """The CHUNKERSAFE identity-scheme guard must recognize v4 as a distinct
+    scheme (so a v1/v3-built index trips the guard and rebuilds)."""
+    from mcp_server.storage.sqlite_store import current_chunk_id_scheme
+
+    scheme = current_chunk_id_scheme()
+    assert scheme == "treesitter_chunk_id_v4", scheme
+    assert scheme != "treesitter_chunk_id_v1"

--- a/uv.lock
+++ b/uv.lock
@@ -1731,7 +1731,6 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
-    { name = "tree-sitter-languages", marker = "sys_platform == 'linux'" },
     { name = "treesitter-chunker" },
     { name = "uvicorn" },
     { name = "voyageai" },
@@ -1949,10 +1948,9 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'production'", specifier = ">=2.0" },
     { name = "tabulate", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0.1" },
-    { name = "tree-sitter", specifier = ">=0.24,<0.25" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.9,<1.0" },
-    { name = "tree-sitter-languages", marker = "sys_platform == 'linux'", specifier = ">=1.7.0" },
-    { name = "treesitter-chunker", specifier = ">=3.1.0,<4" },
+    { name = "tree-sitter", specifier = ">=0.25,<0.26" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.9,<0.10" },
+    { name = "treesitter-chunker", specifier = ">=4,<5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "types-setuptools", marker = "extra == 'dev'", specifier = ">=68.0.0" },
@@ -5427,24 +5425,31 @@ wheels = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.0"
+version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a2/698b9d31d08ad5558f8bfbfe3a0781bd4b1f284e89bde3ad18e05101a892/tree-sitter-0.24.0.tar.gz", hash = "sha256:abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734", size = 168304, upload-time = "2025-01-17T05:06:38.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/57/3a590f287b5aa60c07d5545953912be3d252481bf5e178f750db75572bff/tree_sitter-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14beeff5f11e223c37be7d5d119819880601a80d0399abe8c738ae2288804afc", size = 140788, upload-time = "2025-01-17T05:06:08.492Z" },
-    { url = "https://files.pythonhosted.org/packages/61/0b/fc289e0cba7dbe77c6655a4dd949cd23c663fd62a8b4d8f02f97e28d7fe5/tree_sitter-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26a5b130f70d5925d67b47db314da209063664585a2fd36fa69e0717738efaf4", size = 133945, upload-time = "2025-01-17T05:06:12.39Z" },
-    { url = "https://files.pythonhosted.org/packages/86/d7/80767238308a137e0b5b5c947aa243e3c1e3e430e6d0d5ae94b9a9ffd1a2/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fc5c3c26d83c9d0ecb4fc4304fba35f034b7761d35286b936c1db1217558b4e", size = 564819, upload-time = "2025-01-17T05:06:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b3/6c5574f4b937b836601f5fb556b24804b0a6341f2eb42f40c0e6464339f4/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:772e1bd8c0931c866b848d0369b32218ac97c24b04790ec4b0e409901945dd8e", size = 579303, upload-time = "2025-01-17T05:06:16.685Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/f4/bd0ddf9abe242ea67cca18a64810f8af230fc1ea74b28bb702e838ccd874/tree_sitter-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:24a8dd03b0d6b8812425f3b84d2f4763322684e38baf74e5bb766128b5633dc7", size = 581054, upload-time = "2025-01-17T05:06:19.439Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/1c/ff23fa4931b6ef1bbeac461b904ca7e49eaec7e7e5398584e3eef836ec96/tree_sitter-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9e8b1605ab60ed43803100f067eed71b0b0e6c1fb9860a262727dbfbbb74751", size = 120221, upload-time = "2025-01-17T05:06:20.654Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2a/9979c626f303177b7612a802237d0533155bf1e425ff6f73cc40f25453e2/tree_sitter-0.24.0-cp312-cp312-win_arm64.whl", hash = "sha256:f733a83d8355fc95561582b66bbea92ffd365c5d7a665bc9ebd25e049c2b2abb", size = 108234, upload-time = "2025-01-17T05:06:21.713Z" },
-    { url = "https://files.pythonhosted.org/packages/61/cd/2348339c85803330ce38cee1c6cbbfa78a656b34ff58606ebaf5c9e83bd0/tree_sitter-0.24.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d4a6416ed421c4210f0ca405a4834d5ccfbb8ad6692d4d74f7773ef68f92071", size = 140781, upload-time = "2025-01-17T05:06:22.82Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/a3/1ea9d8b64e8dcfcc0051028a9c84a630301290995cd6e947bf88267ef7b1/tree_sitter-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0992d483677e71d5c5d37f30dfb2e3afec2f932a9c53eec4fca13869b788c6c", size = 133928, upload-time = "2025-01-17T05:06:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ae/55c1055609c9428a4aedf4b164400ab9adb0b1bf1538b51f4b3748a6c983/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57277a12fbcefb1c8b206186068d456c600dbfbc3fd6c76968ee22614c5cd5ad", size = 564497, upload-time = "2025-01-17T05:06:27.53Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d0/f2ffcd04882c5aa28d205a787353130cbf84b2b8a977fd211bdc3b399ae3/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25fa22766d63f73716c6fec1a31ee5cf904aa429484256bd5fdf5259051ed74", size = 578917, upload-time = "2025-01-17T05:06:31.057Z" },
-    { url = "https://files.pythonhosted.org/packages/af/82/aebe78ea23a2b3a79324993d4915f3093ad1af43d7c2208ee90be9273273/tree_sitter-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d5d9537507e1c8c5fa9935b34f320bfec4114d675e028f3ad94f11cf9db37b9", size = 581148, upload-time = "2025-01-17T05:06:32.409Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/b4/6b0291a590c2b0417cfdb64ccb8ea242f270a46ed429c641fbc2bfab77e0/tree_sitter-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:f58bb4956917715ec4d5a28681829a8dad5c342cafd4aea269f9132a83ca9b34", size = 120207, upload-time = "2025-01-17T05:06:34.841Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/18/542fd844b75272630229c9939b03f7db232c71a9d82aadc59c596319ea6a/tree_sitter-0.24.0-cp313-cp313-win_arm64.whl", hash = "sha256:23641bd25dcd4bb0b6fa91b8fb3f46cc9f1c9f475efe4d536d3f1f688d1b84c8", size = 108232, upload-time = "2025-01-17T05:06:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
 ]
 
 [[package]]
@@ -5498,22 +5503,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tree-sitter-languages"
-version = "1.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tree-sitter" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/6c/1855a65c9d6b50600f7a68e0182153db7cb12ff81fdebd93e87851dfdd8f/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15db3c8510bc39a80147ee7421bf4782c15c09581c1dc2237ea89cefbd95b846", size = 8678682, upload-time = "2024-02-04T10:28:44.642Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/75/eff180f187ce4dc3e5177b3f8508e0061ea786ac44f409cf69cf24bf31a6/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92c6487a6feea683154d3e06e6db68c30e0ae749a7ce4ce90b9e4e46b78c85c7", size = 8595099, upload-time = "2024-02-04T10:28:47.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e6/eddc76ad899d77adcb5fca6cdf651eb1d33b4a799456bf303540f6cf8204/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2f1cd1d1bdd65332f9c2b67d49dcf148cf1ded752851d159ac3e5ee4f4d260", size = 8433569, upload-time = "2024-02-04T10:28:50.404Z" },
-    { url = "https://files.pythonhosted.org/packages/06/95/a13da048c33a876d0475974484bf66b1fae07226e8654b1365ab549309cd/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:976c8039165b8e12f17a01ddee9f4e23ec6e352b165ad29b44d2bf04e2fbe77e", size = 9196003, upload-time = "2024-02-04T10:28:52.466Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/13/9e5cb03914d60dd51047ecbfab5400309fbab14bb25014af388f492da044/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:dafbbdf16bf668a580902e1620f4baa1913e79438abcce721a50647564c687b9", size = 9175560, upload-time = "2024-02-04T10:28:55.064Z" },
-    { url = "https://files.pythonhosted.org/packages/19/76/25bb32a9be1c476e388835d5c8de5af2920af055e295770003683896cfe2/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1aeabd3d60d6d276b73cd8f3739d595b1299d123cc079a317f1a5b3c5461e2ca", size = 8956249, upload-time = "2024-02-04T10:28:57.094Z" },
-]
-
-[[package]]
 name = "tree-sitter-yaml"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5531,7 +5520,7 @@ wheels = [
 
 [[package]]
 name = "treesitter-chunker"
-version = "3.1.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
@@ -5553,9 +5542,9 @@ dependencies = [
     { name = "typer" },
     { name = "unicodedata2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/95/5060abbc4a6210b65bd2be9aef7813869110ee8ca900412b709f84388cd4/treesitter_chunker-3.1.0.tar.gz", hash = "sha256:bdb54008ceaa74d28fab99ae80ab47af8cafb34a893dac31e999badd2181ca95", size = 1428663, upload-time = "2026-06-23T11:49:24.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/61/86b58021b0580b2192540b9485c51b80506d251e8b30d56e75b0982b05fb/treesitter_chunker-4.0.0.tar.gz", hash = "sha256:f54e1e76e371836955687a20dc36f42e381bae30dcc073647cffa567ea861503", size = 1157259, upload-time = "2026-07-12T14:14:31.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4e/6b5dcf8781d87b6570312ddeafe4c85a27f2a6fb9f0bee8d9743ed8867f1/treesitter_chunker-3.1.0-py3-none-any.whl", hash = "sha256:6148743d8409bec93a06e9fda84aa645e5e175f28d25361a070c2e47c548ad4c", size = 1147356, upload-time = "2026-06-23T11:49:22.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e6/297b5eb8933652d6fe485ada42f3f88c0766b4b532194be869648e2de39c/treesitter_chunker-4.0.0-py3-none-any.whl", hash = "sha256:7b51d6f9bc0de661c5d2418359860028d4db14f8a68905315928ce4d0db1687e", size = 834571, upload-time = "2026-07-12T14:14:29.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts **treesitter-chunker 4.0.0** (published today) — the deferred CHUNKERSAFE Lane B from roadmap `specs/phase-plans-v12.md` Phase 1. The Lane A id-scheme guard + atomic rebuild (merged in #77) now engages on the real v3→v4 scheme change.

## Changes
- **Pin + ABI re-solve:** `treesitter-chunker>=4,<5`; `tree_sitter>=0.25,<0.26` (was 0.24.x) and `tree-sitter-language-pack>=0.9,<0.10` per v4's metadata; dropped unused `tree-sitter-languages` (grammars load via `tree_sitter_language_pack`). `uv lock` re-solved cleanly.
- **Import smoke** (`test_chunker_graph_imports_smoke.py`): all chunker imports resolve under v4 — no paths moved.
- **Real-v4 contract test** (`test_chunker_v4_contract.py`, new): pins v4's `CodeChunk` attribute + metadata shape (name nested under `signature`; new `complexity`/`dependencies`/`type` keys), `chunk_text`/`chunk_file` call shapes, working `xref`/`graph_cut`, and that the guard derives `treesitter_chunk_id_v4`.
- **Adapter compatibility:** `chunker_adapter` was already version-tolerant (reads `signature.name`); v4's metadata reshape verified non-breaking.

## Verification
- Grammar loading OK under tree_sitter 0.25 (python/js/c/cpp).
- 109 pass across chunker/scheme/recovery/contract + readiness + sqlite suites; **591 pass** across plugin/dispatcher/incremental under v4.

Closes #78 (CHUNKERV4LIVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
