### PR TITLE
chunksafe: four Lane A cleanups from PR #77 review (#80)

### DIFF
--- a/mcp_server/cli/tool_handlers.py
+++ b/mcp_server/cli/tool_handlers.py
@@ -678,7 +678,11 @@ async def handle_search_code(
             scheme_readable = True
             try:
                 scheme_status, _sc_marker, _sc_target = sqlite_store.get_chunk_scheme_status()
-                scheme_readable = scheme_status in ("compatible", "empty")
+                scheme_readable = scheme_status in (
+                    "compatible",
+                    "compatible_legacy",
+                    "empty",
+                )
             except Exception:
                 scheme_readable = False
             if scheme_readable:

--- a/mcp_server/health/repository_readiness.py
+++ b/mcp_server/health/repository_readiness.py
@@ -29,6 +29,7 @@ class RepositoryReadinessState(str, Enum):
     UNSUPPORTED_WORKTREE = "unsupported_worktree"
     AMBIGUOUS_SELECTOR = "ambiguous_selector"
     CORRUPT_SQLITE = "corrupt_sqlite"
+    INDEX_LOCKED = "index_locked"
     MISSING_SCHEMA = "missing_schema"
     MISSING_PROVENANCE = "missing_provenance"
     SCHEME_MISMATCH = "scheme_mismatch"
@@ -180,6 +181,18 @@ def _inspect_index_uncached(index_path: Path) -> Optional[RepositoryReadinessSta
                 return RepositoryReadinessState.INDEX_REBUILDING
             if scheme_status in ("mismatch", "missing_marker"):
                 return RepositoryReadinessState.SCHEME_MISMATCH
+    except sqlite3.OperationalError as exc:
+        # A "database is locked"/"database is busy" OperationalError is a
+        # concurrent-writer contention signal over a busy-but-HEALTHY index, not
+        # on-disk corruption. Classify it distinctly (and BEFORE the DatabaseError
+        # catch-all, since OperationalError subclasses DatabaseError) so a
+        # transient lock is never reported as CORRUPT_SQLITE and never triggers a
+        # destructive quarantine/reindex. Any other OperationalError falls through
+        # to the corruption fail-closed default.
+        message = str(exc).lower()
+        if "database is locked" in message or "database is busy" in message or "locked" in message:
+            return RepositoryReadinessState.INDEX_LOCKED
+        return RepositoryReadinessState.CORRUPT_SQLITE
     except sqlite3.DatabaseError:
         return RepositoryReadinessState.CORRUPT_SQLITE
     return None
@@ -269,7 +282,13 @@ class ReadinessClassifier:
         else:
             db_state = cls._inspect_index(index_path)
 
-            if db_state == RepositoryReadinessState.CORRUPT_SQLITE:
+            if db_state == RepositoryReadinessState.INDEX_LOCKED:
+                state = RepositoryReadinessState.INDEX_LOCKED
+                remediation = (
+                    "The index is temporarily locked by a concurrent writer; the "
+                    "index is healthy -- retry the query shortly (do not reindex)."
+                )
+            elif db_state == RepositoryReadinessState.CORRUPT_SQLITE:
                 state = RepositoryReadinessState.CORRUPT_SQLITE
                 remediation = "Run reindex to quarantine the corrupt bytes and rebuild the index."
             elif db_state == RepositoryReadinessState.MISSING_SCHEMA:

--- a/mcp_server/indexing/incremental_indexer.py
+++ b/mcp_server/indexing/incremental_indexer.py
@@ -14,7 +14,11 @@ from typing import Any, Dict, List, Optional
 from ..core.path_resolver import PathResolver
 from ..core.repo_context import RepoContext
 from ..dispatcher.dispatcher_enhanced import EnhancedDispatcher
-from ..storage.sqlite_store import SQLiteStore, assert_chunk_scheme_readable
+from ..storage.sqlite_store import (
+    SQLiteStore,
+    _escape_like,
+    assert_chunk_scheme_readable,
+)
 from ..storage.two_phase import two_phase_commit
 from ..utils.subprocess_env import get_full_env
 from .change_detector import FileChange
@@ -27,18 +31,6 @@ from .checkpoint import save as _save_ckpt
 from .lock_registry import lock_registry
 
 logger = logging.getLogger(__name__)
-
-
-def _escape_like(text: str) -> str:
-    """Escape SQL LIKE metacharacters so a literal chunk_id matches only itself.
-
-    Backslash is the ESCAPE char (see ``LIKE ? ESCAPE '\\'`` below), so it must be
-    escaped first; then the ``%`` and ``_`` wildcards are neutralised. Under v4's
-    collision-free ids a ``chunk_id`` may legitimately contain ``%``/``_``, which
-    would otherwise cause a ``chunk_id LIKE '<id>:part:%'`` query to mis-match
-    unrelated rows.
-    """
-    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 @dataclass

--- a/mcp_server/storage/sqlite_store.py
+++ b/mcp_server/storage/sqlite_store.py
@@ -1622,6 +1622,24 @@ class SQLiteStore:
         index)."""
         target = target or self._current_scheme()
         status, marker, target = evaluate_chunk_scheme(conn, target)
+        if status == "rebuilding":
+            # Symmetric with ``_assert_chunk_scheme_writable``: during the
+            # begin->finalize rebuild window ONLY the explicitly-scoped rebuild
+            # writer (whose target equals the persisted rebuild target) may touch
+            # code_chunks. An ordinary cross-scheme deleter would otherwise erase
+            # old-scheme rows that finalize then restamps, matching the mixed-scheme
+            # corruption the guard exists to prevent -- so refuse it exactly as the
+            # writable assert refuses the corresponding insert.
+            if target != marker:
+                raise ChunkSchemeMismatchError(
+                    f"code_chunks is rebuilding to {marker!r}; refusing a delete "
+                    f"scoped to {target!r}. Only the rebuild writer (scheme_target="
+                    f"{marker!r}) may modify chunks until the rebuild is finalized.",
+                    expected=marker,
+                    found=target,
+                    state=status,
+                )
+            return
         if status in _SCHEME_WRITE_BLOCKING:
             raise ChunkSchemeMismatchError(
                 f"code_chunks scheme is {status!r} (index marker={marker!r}, "

--- a/tests/test_chunker_identity_migration.py
+++ b/tests/test_chunker_identity_migration.py
@@ -599,3 +599,26 @@ def test_scheme_probe_reraises_non_schema_operational_error():
 
     # An older/minimal schema (table present, column absent) is absent, not corrupt.
     assert sqlite_store_module._has_chunker_rows(_NoColumnConn()) is False
+
+
+# --------------------------------------------------------------------------- #
+# Cleanup item 1: _escape_like is deduplicated (single canonical helper)
+# --------------------------------------------------------------------------- #
+def test_escape_like_is_single_canonical_helper():
+    """The chunk_id LIKE-escape helper lives once in sqlite_store; the incremental
+    indexer imports that canonical function instead of keeping a divergent copy.
+
+    Asserts both call sites resolve to the SAME object and escape ``%``, ``_``,
+    and the backslash ESCAPE char identically for a range of inputs (so a future
+    edit to one cannot silently drift the two escapings apart)."""
+    from mcp_server.indexing.incremental_indexer import _escape_like as indexer_escape
+    from mcp_server.storage.sqlite_store import _escape_like as store_escape
+
+    # Deduplicated: the indexer no longer defines its own copy.
+    assert indexer_escape is store_escape
+
+    for sample in ("plain", "a_b", "50%", "a\\b", "x_%\\y", "a:part:%", ""):
+        assert indexer_escape(sample) == store_escape(sample)
+
+    # Behavior is unchanged: backslash escaped first, then %/_ wildcards.
+    assert store_escape("a_b%c\\d") == "a\\_b\\%c\\\\d"

--- a/tests/test_chunker_scheme_recovery.py
+++ b/tests/test_chunker_scheme_recovery.py
@@ -635,3 +635,42 @@ def test_delete_remote_points_error_does_not_trip_upsert_circuit_breaker(tmp_pat
     # Upserts remain available after the delete failure (the run is not degraded).
     indexer.qdrant.upsert(collection_name="col-a", points=["p"])
     assert qdrant.upserted == [("col-a", ["p"])]
+
+
+def test_delete_during_rebuild_is_symmetric_with_insert(tmp_path):
+    """Cleanup item 3: a cross-scheme DELETE during the rebuild window is admitted
+    or refused by exactly the same rule as the corresponding INSERT.
+
+    Before the fix ``_assert_chunk_scheme_deletable`` had no ``rebuilding`` branch,
+    so an ordinary cross-scheme writer's INSERT was refused while its DELETE was
+    silently admitted -- an asymmetry that let a non-rebuild actor erase old-scheme
+    rows the finalize step would then restamp (mixed-scheme corruption). Both choke
+    points must now make the SAME admit/refuse decision."""
+    store = SQLiteStore(str(tmp_path / "code_index.db"))
+    store.ensure_repository_row(tmp_path, name="test-repo")
+
+    rebuild_target = current_chunk_id_scheme()
+    other_scheme = FOREIGN_SCHEME  # a scheme this rebuild is NOT building
+
+    # Enter the blocked 'rebuilding' state scoped to rebuild_target.
+    store.begin_chunk_scheme_rebuild(target_scheme=rebuild_target)
+
+    with store._get_connection() as conn:
+        status, marker, _t = evaluate_chunk_scheme(conn, rebuild_target)
+        assert status == "rebuilding" and marker == rebuild_target
+
+        # The rebuild writer (target == marker): both insert and delete admitted.
+        store._assert_chunk_scheme_writable(conn, chunk_type="code", target=rebuild_target)
+        store._assert_chunk_scheme_deletable(conn, target=rebuild_target)
+
+        # An ordinary cross-scheme actor (target != marker): the insert is refused,
+        # and the delete must now be refused symmetrically (previously admitted).
+        with pytest.raises(ChunkSchemeMismatchError) as insert_exc:
+            store._assert_chunk_scheme_writable(conn, chunk_type="code", target=other_scheme)
+        with pytest.raises(ChunkSchemeMismatchError) as delete_exc:
+            store._assert_chunk_scheme_deletable(conn, target=other_scheme)
+
+        # Same admit/refuse decision AND same state classification on both paths.
+        assert insert_exc.value.state == delete_exc.value.state == "rebuilding"
+
+    store.close()

--- a/tests/test_repository_readiness.py
+++ b/tests/test_repository_readiness.py
@@ -48,6 +48,7 @@ def test_readiness_state_values_are_exact():
         "unsupported_worktree",
         "ambiguous_selector",
         "corrupt_sqlite",
+        "index_locked",
         "missing_schema",
         "missing_provenance",
         "scheme_mismatch",
@@ -386,6 +387,47 @@ def test_sqlite_query_exception_fails_closed_as_corrupt(tmp_path, monkeypatch):
     readiness = ReadinessClassifier.classify_registered(repo_info)
 
     assert readiness.state == RepositoryReadinessState.CORRUPT_SQLITE
+
+
+def test_locked_database_classifies_as_index_locked_not_corrupt(tmp_path, monkeypatch):
+    """Cleanup item 4: a 'database is locked'/'database is busy' OperationalError is
+    a busy-but-HEALTHY index (concurrent writer contention), not corruption, and
+    must classify as the distinct INDEX_LOCKED state -- never the alarming
+    CORRUPT_SQLITE, which would advise a destructive quarantine/reindex."""
+    ReadinessClassifier.clear_index_inspection_cache()
+    repo_info = make_repo_info(tmp_path)
+
+    def locked_connect(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(sqlite3, "connect", locked_connect)
+
+    readiness = ReadinessClassifier.classify_registered(repo_info)
+
+    assert readiness.state == RepositoryReadinessState.INDEX_LOCKED
+    assert readiness.state != RepositoryReadinessState.CORRUPT_SQLITE
+    assert readiness.ready is False
+    # Remediation must NOT tell the operator to quarantine/reindex a healthy index.
+    assert "quarantine" not in (readiness.remediation or "").lower()
+    assert "retry" in (readiness.remediation or "").lower()
+    ReadinessClassifier.clear_index_inspection_cache()
+
+
+def test_non_lock_operational_error_still_classifies_as_corrupt(tmp_path, monkeypatch):
+    """The lock guard is specific: an OperationalError that is NOT a lock/busy
+    contention signal still fails closed as CORRUPT_SQLITE."""
+    ReadinessClassifier.clear_index_inspection_cache()
+    repo_info = make_repo_info(tmp_path)
+
+    def broken_connect(*_args, **_kwargs):
+        raise sqlite3.OperationalError("unable to open database file")
+
+    monkeypatch.setattr(sqlite3, "connect", broken_connect)
+
+    readiness = ReadinessClassifier.classify_registered(repo_info)
+
+    assert readiness.state == RepositoryReadinessState.CORRUPT_SQLITE
+    ReadinessClassifier.clear_index_inspection_cache()
 
 
 def test_unchanged_index_reuses_cached_integrity_inspection(tmp_path, monkeypatch):

--- a/tests/test_tool_handlers_readiness.py
+++ b/tests/test_tool_handlers_readiness.py
@@ -802,3 +802,74 @@ def test_write_summaries_remains_summary_only(tmp_path, monkeypatch):
     assert data["chunks_summarized"] == 3
     assert data["semantic_vectors_written"] is False
     assert data["summary_missing_chunks"] == 1
+
+
+def _run_summarization_gate(monkeypatch, scheme_status: str) -> bool:
+    """Drive handle_search_code past the lazy-summarization pre-check with the
+    given chunk-scheme status and report whether a chunk was enqueued.
+
+    Cleanup item 2 regression harness: the gate must admit ``compatible_legacy``
+    (a legacy unmarked index) so summarization is not skipped until the first
+    write auto-stamps the marker."""
+    from mcp_server.cli import tool_handlers as th
+
+    item = SimpleNamespace(
+        file="pkg/mod.py",
+        line=10,
+        line_end=20,
+        symbol="fn",
+        snippet="def fn(): ...",
+        last_indexed=None,
+        source_metadata=None,
+        semantic_source=None,
+        semantic_profile_id=None,
+        semantic_collection_name=None,
+    )
+    fake_result = SimpleNamespace(
+        results=(item,),
+        semantic_requested=False,
+        source_type=None,
+        friction_categories=(),
+        history_labels=(),
+        history_repos=(),
+        include_source_metadata=False,
+        readiness={},
+        semantic_readiness=None,
+        index_unavailable=None,
+        code=None,
+        message=None,
+        semantic_profile_id=None,
+        semantic_collection_name=None,
+    )
+    monkeypatch.setattr(th, "execute_search_service", lambda **_kwargs: fake_result)
+
+    lazy_summarizer = MagicMock()
+    lazy_summarizer.can_summarize.return_value = True
+    sqlite_store = MagicMock()
+    sqlite_store.get_chunk_scheme_status.return_value = (scheme_status, None, "scheme-x")
+    sqlite_store.find_chunk_at_line.return_value = {"chunk_id": "c1"}
+
+    _run(
+        th.handle_search_code(
+            arguments={"query": "fn"},
+            dispatcher=MagicMock(),
+            repo_resolver=object(),  # no .classify -> selector path skipped
+            sqlite_store=sqlite_store,
+            lazy_summarizer=lazy_summarizer,
+        )
+    )
+    return lazy_summarizer.enqueue.called
+
+
+def test_compatible_legacy_scheme_allows_summarization(monkeypatch):
+    """A ``compatible_legacy`` (legacy unmarked) index must NOT skip lazy
+    summarization -- the pre-check now accepts it alongside compatible/empty."""
+    assert _run_summarization_gate(monkeypatch, "compatible_legacy") is True
+
+
+def test_incompatible_scheme_still_skips_summarization(monkeypatch):
+    """The gate stays fail-closed: a mismatched/rebuilding scheme still skips
+    summarization (proves the compatible_legacy admission is scoped, not a
+    blanket open of the gate)."""
+    assert _run_summarization_gate(monkeypatch, "mismatch") is False
+    assert _run_summarization_gate(monkeypatch, "rebuilding") is False


### PR DESCRIPTION
The four **non-blocking** cleanup items from Consiliency/Code-Index-MCP#80 (CHUNKERSAFE Lane A code review). The IMPORTANT ledger drain shipped in #84; this closes out the remainder.

- **Dedup `_escape_like`** — `incremental_indexer` now imports the canonical helper from `sqlite_store` (import direction was already indexer→storage; no new cycle) and drops its local copy. Identical `%`/`_`/backslash escaping, one source of truth.
- **Lazy-summarization accepts `compatible_legacy`** — the pre-check took `compatible`/`empty` only, so summaries were skipped over a legacy unmarked index until the first write auto-stamped it. Now admitted.
- **`_assert_chunk_scheme_deletable` gains a `rebuilding` branch** mirroring `_assert_chunk_scheme_writable` — during a real rebuild a cross-scheme *delete* is now refused (and the rebuild writer admitted) symmetrically with *insert*, instead of being silently admitted.
- **`INDEX_LOCKED` readiness state** — a "database is locked"/"busy" `OperationalError` is a healthy-but-busy index, classified `INDEX_LOCKED` (retry, do **not** reindex) before the `CORRUPT_SQLITE` catch-all, and deliberately kept out of the recoverable/quarantine-rebuild sets so a busy index can't trigger a destructive reindex.

**Verification:** 72 owned + 389 sweep tests, 0 failed (rebased onto main post-#84). Closes Consiliency/Code-Index-MCP#80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->