### PR TITLE
phase INFERPOLISH: inference-boundary hygiene follow-ups (roadmap v12)

### DIFF
--- a/mcp_server/config/settings.py
+++ b/mcp_server/config/settings.py
@@ -1119,11 +1119,13 @@ def commercial_egress_allowed(env: Optional[Mapping[str, str]] = None) -> bool:
 def learned_models_allowed(env: Optional[Mapping[str, str]] = None) -> bool:
     """Return ``True`` unless the profile is EXPLICITLY ``lexical_only``.
 
-    ``lexical_only`` is the only profile that forbids ALL learned providers and
-    rerankers (BM25 / symbol search only). When the profile is unset (legacy) or
-    set to any learned-model profile, learned providers are permitted. An unknown
-    explicit profile name is not ``lexical_only`` and so is permitted here (the
-    contract resolver raises on it elsewhere).
+    ``lexical_only`` is the only *known* profile that forbids ALL learned
+    providers and rerankers (BM25 / symbol search only). When the profile is
+    unset (legacy) or set to any learned-model profile, learned providers are
+    permitted. An unknown explicit profile name is treated as forbidding learned
+    models (fail-closed), symmetric with :func:`commercial_egress_allowed`; use
+    :func:`resolve_active_deployment_profile` when a raising contract check is
+    desired.
     """
     if not deployment_profile_is_explicitly_set(env):
         return True  # LEGACY: unset -> allow.
@@ -1131,7 +1133,7 @@ def learned_models_allowed(env: Optional[Mapping[str, str]] = None) -> bool:
     try:
         profile = _coerce_profile(environ.get(ACTIVE_PROFILE_ENV, ""))
     except ValueError:
-        return True
+        return False  # Unknown explicit profile: fail closed.
     return profile is not DeploymentProfile.LEXICAL_ONLY
 
 

--- a/mcp_server/dispatcher/dispatcher_enhanced.py
+++ b/mcp_server/dispatcher/dispatcher_enhanced.py
@@ -3938,7 +3938,11 @@ class EnhancedDispatcher:
         # Deduplicate queries
         queries = list(dict.fromkeys(queries))
 
-        logger.info(f"Cross-document search for '{topic}' with {len(queries)} query variations")
+        logger.info(
+            "Cross-document search (topic_chars=%d, variations=%d)",
+            len(topic or ""),
+            len(queries),
+        )
 
         # Use the enhanced search with document-specific handling
         all_results = []

--- a/mcp_server/indexer/hybrid_search.py
+++ b/mcp_server/indexer/hybrid_search.py
@@ -19,7 +19,7 @@ from ..storage.sqlite_store import SQLiteStore
 from ..utils.semantic_indexer import SemanticIndexer
 from .bm25_indexer import BM25Indexer
 from .query_optimizer import QueryType
-from .reranker import IReranker, RerankerFactory
+from .reranker import IReranker, RerankerFactory, _redact_error
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class HybridSearch:
             # Initialize reranker asynchronously will be done on first use
             logger.info(f"Initialized {self.reranking_settings.reranker_type} reranker")
         except Exception as e:
-            logger.error(f"Failed to initialize reranker: {e}")
+            logger.error("Failed to initialize reranker: %s", _redact_error(e))
             self.reranker = None
 
     async def search(
@@ -281,7 +281,7 @@ class HybridSearch:
                 if bm25_results:
                     all_results.append(bm25_results)
             except Exception as e:
-                logger.error(f"BM25 search error: {e}")
+                logger.error("BM25 search error: %s", _redact_error(e))
 
         if self.config.enable_semantic and self.semantic_indexer:
             try:
@@ -289,7 +289,7 @@ class HybridSearch:
                 if semantic_results:
                     all_results.append(semantic_results)
             except Exception as e:
-                logger.error(f"Semantic search error: {e}")
+                logger.error("Semantic search error: %s", _redact_error(e))
 
         if self.config.enable_fuzzy and self.fuzzy_indexer:
             try:
@@ -297,7 +297,7 @@ class HybridSearch:
                 if fuzzy_results:
                     all_results.append(fuzzy_results)
             except Exception as e:
-                logger.error(f"Fuzzy search error: {e}")
+                logger.error("Fuzzy search error: %s", _redact_error(e))
 
         return all_results
 
@@ -399,8 +399,9 @@ class HybridSearch:
                 return search_results
             except Exception as e:
                 logger.error(
-                    f"Semantic search failed with error: {e}. "
-                    "Temporarily disabling semantic search."
+                    "Semantic search failed with error: %s. "
+                    "Temporarily disabling semantic search.",
+                    _redact_error(e),
                 )
                 self._semantic_temporarily_disabled = True
                 self._search_stats["semantic_search_errors"] += 1

--- a/mcp_server/indexer/reranker.py
+++ b/mcp_server/indexer/reranker.py
@@ -283,7 +283,7 @@ class CohereReranker(BaseReranker):
                     "Cohere library not installed. Install with: pip install cohere"
                 )
         except Exception as e:
-            logger.error(f"Failed to initialize Cohere reranker: {e}")
+            logger.error("Failed to initialize Cohere reranker: %s", _redact_error(e))
             return Result.error(f"Initialization failed: {str(e)}")
 
     async def shutdown(self) -> Result:
@@ -365,7 +365,7 @@ class CohereReranker(BaseReranker):
             return Result.ok(rerank_result)
 
         except Exception as e:
-            logger.error(f"Cohere reranking failed: {e}")
+            logger.error("Cohere reranking failed: %s", _redact_error(e))
             return Result.error(f"Reranking failed: {str(e)}")
 
     def get_capabilities(self) -> Dict[str, Any]:
@@ -409,7 +409,7 @@ class LocalCrossEncoderReranker(BaseReranker):
                     "Install with: pip install sentence-transformers"
                 )
         except Exception as e:
-            logger.error(f"Failed to initialize cross-encoder: {e}")
+            logger.error("Failed to initialize cross-encoder: %s", _redact_error(e))
             return Result.error(f"Initialization failed: {str(e)}")
 
     async def shutdown(self) -> Result:
@@ -507,7 +507,7 @@ class LocalCrossEncoderReranker(BaseReranker):
             return Result.ok(rerank_result)
 
         except Exception as e:
-            logger.error(f"Cross-encoder reranking failed: {e}")
+            logger.error("Cross-encoder reranking failed: %s", _redact_error(e))
             return Result.error(f"Reranking failed: {str(e)}")
 
     def get_capabilities(self) -> Dict[str, Any]:
@@ -551,7 +551,7 @@ class TFIDFReranker(BaseReranker):
                 "Scikit-learn not installed. Install with: pip install scikit-learn"
             )
         except Exception as e:
-            logger.error(f"Failed to initialize TF-IDF reranker: {e}")
+            logger.error("Failed to initialize TF-IDF reranker: %s", _redact_error(e))
             return Result.error(f"Initialization failed: {str(e)}")
 
     async def shutdown(self) -> Result:
@@ -638,7 +638,7 @@ class TFIDFReranker(BaseReranker):
             return Result.ok(rerank_result)
 
         except Exception as e:
-            logger.error(f"TF-IDF reranking failed: {e}")
+            logger.error("TF-IDF reranking failed: %s", _redact_error(e))
             return Result.error(f"Reranking failed: {str(e)}")
 
     def get_capabilities(self) -> Dict[str, Any]:
@@ -1075,8 +1075,11 @@ class EndpointReranker(IReranker):
         # Intrinsic per-call timeout so DIRECT async consumers (hybrid /
         # cross_repo) are bounded even without the dispatcher's wait_for wrapper.
         if timeout is None:
+            # Mirror the dispatcher's _get_endpoint_rerank_timeout_seconds clamp:
+            # fall back to 30s on an unparseable value and floor to >=1s so a
+            # 0/negative env can never disable the intrinsic per-call timeout.
             try:
-                timeout = float(os.getenv("MCP_RERANK_TIMEOUT_S", "30.0"))
+                timeout = max(float(os.getenv("MCP_RERANK_TIMEOUT_S", "30.0")), 1.0)
             except (TypeError, ValueError):
                 timeout = 30.0
         self._timeout = timeout
@@ -1333,7 +1336,10 @@ class CohereV2RerankAdapter:
             "request_id": request_dict.get("request_id", ""),
             "provider": self.provider,
             "model_id": self.model,
-            "model_revision": cohere_response.get("model_revision", self.model),
+            # Report the provider's response revision when present; otherwise
+            # None (unknown). Never echo the configured ``model`` as a revision
+            # it isn't -- that would misreport the served model version.
+            "model_revision": cohere_response.get("model_revision"),
             "results": results,
             "candidate_count": len(candidates),
             "scored_count": scored,

--- a/mcp_server/utils/embedding_providers.py
+++ b/mcp_server/utils/embedding_providers.py
@@ -132,9 +132,12 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
     ) -> EmbeddingResponseV1:
         role = _role_from_input_type(input_type)
 
+        texts_list = list(texts)
+        request_size = len(texts_list)
+
         started = time.perf_counter()
         response = self.client.embed(
-            list(texts),
+            texts_list,
             model=self.model_name,
             input_type=input_type,
             output_dimension=self.vector_dimension,
@@ -142,7 +145,20 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         )
         latency_ms = (time.perf_counter() - started) * 1000.0
 
+        # Fail closed on request<->response arity. Voyage returns a bare
+        # ``embeddings`` list with no per-item server index, so the ONLY defense
+        # against a short/over-long batch is a length check: a mismatch means we
+        # cannot know which input each vector answers. Refuse rather than
+        # positionally misattach vectors to the wrong texts.
         vectors = response.embeddings
+        if len(vectors) != request_size:
+            raise RuntimeError(
+                "Voyage embedding arity mismatch for model "
+                f"{self.model_name}: requested {request_size} inputs but the "
+                f"response carried {len(vectors)} embeddings. Refusing to "
+                "positionally attach a partial/short embedding batch."
+            )
+
         items = [
             EmbeddingItem(
                 index=idx,

--- a/mcp_server/utils/semantic_indexer.py
+++ b/mcp_server/utils/semantic_indexer.py
@@ -20,6 +20,13 @@ except Exception:
 from qdrant_client import QdrantClient, models
 from qdrant_client.http.models import FieldCondition, Filter, MatchValue
 
+try:
+    from qdrant_client.http.exceptions import (
+        ResponseHandlingException as _QdrantResponseHandlingException,
+    )
+except Exception:  # pragma: no cover - defensive: client layout drift
+    _QdrantResponseHandlingException = None  # type: ignore[assignment]
+
 from ..artifacts.semantic_namespace import SemanticNamespaceResolver
 from ..artifacts.semantic_profiles import (
     REINDEX_REMEDIATION,
@@ -39,6 +46,37 @@ if TYPE_CHECKING:
     from ..storage.sqlite_store import SQLiteStore
 
 logger = logging.getLogger(__name__)
+
+
+class TransientCollectionReadError(RuntimeError):
+    """A live-collection shape read failed transiently (connectivity/timeout).
+
+    Distinct from a genuine, readable shape mismatch: the collection's shape
+    could not be READ at all because the Qdrant backend was unreachable or timed
+    out. The correct remediation is therefore to RETRY once the backend is
+    reachable again — NOT to reindex/rebuild the collection. Conflating the two
+    would emit a misleading ``blocked``/reindex diagnostic for what is really a
+    backend-reachability problem.
+    """
+
+
+def _is_transient_qdrant_read_error(exc: BaseException) -> bool:
+    """Classify ``exc`` as a transient connectivity/timeout read failure.
+
+    Returns ``True`` for an unreachable/timed-out backend (retryable) and
+    ``False`` for a reachable backend that returned an unreadable/unexpected
+    shape (which must fail closed / block). Only exceptions raised while READING
+    the live shape reach this classifier — a readable shape mismatch never
+    raises, so it is never misclassified here.
+    """
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    if _QdrantResponseHandlingException is not None and isinstance(
+        exc, _QdrantResponseHandlingException
+    ):
+        return True
+    name = type(exc).__name__.lower()
+    return "timeout" in name or "connect" in name
 
 
 @dataclass
@@ -1611,9 +1649,21 @@ class SemanticIndexer:
                 actual_dimension != self.embedding_dimension
                 or actual_distance != expected_distance
             )
-        except Exception:
-            # An unknown/unreadable live shape must fail closed (block), never be
-            # silently treated as a compatible reuse.
+        except Exception as exc:
+            if _is_transient_qdrant_read_error(exc):
+                # Connectivity/timeout: the shape could not be READ at all. This is
+                # retryable, NOT a reindex-requiring shape mismatch. Surface it
+                # distinctly so callers emit a retry (not a blocked/reindex)
+                # diagnostic for what is really a backend-reachability problem.
+                raise TransientCollectionReadError(
+                    f"Could not read the shape of Qdrant collection "
+                    f"'{self.collection}': the backend was unreachable or timed out "
+                    f"({type(exc).__name__}: {exc}). This is retryable — retry once "
+                    "the Qdrant backend is reachable again; it is NOT a shape "
+                    "mismatch requiring a reindex."
+                ) from exc
+            # Server reachable but the live shape is genuinely unknown/unreadable:
+            # fail closed (block), never silently treat as a compatible reuse.
             return True
 
     # ------------------------------------------------------------------
@@ -1694,7 +1744,22 @@ class SemanticIndexer:
         # v9) one. Validate the live shape (read-only) BEFORE persisting attested
         # metadata, so we never stamp attested=True at the new dimension over
         # vectors still stored at the old one.
-        if self._existing_collection_shape_blocked():
+        try:
+            shape_blocked = self._existing_collection_shape_blocked()
+        except TransientCollectionReadError as exc:
+            # Backend unreachable/timed out while reading the live shape: this is
+            # retryable, NOT a reindex-requiring shape mismatch. Report it as such
+            # so the operator retries rather than rebuilds. Nothing is mutated.
+            return {
+                "status": "retryable",
+                "collection": self.collection,
+                "message": str(exc),
+                "remediation": (
+                    "Retry after the Qdrant backend is reachable again; this is "
+                    "not a reindex-requiring shape mismatch."
+                ),
+            }
+        if shape_blocked:
             if allow_reindex:
                 # Operator authorized a destructive rebuild for the profile-
                 # migrated collection: recreate to the active shape FIRST, then

--- a/tests/test_deployment_profiles.py
+++ b/tests/test_deployment_profiles.py
@@ -414,6 +414,18 @@ def test_learned_models_allowed_only_forbidden_under_explicit_lexical_only():
     assert learned_models_allowed(env={"MCP_DEPLOYMENT_PROFILE": "lexical_only"}) is False
 
 
+def test_learned_models_allowed_unknown_profile_fails_closed():
+    """An explicit but UNKNOWN profile forbids learned models (fail-closed),
+    symmetric with :func:`commercial_egress_allowed`."""
+    assert learned_models_allowed(env={"MCP_DEPLOYMENT_PROFILE": "nonsense"}) is False
+    # Symmetry: both siblings fail closed on the same unknown explicit profile.
+    assert commercial_egress_allowed(env={"MCP_DEPLOYMENT_PROFILE": "nonsense"}) is False
+    assert (
+        learned_models_allowed(env={"MCP_DEPLOYMENT_PROFILE": "nonsense"})
+        is commercial_egress_allowed(env={"MCP_DEPLOYMENT_PROFILE": "nonsense"})
+    )
+
+
 # ---------------------------------------------------------------------------
 # Provider-construction enforcement (SemanticIndexer._enforce_commercial_egress_policy)
 # ---------------------------------------------------------------------------

--- a/tests/test_embedding_provenance.py
+++ b/tests/test_embedding_provenance.py
@@ -661,3 +661,71 @@ def test_reconcile_unattestable_for_legacy_provider(tmp_path):
     result = ix.reconcile_existing_collection()
     assert result["status"] == "unattestable"
     assert "reindex" in result["message"].lower()
+
+
+# ===========================================================================
+# 7. Transient live-shape read is retryable, NOT a reindex-requiring block
+# ===========================================================================
+
+
+class _TransientReadQdrant(_RecordingQdrant):
+    """Qdrant double whose live-shape read fails transiently (connectivity)."""
+
+    def get_collections(self):
+        raise ConnectionError("connection refused: qdrant backend unreachable")
+
+
+def test_existing_shape_blocked_raises_transient_on_connectivity_error(tmp_path):
+    """A connectivity read failure surfaces distinctly as retryable, not blocked."""
+    from mcp_server.utils.semantic_indexer import TransientCollectionReadError
+
+    ix = _make_indexer(tmp_path, _FakeProvenanceProvider(_openai_response), dim=8)
+    ix.qdrant = _TransientReadQdrant()
+    with pytest.raises(TransientCollectionReadError):
+        ix._existing_collection_shape_blocked()
+
+
+def test_existing_shape_blocked_true_on_real_readable_mismatch(tmp_path):
+    """A genuinely mismatched (readable) live shape is blocked, not retryable."""
+    ix = _make_indexer(tmp_path, _FakeProvenanceProvider(_openai_response), dim=8)
+    # Readable collection whose dimension does NOT match the active profile (8).
+    ix.qdrant.collections["semantic-oss-high"] = (
+        16,
+        SemanticIndexer.resolve_qdrant_distance("cosine"),
+    )
+    assert ix._existing_collection_shape_blocked() is True
+
+
+def test_reconcile_transient_read_is_retryable_not_reindex(tmp_path):
+    """Compatible probe + a transient live-shape read -> 'retryable', no mutation."""
+    ix = _make_indexer(tmp_path, _FakeProvenanceProvider(_openai_response), dim=8)
+    ix.qdrant = _TransientReadQdrant()
+
+    result = ix.reconcile_existing_collection()
+
+    # Classified as retryable, NOT reindex_required (the misattribution we fix).
+    assert result["status"] == "retryable"
+    assert result["status"] != "reindex_required"
+    assert "retry" in result["message"].lower()
+    # The message names the true cause: a backend-reachability problem.
+    assert "unreachable" in result["message"].lower() or "timed out" in result["message"].lower()
+    # Nothing mutated: no attested metadata persisted, gate stays shut.
+    assert ix._writes_prepared is False
+    assert not (tmp_path / ".index_metadata.json").exists()
+    assert all(kind != "recreate" for kind, _ in ix.qdrant.calls)
+
+
+def test_reconcile_real_shape_mismatch_is_blocked_reindex(tmp_path):
+    """Compatible probe + a readable stale shape -> 'reindex_required' (blocked)."""
+    ix = _make_indexer(tmp_path, _FakeProvenanceProvider(_openai_response), dim=8)
+    # Active profile is dim 8; the on-disk collection is a stale dim-16 shape.
+    ix.qdrant.collections["semantic-oss-high"] = (
+        16,
+        SemanticIndexer.resolve_qdrant_distance("cosine"),
+    )
+
+    result = ix.reconcile_existing_collection()
+
+    assert result["status"] == "reindex_required"
+    assert "reindex" in result["message"].lower()
+    assert all(kind != "recreate" for kind, _ in ix.qdrant.calls)

--- a/tests/test_embedding_provider_provenance.py
+++ b/tests/test_embedding_provider_provenance.py
@@ -413,6 +413,45 @@ def test_openai_arity_mismatch_raises():
         p.embed_with_provenance(["a", "b", "c"], input_type="document")
 
 
+class _FixedCountVoyageClient:
+    """Voyage double returning a FIXED number of embeddings, ignoring input size.
+
+    Simulates a provider that answers with too few / too many vectors than the
+    request carried — the only failure Voyage's bare ``embeddings`` list exposes.
+    """
+
+    def __init__(self, dimension: int, returned_count: int) -> None:
+        self.dimension = dimension
+        self.returned_count = returned_count
+
+    def embed(self, texts, model, input_type, output_dimension, output_dtype):
+        embeddings = [[float(i)] * self.dimension for i in range(self.returned_count)]
+        return _FakeVoyageResponse(embeddings)
+
+
+def test_voyage_arity_mismatch_too_few_raises():
+    p = _make_voyage(dimension=4)
+    p.client = _FixedCountVoyageClient(dimension=4, returned_count=2)
+    # Requested 3 inputs but the client returns only 2 embeddings.
+    with pytest.raises(RuntimeError, match="arity mismatch"):
+        p.embed_with_provenance(["a", "b", "c"], input_type="document")
+
+
+def test_voyage_arity_mismatch_too_many_raises():
+    p = _make_voyage(dimension=4)
+    p.client = _FixedCountVoyageClient(dimension=4, returned_count=3)
+    # Requested 2 inputs but the client returns 3 embeddings.
+    with pytest.raises(RuntimeError, match="arity mismatch"):
+        p.embed_with_provenance(["a", "b"], input_type="document")
+
+
+def test_voyage_matching_arity_still_ok():
+    """The added arity guard must not reject a correct one-to-one response."""
+    p = _make_voyage(dimension=4)
+    resp = p.embed_with_provenance(["a", "b", "c"], input_type="document")
+    assert [item.index for item in resp.items] == [0, 1, 2]
+
+
 # ---------------------------------------------------------------------------
 # 6. OpenAI role authority is ``declared`` (not ``reported``), value preserved
 # ---------------------------------------------------------------------------

--- a/tests/test_endpoint_reranker.py
+++ b/tests/test_endpoint_reranker.py
@@ -567,11 +567,12 @@ def _slow_transport(latency_s: float):
 
 
 async def test_endpoint_reranker_intrinsic_default_timeout(monkeypatch):
-    # No external wait_for wrapper: the EndpointReranker's own default timeout
-    # (read from MCP_RERANK_TIMEOUT_S) must still bound a slow transport.
+    # No external wait_for wrapper: the EndpointReranker's own env-driven timeout
+    # must still bound a slow transport. A sub-1s env value is clamped up to the
+    # >=1s floor (INFERPOLISH item 4), so the intrinsic bound stays enabled.
     monkeypatch.setenv("MCP_RERANK_TIMEOUT_S", "0.05")
-    reranker = EndpointReranker(_slow_transport(1.0), provider="slow")
-    assert reranker._timeout == 0.05
+    reranker = EndpointReranker(_slow_transport(3.0), provider="slow")
+    assert reranker._timeout == 1.0
     with pytest.raises(asyncio.TimeoutError):
         await reranker.rerank("q", _results(3))
 
@@ -588,3 +589,106 @@ def test_endpoint_reranker_default_timeout_is_30s(monkeypatch):
     monkeypatch.delenv("MCP_RERANK_TIMEOUT_S", raising=False)
     reranker = EndpointReranker(_fake_transport({0: 0.1}), provider="fake")
     assert reranker._timeout == 30.0
+
+
+# --------------------------------------------------------------------------
+# INFERPOLISH item 4: EndpointReranker's own MCP_RERANK_TIMEOUT_S parsing must
+# clamp to a >=1s floor (mirroring the dispatcher clamp) so a 0/negative env
+# can never disable the intrinsic per-call timeout, and an unparseable value
+# falls back to the 30s default.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("raw", ["0", "0.0", "-5", "0.001"])
+def test_endpoint_reranker_timeout_clamps_to_one_second_floor(monkeypatch, raw):
+    monkeypatch.setenv("MCP_RERANK_TIMEOUT_S", raw)
+    reranker = EndpointReranker(_fake_transport({0: 0.1}), provider="fake")
+    assert reranker._timeout == 1.0
+
+
+def test_endpoint_reranker_timeout_unparseable_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("MCP_RERANK_TIMEOUT_S", "not-a-number")
+    reranker = EndpointReranker(_fake_transport({0: 0.1}), provider="fake")
+    assert reranker._timeout == 30.0
+
+
+def test_endpoint_reranker_timeout_above_floor_is_preserved(monkeypatch):
+    monkeypatch.setenv("MCP_RERANK_TIMEOUT_S", "12.5")
+    reranker = EndpointReranker(_fake_transport({0: 0.1}), provider="fake")
+    assert reranker._timeout == 12.5
+
+
+# --------------------------------------------------------------------------
+# INFERPOLISH item 5: a timed-out endpoint call must not publish outcome /
+# diagnostics. Shared reranker state (last_outcome / last_diagnostics) is only
+# assigned after a successful response is fully processed in the coroutine, so
+# a late transport worker cannot mutate it after the bridge raised TimeoutError.
+# --------------------------------------------------------------------------
+def test_endpoint_reranker_timeout_does_not_publish_shared_state():
+    import time as _time
+
+    def slow_transport(request_dict):
+        # Sleeps well past the tiny per-call timeout; if it "wins" late it must
+        # still be unable to touch shared reranker state.
+        _time.sleep(0.3)
+        return {"results": []}
+
+    reranker = EndpointReranker(slow_transport, provider="fake", timeout=0.01)
+
+    with pytest.raises(asyncio.TimeoutError):
+        run_coroutine_sync(reranker.rerank("find json", _results(2), top_k=2))
+
+    assert reranker.last_outcome is None
+    assert reranker.last_diagnostics is None
+
+
+# --------------------------------------------------------------------------
+# INFERPOLISH item 6: CohereV2RerankAdapter must report model_revision honestly
+# -- pass through the provider's revision when present, else None (unknown),
+# never echoing the configured ``model`` as a revision it isn't.
+# --------------------------------------------------------------------------
+def test_cohere_adapter_model_revision_none_when_response_omits_it():
+    def send(body):
+        # Cohere native response with NO model_revision field.
+        return {
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.5},
+            ]
+        }
+
+    adapter = CohereV2RerankAdapter(send)
+    out = adapter(
+        {
+            "candidates": [
+                {"candidate_id": "cand-0", "text": "a"},
+                {"candidate_id": "cand-1", "text": "b"},
+            ],
+            "query": "q",
+            "request_id": "r",
+            "contract_version": "rerank.v1",
+        }
+    )
+
+    # model_id honestly reports the configured model...
+    assert out["model_id"] == COHERE_CURRENT_RERANK_MODEL
+    # ...but model_revision is None (unknown), not the model echoed as a revision.
+    assert out["model_revision"] is None
+
+
+def test_cohere_adapter_model_revision_passes_through_when_present():
+    def send(body):
+        return {
+            "results": [{"index": 0, "relevance_score": 0.9}],
+            "model_revision": "2026-06-01",
+        }
+
+    adapter = CohereV2RerankAdapter(send)
+    out = adapter(
+        {
+            "candidates": [{"candidate_id": "cand-0", "text": "a"}],
+            "query": "q",
+            "request_id": "r",
+            "contract_version": "rerank.v1",
+        }
+    )
+
+    assert out["model_revision"] == "2026-06-01"

--- a/tests/test_rerank_consumer_migration.py
+++ b/tests/test_rerank_consumer_migration.py
@@ -378,3 +378,41 @@ async def test_dispatcher_failure_redacts_secret(caplog):
     assert BEARER_SECRET not in (diag.error or "")
     assert QUERY_SENTINEL not in caplog.text
     assert DOC_SENTINEL not in caplog.text
+
+
+# --------------------------------------------------------------------------
+# INFERPOLISH item 2: the HybridSearch._search_semantic exception path (the
+# semantic indexer's own .search() raising, distinct from a reranker failure)
+# must redact a credential AND never log the raw query body.
+# --------------------------------------------------------------------------
+async def test_hybrid_semantic_search_failure_redacts_secret(caplog):
+    from collections import defaultdict
+
+    hs = HybridSearch.__new__(HybridSearch)
+    hs._semantic_temporarily_disabled = False
+    hs._search_stats = defaultdict(int)
+    hs.config = types.SimpleNamespace(individual_limit=10, min_semantic_score=0.0)
+
+    class _RaisingSemanticIndexer:
+        is_available = True
+        connection_mode = "server"
+
+        def validate_connection(self):
+            return True
+
+        def search(self, query, limit):
+            raise RuntimeError(SECRET_MSG)
+
+    hs.semantic_indexer = _RaisingSemanticIndexer()
+
+    with caplog.at_level(logging.DEBUG):
+        out = await hs._search_semantic(QUERY_SENTINEL, None)
+
+    assert out == []
+    # The failure disables semantic search and the instrumented log fired...
+    assert hs._semantic_temporarily_disabled is True
+    assert "Semantic search failed with error" in caplog.text
+    # ...but neither the credential nor the raw query body leaked.
+    assert BEARER_SECRET not in caplog.text
+    assert QUERY_SENTINEL not in caplog.text
+    assert "[REDACTED]" in caplog.text

--- a/tests/test_reranker_outcomes.py
+++ b/tests/test_reranker_outcomes.py
@@ -329,3 +329,126 @@ def test_dispatcher_search_logs_no_raw_query_body(caplog):
     assert "Using fuzzy trigram search" in caplog.text
     # ...but the raw query body never appears in any dispatcher log.
     assert query_sentinel not in caplog.text
+
+
+# ==========================================================================
+# INFERPOLISH item 1: the ASYNC BaseReranker trio (Cohere / cross-encoder /
+# TF-IDF) rerank() exception paths must route the provider exception through
+# ``_redact_error`` before logging -- a credential embedded in the exception
+# must never reach caplog.
+# ==========================================================================
+import asyncio as _asyncio
+
+from mcp_server.indexer.reranker import (
+    CohereReranker,
+    LocalCrossEncoderReranker,
+    SearchResult,
+    TFIDFReranker,
+)
+
+_ASYNC_SECRET = "sk-ASYNCSECRET789"
+_ASYNC_EXC_MSG = f"provider auth failed Bearer {_ASYNC_SECRET}"
+
+
+def _async_results():
+    return [
+        SearchResult(
+            file_path="a.py",
+            start_line=1,
+            end_line=1,
+            column=0,
+            snippet="alpha",
+            match_type="semantic",
+            score=0.5,
+        ),
+        SearchResult(
+            file_path="b.py",
+            start_line=2,
+            end_line=2,
+            column=0,
+            snippet="beta",
+            match_type="semantic",
+            score=0.4,
+        ),
+    ]
+
+
+def test_async_cohere_rerank_failure_redacts_log(caplog):
+    r = CohereReranker({})
+    r.initialized = True
+
+    class _FakeClient:
+        def rerank(self, **kwargs):
+            raise RuntimeError(_ASYNC_EXC_MSG)
+
+    r.client = _FakeClient()
+
+    with caplog.at_level(logging.DEBUG):
+        result = _asyncio.run(r.rerank("secretqueryzz", _async_results(), top_k=2))
+
+    assert not result.is_success
+    assert "Cohere reranking failed" in caplog.text
+    assert _ASYNC_SECRET not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_async_crossencoder_rerank_failure_redacts_log(caplog):
+    r = LocalCrossEncoderReranker({})
+    r.initialized = True
+
+    class _FakeModel:
+        def predict(self, pairs):
+            raise RuntimeError(_ASYNC_EXC_MSG)
+
+    r.model = _FakeModel()
+
+    with caplog.at_level(logging.DEBUG):
+        result = _asyncio.run(r.rerank("secretqueryzz", _async_results(), top_k=2))
+
+    assert not result.is_success
+    assert "Cross-encoder reranking failed" in caplog.text
+    assert _ASYNC_SECRET not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_async_tfidf_rerank_failure_redacts_log(caplog):
+    r = TFIDFReranker({})
+    r.initialized = True
+
+    class _FakeVectorizer:
+        def fit_transform(self, texts):
+            raise RuntimeError(_ASYNC_EXC_MSG)
+
+    r.vectorizer = _FakeVectorizer()
+
+    with caplog.at_level(logging.DEBUG):
+        result = _asyncio.run(r.rerank("secretqueryzz", _async_results(), top_k=2))
+
+    assert not result.is_success
+    assert "TF-IDF reranking failed" in caplog.text
+    assert _ASYNC_SECRET not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+# ==========================================================================
+# INFERPOLISH item 3: search_documentation() logs topic metadata only
+# (topic_chars), never the raw topic body.
+# ==========================================================================
+def test_search_documentation_logs_no_raw_topic_body(caplog):
+    from unittest.mock import MagicMock
+
+    d = EnhancedDispatcher.__new__(EnhancedDispatcher)
+    # search_documentation only touches self.search (mocked empty) before/while
+    # logging; no other dispatcher wiring is exercised on this path.
+    d.search = MagicMock(return_value=[])
+
+    topic_sentinel = "zzz_raw_topic_body_sentinel_zzz"
+    ctx = MagicMock()
+
+    with caplog.at_level(logging.DEBUG):
+        list(d.search_documentation(ctx, topic_sentinel, limit=5))
+
+    # The instrumented cross-document log fired...
+    assert "Cross-document search" in caplog.text
+    # ...but the raw topic body never appears in any dispatcher log.
+    assert topic_sentinel not in caplog.text


### PR DESCRIPTION
Roadmap `specs/phase-plans-v12.md` **Phase 2 (INFERPOLISH)** — the deferred nice-to-haves the #73/#74 cross-vendor code reviews recommended. All verified outstanding on `main` (not already covered by the #74 convergence) and fixed:

- **Redaction completeness:** legacy async reranker raw-exception logs (`reranker.py` 286/368/412/510/554/641), hybrid_search raw `{e}` logs (151/284/292/300/402), and the cross-document raw-topic log now route through the redactor / log ids+counts only.
- **Profile-gating symmetry:** `learned_models_allowed` now fails **closed** on an unknown explicit `MCP_DEPLOYMENT_PROFILE` (was fail-open), matching `commercial_egress_allowed`.
- **`EndpointReranker` timeout** parse clamps to `>=1s` (mirrors the dispatcher).
- **Provenance honesty:** Cohere v2 adapter reports `model_revision=None` when the response omits it (was echoing the configured model); `VoyageEmbeddingProvider.embed_with_provenance` raises on an arity mismatch.
- **Reconcile diagnostic:** distinguishes a transient Qdrant read error (retryable) from a real readable shape mismatch (`blocked`/reindex).
- Async cancellation safety confirmed + regression test.

**Verification:** 165 owned tests pass; 464 regression pass, 0 failures.

Next: INFERLIVEGATE (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->