### PR TITLE
chunksafe: drain the pending_vector_deletions crash-ledger on reindex (#80)

### DIFF
--- a/mcp_server/dispatcher/dispatcher_enhanced.py
+++ b/mcp_server/dispatcher/dispatcher_enhanced.py
@@ -3497,6 +3497,47 @@ class EnhancedDispatcher:
             record_handled_error(__name__, exc)
             return {"total": 0, "by_language": {}}
 
+    def _drain_pending_vector_deletions(self, ctx: RepoContext) -> None:
+        """Best-effort recovery drain of the remote-vector crash-ledger (I4).
+
+        A crashed chunk-scheme rebuild durably records orphaned remote (Qdrant)
+        point ids in the SQLite ``pending_vector_deletions`` ledger, but the local
+        ``semantic_points`` mappings are already gone, so nothing else will ever
+        clean the remote vectors. Reindex is the natural recovery point: here BOTH
+        the store and a semantic (Qdrant) client are available, so finish the
+        deferred remote delete and clear only the rows actually drained.
+
+        No-ops cleanly when semantic indexing is disabled (no client) or the store
+        predates the ledger, and never raises - a recovery failure must not crash
+        the reindex it is hooked into.
+        """
+        store = getattr(ctx, "sqlite_store", None)
+        if store is None or not hasattr(store, "drain_pending_vector_deletions"):
+            return
+        try:
+            sem = self._get_semantic_indexer(ctx)
+        except Exception:  # semantic client build is best-effort here
+            sem = None
+        if sem is None or not hasattr(sem, "delete_remote_points"):
+            return
+        try:
+            result = store.drain_pending_vector_deletions(
+                lambda collection, point_ids: sem.delete_remote_points(
+                    point_ids, collection=collection
+                )
+            )
+        except Exception as exc:  # store method is fail-safe, but never crash reindex
+            logger.warning("Pending-vector-deletion drain skipped: %s", exc)
+            return
+        if result.get("rows_drained") or result.get("groups_failed"):
+            logger.info(
+                "Pending-vector-deletion drain: %s drained, %s remaining, "
+                "%s group(s) deferred",
+                result.get("rows_drained"),
+                result.get("rows_remaining"),
+                result.get("groups_failed"),
+            )
+
     def index_directory(
         self,
         ctx: RepoContext,
@@ -3507,6 +3548,12 @@ class EnhancedDispatcher:
     ) -> Dict[str, Any]:
         """Index all files in a directory, respecting ignore patterns."""
         logger.info(f"Indexing directory: {directory} (recursive={recursive})")
+
+        # Recovery point (I4): finish any deferred remote-vector deletions left by
+        # a crashed chunk-scheme rebuild before we repopulate. Reindex is where both
+        # the store and a semantic (Qdrant) client are available; best-effort so a
+        # recovery failure can never block the reindex.
+        self._drain_pending_vector_deletions(ctx)
 
         # Note: We don't use ignore patterns during indexing
         # ALL files are indexed for local search capability

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -509,6 +509,79 @@ class SQLiteStore:
                 removed += cursor.rowcount
             return removed
 
+    def drain_pending_vector_deletions(
+        self,
+        delete_remote: Callable[[Optional[str], List[Any]], None],
+    ) -> Dict[str, int]:
+        """Best-effort recovery drain of the remote-vector crash-ledger (I4).
+
+        When a chunk-scheme rebuild deletes the local ``semantic_points`` rows but
+        crashes before the caller finishes the matching *remote* (Qdrant) delete,
+        the orphaned remote point ids survive only in the durable
+        ``pending_vector_deletions`` ledger.  Nothing else will ever clean them up
+        because the local mapping is already gone.  This drains that ledger: it
+        reads the pending rows, groups them by ``(profile_id, collection)`` so each
+        remote delete targets the right collection, and asks
+        ``delete_remote(collection, point_ids)`` to remove those remote points.
+
+        Guarantees:
+
+        * **fail-safe** - a group's ledger rows are cleared ONLY when its
+          ``delete_remote`` returns without raising; a raise leaves that group's
+          rows in the ledger for the next attempt (an un-drained row is never
+          cleared), while OTHER healthy groups still drain.  A remote-delete error
+          is logged and swallowed, so this method itself never raises and can never
+          crash the reindex/startup it is hooked into.
+        * **idempotent** - an empty ledger (including a re-run after a successful
+          drain) is a no-op.
+
+        Returns a small counts dict (``rows_drained``, ``rows_remaining``,
+        ``groups_failed``) for observability and tests.
+        """
+        pending = self.get_pending_vector_deletions()
+        if not pending:
+            return {"rows_drained": 0, "rows_remaining": 0, "groups_failed": 0}
+
+        groups: Dict[Tuple[Optional[str], Optional[str]], Dict[str, List[Any]]] = {}
+        for row in pending:
+            key = (row.get("profile_id"), row.get("collection"))
+            group = groups.setdefault(key, {"ledger_ids": [], "point_ids": []})
+            group["ledger_ids"].append(row["id"])
+            point_id = row.get("point_id")
+            if point_id is not None:
+                group["point_ids"].append(point_id)
+
+        drainable_ids: List[int] = []
+        groups_failed = 0
+        for (profile_id, collection), group in groups.items():
+            point_ids = list(dict.fromkeys(group["point_ids"]))
+            try:
+                # A group with no remote point ids carries no remote debt; its
+                # rows are ledger noise we can clear without a remote call.
+                if point_ids:
+                    delete_remote(collection, point_ids)
+            except Exception as exc:  # best-effort recovery: keep this group's rows
+                groups_failed += 1
+                logger.warning(
+                    "Deferred pending-vector-deletion drain for profile %r / "
+                    "collection %r (%d point ids): %s",
+                    profile_id,
+                    collection,
+                    len(point_ids),
+                    exc,
+                )
+                continue
+            drainable_ids.extend(group["ledger_ids"])
+
+        rows_drained = (
+            self.clear_pending_vector_deletions(drainable_ids) if drainable_ids else 0
+        )
+        return {
+            "rows_drained": rows_drained,
+            "rows_remaining": len(pending) - rows_drained,
+            "groups_failed": groups_failed,
+        }
+
     def _ensure_chunk_summary_audit_columns(self) -> None:
         """Ensure additive chunk summary audit columns exist."""
         with self._get_connection() as conn:

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -509,6 +509,48 @@ class SQLiteStore:
                 removed += cursor.rowcount
             return removed
 
+    def get_live_semantic_point_ids(
+        self,
+        profile_id: Optional[str],
+        collection: Optional[str],
+        point_ids: List[Any],
+    ) -> set:
+        """Return the subset of ``point_ids`` that still have a live mapping.
+
+        A ledger point id may have been legitimately RE-CREATED (deterministic,
+        content-derived point ids) by an incremental index pass before the drain
+        runs.  Such a point id has a fresh ``semantic_points`` row and its remote
+        vector is in active use - it is NOT an orphan and must NOT be remote
+        deleted.  This resolves, in a single batched query per group, which of the
+        candidate ``point_ids`` still map to a live ``semantic_points`` row for the
+        given ``profile_id`` / ``collection``.  When the ledger row recorded no
+        ``collection`` we protect the point id across any collection for the
+        profile (err toward never deleting a live vector).
+        """
+        if not point_ids:
+            return set()
+        live: set = set()
+        with self._get_connection() as conn:
+            for start in range(0, len(point_ids), 500):
+                batch = point_ids[start : start + 500]
+                placeholders = ",".join("?" * len(batch))
+                if collection is None:
+                    sql = (
+                        f"SELECT point_id FROM semantic_points "
+                        f"WHERE profile_id = ? AND point_id IN ({placeholders})"
+                    )
+                    params: List[Any] = [profile_id, *batch]
+                else:
+                    sql = (
+                        f"SELECT point_id FROM semantic_points "
+                        f"WHERE profile_id = ? AND collection = ? "
+                        f"AND point_id IN ({placeholders})"
+                    )
+                    params = [profile_id, collection, *batch]
+                for row in conn.execute(sql, params).fetchall():
+                    live.add(row[0])
+        return live
+
     def drain_pending_vector_deletions(
         self,
         delete_remote: Callable[[Optional[str], List[Any]], None],
@@ -526,14 +568,26 @@ class SQLiteStore:
 
         Guarantees:
 
+        * **no live-vector loss** - because point ids are deterministic and
+          content-derived, an incremental index pass can legitimately RE-CREATE a
+          ledger point id (fresh ``semantic_points`` row + remote vector) before
+          this drain runs.  Such a revived point id is in active use and is NEVER
+          remote deleted; only true orphans (ledger point ids with no live
+          ``semantic_points`` mapping) are deleted.  A revived row's ledger debt is
+          still cleared on success (the remote vector it pointed to is now owned by
+          the live mapping).
         * **fail-safe** - a group's ledger rows are cleared ONLY when its
           ``delete_remote`` returns without raising; a raise leaves that group's
           rows in the ledger for the next attempt (an un-drained row is never
-          cleared), while OTHER healthy groups still drain.  A remote-delete error
-          is logged and swallowed, so this method itself never raises and can never
-          crash the reindex/startup it is hooked into.
+          cleared), while OTHER healthy groups still drain.
         * **idempotent** - an empty ledger (including a re-run after a successful
           drain) is a no-op.
+
+        Best-effort: a remote-delete error for one group is isolated (logged and
+        swallowed) and never raises; but the ledger read/clear I/O
+        (:meth:`get_pending_vector_deletions` / :meth:`clear_pending_vector_deletions`)
+        sits outside the per-group guard and may propagate to the caller (the
+        dispatcher drain hook catches it).
 
         Returns a small counts dict (``rows_drained``, ``rows_remaining``,
         ``groups_failed``) for observability and tests.
@@ -559,7 +613,18 @@ class SQLiteStore:
                 # A group with no remote point ids carries no remote debt; its
                 # rows are ledger noise we can clear without a remote call.
                 if point_ids:
-                    delete_remote(collection, point_ids)
+                    # Partition into true orphans vs. revived point ids: a point id
+                    # that still has a live ``semantic_points`` mapping was
+                    # legitimately RE-CREATED before this drain ran and must NOT be
+                    # deleted (its remote vector is in active use).  Only orphans
+                    # (no live mapping) are remote deleted; the revived rows' ledger
+                    # debt is still cleared below on success.
+                    live = self.get_live_semantic_point_ids(
+                        profile_id, collection, point_ids
+                    )
+                    orphan_ids = [p for p in point_ids if p not in live]
+                    if orphan_ids:
+                        delete_remote(collection, orphan_ids)
             except Exception as exc:  # best-effort recovery: keep this group's rows
                 groups_failed += 1
                 logger.warning(

--- a/mcp_server/utils/semantic_indexer.py
+++ b/mcp_server/utils/semantic_indexer.py
@@ -3260,7 +3260,12 @@ class SemanticIndexer:
             logger.error(
                 "Failed deleting ledger points from collection '%s': %s", target, e
             )
-            self._qdrant_available = False
+            # NOTE: deliberately do NOT set ``self._qdrant_available = False`` here.
+            # That flag is the upsert path's circuit breaker (``_batch_upsert``).
+            # The drain runs at the FRONT of every reindex against the shared cached
+            # indexer, so a transient DELETE blip must not degrade indexing
+            # availability for the rest of the run.  We still raise so the caller
+            # (the ledger drain) leaves the row for a later attempt.
             raise RuntimeError(f"Failed to delete remote points from Qdrant: {e}")
         return len(point_ids)
 

--- a/mcp_server/utils/semantic_indexer.py
+++ b/mcp_server/utils/semantic_indexer.py
@@ -3229,6 +3229,41 @@ class SemanticIndexer:
         sqlite_store.delete_semantic_point_mappings(profile_id, chunk_ids)
         return len(point_ids)
 
+    def delete_remote_points(
+        self,
+        point_ids: List[Any],
+        *,
+        collection: Optional[str] = None,
+    ) -> int:
+        """Delete specific remote (Qdrant) points by id from ``collection``.
+
+        Mirrors the remote delete in :meth:`delete_stale_vectors`, but takes raw
+        remote point ids instead of chunk ids.  Used by the crash-ledger drain
+        (:meth:`SQLiteStore.drain_pending_vector_deletions`), whose rows record
+        only the remote point id + collection because the local chunk mapping is
+        already gone.  ``collection`` defaults to this indexer's collection when
+        the ledger row did not record one.  Raises on a remote failure so the
+        caller can leave the ledger row for a later attempt.
+        """
+        point_ids = list(dict.fromkeys(point_ids))
+        if not point_ids:
+            return 0
+        if not self._qdrant_available:
+            raise RuntimeError("Qdrant client unavailable for remote point deletion")
+        target = collection or self.collection
+        try:
+            self.qdrant.delete(
+                collection_name=target,
+                points_selector=models.PointIdsList(points=point_ids),
+            )
+        except Exception as e:
+            logger.error(
+                "Failed deleting ledger points from collection '%s': %s", target, e
+            )
+            self._qdrant_available = False
+            raise RuntimeError(f"Failed to delete remote points from Qdrant: {e}")
+        return len(point_ids)
+
     def cleanup_stale_semantic_artifacts(
         self,
         profile_id: str,

--- a/tests/test_chunker_scheme_recovery.py
+++ b/tests/test_chunker_scheme_recovery.py
@@ -403,3 +403,160 @@ def test_inplace_rebuild_preserves_synthetic_and_returns_stale_vector_ids(tmp_pa
     assert summary_hashes == {"history:issue"}  # chunker summaries dropped, no dangling
     assert point_ids == {900}  # chunker point mappings dropped, no dangling
     store.close()
+
+
+# --------------------------------------------------------------------------- #
+# Production drain of the pending_vector_deletions crash-ledger (I4)
+#
+# A crashed chunk-scheme rebuild deletes local semantic_points but leaves the
+# orphaned REMOTE (Qdrant) point ids only in the durable ledger. The reindex/
+# startup drain finishes that remote cleanup and clears the drained rows.
+# --------------------------------------------------------------------------- #
+class _FakeVectorClient:
+    """Records remote-delete calls; can fail selected collections (per-profile)."""
+
+    def __init__(self, fail_collections=frozenset()):
+        self.calls = []  # list of (collection, sorted point_ids)
+        self._fail = set(fail_collections)
+
+    def delete_remote_points(self, point_ids, *, collection=None):
+        self.calls.append((collection, sorted(point_ids)))
+        if collection in self._fail:
+            raise RuntimeError(f"Qdrant unavailable for collection {collection!r}")
+        return len(point_ids)
+
+
+def _drain_callback(client):
+    return lambda collection, point_ids: client.delete_remote_points(
+        point_ids, collection=collection
+    )
+
+
+def _seed_ledger(store, points):
+    """Insert crash-ledger rows exactly as a mid-rebuild crash would leave them."""
+    with store._get_connection() as conn:
+        store._record_pending_vector_deletions(conn, points)
+
+
+def test_drain_deletes_recorded_orphans_and_clears_rows(tmp_path):
+    """(a) A ledger of recorded orphans -> drain deletes exactly those remote point
+    ids (per collection) and clears the ledger."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    _seed_ledger(
+        store,
+        [
+            {"profile_id": "profile-a", "chunk_id": "c1", "point_id": 101, "collection": "col-a"},
+            {"profile_id": "profile-a", "chunk_id": "c2", "point_id": 102, "collection": "col-a"},
+        ],
+    )
+
+    client = _FakeVectorClient()
+    result = store.drain_pending_vector_deletions(_drain_callback(client))
+
+    assert client.calls == [("col-a", [101, 102])]
+    assert result == {"rows_drained": 2, "rows_remaining": 0, "groups_failed": 0}
+    assert store.get_pending_vector_deletions() == []
+    store.close()
+
+
+def test_drain_is_fail_safe_per_profile(tmp_path):
+    """(b) A remote-delete failure for one profile/collection leaves ITS rows in the
+    ledger for a later attempt, still clears the healthy profile's rows, and the
+    drain call itself never raises."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    _seed_ledger(
+        store,
+        [
+            {"profile_id": "profile-a", "chunk_id": "a1", "point_id": 101, "collection": "col-a"},
+            {"profile_id": "profile-a", "chunk_id": "a2", "point_id": 102, "collection": "col-a"},
+            {"profile_id": "profile-b", "chunk_id": "b1", "point_id": 201, "collection": "col-b"},
+        ],
+    )
+
+    client = _FakeVectorClient(fail_collections={"col-b"})
+    # Must not raise despite the remote failure for col-b.
+    result = store.drain_pending_vector_deletions(_drain_callback(client))
+
+    assert result["groups_failed"] == 1
+    assert result["rows_drained"] == 2
+    assert result["rows_remaining"] == 1
+
+    # Healthy profile drained; failed profile's rows REMAIN for the next attempt.
+    remaining = store.get_pending_vector_deletions()
+    assert {row["point_id"] for row in remaining} == {201}
+    assert {row["profile_id"] for row in remaining} == {"profile-b"}
+
+    # Second attempt with a now-healthy client finishes the deferred delete.
+    healthy = _FakeVectorClient()
+    result2 = store.drain_pending_vector_deletions(_drain_callback(healthy))
+    assert healthy.calls == [("col-b", [201])]
+    assert result2["rows_drained"] == 1
+    assert store.get_pending_vector_deletions() == []
+    store.close()
+
+
+def test_drain_empty_ledger_is_noop(tmp_path):
+    """(c) An empty ledger is a no-op: no remote calls, nothing cleared."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    client = _FakeVectorClient()
+    result = store.drain_pending_vector_deletions(_drain_callback(client))
+    assert client.calls == []
+    assert result == {"rows_drained": 0, "rows_remaining": 0, "groups_failed": 0}
+    store.close()
+
+
+def test_drain_is_idempotent_on_second_run(tmp_path):
+    """(d) A successful drain followed by a re-run is a no-op (idempotent)."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    _seed_ledger(
+        store,
+        [{"profile_id": "profile-a", "chunk_id": "c1", "point_id": 101, "collection": "col-a"}],
+    )
+    client = _FakeVectorClient()
+    store.drain_pending_vector_deletions(_drain_callback(client))
+    assert store.get_pending_vector_deletions() == []
+
+    # Re-run: ledger already empty, so no further remote calls happen.
+    client2 = _FakeVectorClient()
+    result2 = store.drain_pending_vector_deletions(_drain_callback(client2))
+    assert client2.calls == []
+    assert result2 == {"rows_drained": 0, "rows_remaining": 0, "groups_failed": 0}
+    store.close()
+
+
+def test_dispatcher_drain_wiring_noops_without_semantic(tmp_path):
+    """The reindex hook (EnhancedDispatcher._drain_pending_vector_deletions) drains
+    when a semantic client is present and no-ops cleanly when it is not - without
+    constructing a full dispatcher."""
+    from mcp_server.dispatcher.dispatcher_enhanced import EnhancedDispatcher
+
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    _seed_ledger(
+        store,
+        [{"profile_id": "profile-a", "chunk_id": "c1", "point_id": 101, "collection": "col-a"}],
+    )
+
+    class _Ctx:
+        sqlite_store = store
+
+    ctx = _Ctx()
+
+    # Semantic disabled -> no client -> clean no-op, ledger untouched.
+    class _NoSem:
+        def _get_semantic_indexer(self, ctx):
+            return None
+
+    EnhancedDispatcher._drain_pending_vector_deletions(_NoSem(), ctx)
+    assert {r["point_id"] for r in store.get_pending_vector_deletions()} == {101}
+
+    # Semantic present -> drains through delete_remote_points, clears the ledger.
+    client = _FakeVectorClient()
+
+    class _WithSem:
+        def _get_semantic_indexer(self, ctx):
+            return client
+
+    EnhancedDispatcher._drain_pending_vector_deletions(_WithSem(), ctx)
+    assert client.calls == [("col-a", [101])]
+    assert store.get_pending_vector_deletions() == []
+    store.close()

--- a/tests/test_chunker_scheme_recovery.py
+++ b/tests/test_chunker_scheme_recovery.py
@@ -560,3 +560,78 @@ def test_dispatcher_drain_wiring_noops_without_semantic(tmp_path):
     assert client.calls == [("col-a", [101])]
     assert store.get_pending_vector_deletions() == []
     store.close()
+
+
+def test_drain_skips_revived_point_ids_but_clears_their_ledger_rows(tmp_path):
+    """(e) Finding 1: point ids are deterministic and content-derived, so an
+    incremental index pass can legitimately RE-CREATE a ledger point id (fresh
+    ``semantic_points`` row + remote vector) BEFORE the drain runs.  Such a revived
+    point id is in active use and must NOT be remote deleted - deleting it would
+    silently drop a live vector and leave its fresh mapping dangling.  Its ledger
+    debt is still cleared (resolved).  A true-orphan point id in the SAME group
+    (no live mapping) IS remote deleted."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    _seed_ledger(
+        store,
+        [
+            {"profile_id": "profile-a", "chunk_id": "c1", "point_id": 101, "collection": "col-a"},
+            {"profile_id": "profile-a", "chunk_id": "c2", "point_id": 102, "collection": "col-a"},
+        ],
+    )
+    # Point 101 was revived by an incremental pass: it has a LIVE semantic_points
+    # mapping in the same profile/collection.  Point 102 stays a true orphan.
+    store.upsert_semantic_point("profile-a", "c1-revived", 101, "col-a")
+
+    client = _FakeVectorClient()
+    result = store.drain_pending_vector_deletions(_drain_callback(client))
+
+    # Only the true orphan (102) is remote deleted; the revived point (101) is
+    # SKIPPED so its live remote vector survives.
+    assert client.calls == [("col-a", [102])]
+    # ... but BOTH ledger rows are cleared (debt resolved either way).
+    assert result == {"rows_drained": 2, "rows_remaining": 0, "groups_failed": 0}
+    assert store.get_pending_vector_deletions() == []
+    # The live mapping is untouched.
+    assert store.get_semantic_point_ids("profile-a", ["c1-revived"]) == [101]
+    store.close()
+
+
+def test_delete_remote_points_error_does_not_trip_upsert_circuit_breaker(tmp_path):
+    """(f) Finding 2: a remote-delete failure in ``delete_remote_points`` (the
+    ledger-drain remote hook) must RAISE (so the ledger row survives) WITHOUT
+    setting ``_qdrant_available = False``.  That flag is the UPSERT path's circuit
+    breaker; because the drain runs at the FRONT of every reindex against the
+    shared cached indexer, a transient delete blip must not degrade indexing for
+    the rest of the run."""
+    from types import SimpleNamespace  # noqa: F401
+    from mcp_server.core.path_resolver import PathResolver
+    from mcp_server.utils.semantic_indexer import SemanticIndexer
+
+    class _FailingDeleteQdrant:
+        def __init__(self):
+            self.upserted = []
+
+        def delete(self, collection_name, points_selector):
+            raise RuntimeError("transient Qdrant blip during delete")
+
+        def upsert(self, collection_name, points):
+            self.upserted.append((collection_name, points))
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    qdrant = _FailingDeleteQdrant()
+    indexer = SemanticIndexer.__new__(SemanticIndexer)
+    indexer.qdrant = qdrant
+    indexer.collection = "code-index"
+    indexer._qdrant_available = True
+    indexer.path_resolver = PathResolver(repo_path)
+
+    with pytest.raises(RuntimeError, match="Failed to delete remote points"):
+        indexer.delete_remote_points([101, 102], collection="col-a")
+
+    # The DELETE failure must NOT flip the upsert circuit breaker.
+    assert indexer._qdrant_available is True
+
+    # Upserts remain available after the delete failure (the run is not degraded).
+    indexer.qdrant.upsert(collection_name="col-a", points=["p"])
+    assert qdrant.upserted == [("col-a", ["p"])]


### PR DESCRIPTION
Addresses the **IMPORTANT** item in Consiliency/Code-Index-MCP#80 (CHUNKERSAFE Lane A follow-ups).

**Problem:** when a chunk-scheme rebuild deletes the local `semantic_points` rows but crashes before finishing the matching **remote** (Qdrant) delete, the orphaned remote point ids are durably recorded in `pending_vector_deletions` — but `get_pending_vector_deletions` / `clear_pending_vector_deletions` had **no production caller**, so those remote vectors leaked forever (the local mapping is already gone; nothing else can find them).

**Fix — a fail-safe recovery drain wired into the reindex entry point:**
- `sqlite_store.drain_pending_vector_deletions(delete_remote)` — groups the ledger by `(profile_id, collection)`, calls `delete_remote(collection, point_ids)` per group, and clears a group's rows **only** when its remote delete succeeds. Fail-safe (a remote error keeps that group's rows for next time, never clears an un-drained row, never raises → cannot crash its caller); idempotent (empty ledger / re-run is a no-op).
- `semantic_indexer.delete_remote_points(...)` — deletes raw remote point ids (mirrors the existing `PointIdsList` delete); raises on failure so the row survives.
- `dispatcher_enhanced._drain_pending_vector_deletions(ctx)` at the top of `index_directory` — the reindex entry point where both the store and a semantic client exist; drains before repopulation, no-ops when semantic is disabled.

**Verification:** 5 new tests (drain+clear, per-group failure isolation, empty no-op, idempotent, dispatcher wiring); 27 targeted + 252 sweep, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->