### PR TITLE
docs(inference-rollout): concrete live-run runbook + verified-scaffolding record

### DIFF
--- a/docs/status/INFERENCE_ROLLOUT.md
+++ b/docs/status/INFERENCE_ROLLOUT.md
@@ -151,11 +151,25 @@ reachable) and the verdict stays `dark_opt_in`.
 Only an operator with a reachable, provenance-verified collection may produce
 gate-counting numbers. Steps:
 
-1. **Index with a provenance-writing producer.** Run the semantic-index producer
-   so it persists the `collection-provenance.v1` manifest into the collection
-   (not only the local `.index_metadata.json`). The producer records
+> **Never score the live index.** The driver connects to Qdrant on
+> `localhost:6333`; the production MCP index lives in the `code-embeddings`
+> collection. Point this run at a **dedicated** `SEMANTIC_COLLECTION_NAME`
+> (e.g. `inferbound-v10-eval`) so indexing the frozen corpus can never
+> overwrite the live index.
+
+1. **Index the frozen corpus with a provenance-writing producer.** Index the
+   corpus **at the frozen commit** (`corpus_manifest.json` → `commit`
+   `f7c060b`; use a worktree/checkout at that revision so the file set and the
+   producer's recorded `indexed_commit` match the frozen contract) into the
+   dedicated collection. A normal full build now binds the corpus automatically:
+   `index_files_batch` computes `corpus_sha256` from the sorted+deduped indexed
+   relative paths (the same recipe as `corpus_manifest.json`) and writes the
+   `collection-provenance.v1` sentinel into the collection — recording
    `indexed_commit`, the full `corpus_sha256`, the embedding `profile_fingerprint`,
-   `provider_id` / `provider_revision`, and a `point_set_id` for the build.
+   `provider_id` / `provider_revision`, and a `point_set_id`. (Incremental
+   mutations after the build deliberately invalidate the sentinel, so the scored
+   collection must come from one clean full build, not an incrementally-patched
+   index.)
 2. **Bring up the live services.** Qdrant on `localhost:6333`, the OpenAI-compatible
    embedding endpoint, and (for `hybrid_rerank`) a `rerank.v1` endpoint. Export:
    - `SEMANTIC_COLLECTION_NAME` — the collection to score;
@@ -185,6 +199,37 @@ gate-counting numbers. Steps:
    run where `provenance_verified: true`, the `hybrid_rerank` arm ran and cleared
    every frozen predicate, and the holdout was not used for tuning. No default is
    flipped here.
+
+### Scaffolding verification (2026-07-17)
+
+The gate machinery this procedure relies on was exercised end-to-end on the
+current host; only the two live provider services are absent, so the verdict
+cannot move here. What was verified:
+
+- **Frozen contract intact.** `dataset_sha256` and `thresholds_sha256` recompute
+  to the values recorded in `MANIFEST.json`; the driver's own corpus
+  reconstruction verifies (`corpus_reconstruction_verified: true`, 872 docs at
+  commit `f7c060b`).
+- **Offline gate is honest.** Re-running the driver on this host reproduces the
+  committed artifact: the lexical arm runs, `dense` / `hybrid` / `hybrid_rerank`
+  record `not_run` with truthful `embedding endpoint … unreachable` reasons,
+  `provenance_verified: not_applicable`, verdict `dark_opt_in`.
+- **Provenance write → read → verify round-trips against live Qdrant.** Using a
+  throwaway collection (never `code-embeddings`), the producer's
+  `write_collection_provenance` persisted a `collection-provenance.v1` sentinel
+  bound to the frozen `corpus_sha256` and commit; the gate's module-level
+  `read_collection_provenance` round-tripped it; `verify_collection_provenance`
+  returned **verified** against the frozen corpus; and every tampered manifest
+  mapped to its exact reason code (`stale` for a wrong commit or corpus,
+  `corpus_unbound` for a null corpus, `tampered` for a bad version, `missing`
+  for an absent sentinel, `collection_mismatch` for the wrong collection).
+
+**What remains to produce counting numbers on this host:** a reachable
+OpenAI-compatible embedding endpoint (`SEMANTIC_EMBEDDING_HOST:PORT`, currently
+`ai:8001` unreachable) and a `rerank.v1` endpoint, plus one clean full index of
+the frozen corpus into a dedicated collection. Qdrant on `localhost:6333` is
+already up. With those two services present, this procedure runs unchanged and
+the driver will score the provider arms.
 
 ## Metrics produced (lexical arm only)
 


### PR DESCRIPTION
Follow-through on exercising the INFERLIVEGATE gate. On this host the decisive `hybrid_rerank` arm's two provider services are absent (embedding endpoint `ai:8001` unreachable; no rerank endpoint), so no arm can run and the verdict cannot move off `dark_opt_in`. Rather than leave the "live run" direction as prose, this makes the operator runbook a **verified** deliverable — folded into the existing `docs/status/INFERENCE_ROLLOUT.md` operator section (no new file).

**Runbook improvements**
- Step 1 is now concrete: index the frozen corpus **at the frozen commit `f7c060b`** into a **dedicated** collection; a full build now binds `corpus_sha256` automatically and writes the `collection-provenance.v1` sentinel (the #83 fix), and incremental mutations invalidate it (only a clean full build is scoreable).
- Added a **"never score the live index"** guard — the driver connects to `localhost:6333` where the production `code-embeddings` collection lives; runs must target a dedicated `SEMANTIC_COLLECTION_NAME`.

**Verified scaffolding (recorded in the doc)** — exercised end-to-end on this host:
- `dataset_sha256` / `thresholds_sha256` recompute to `MANIFEST.json`; driver corpus reconstruction verifies (872 docs).
- Offline gate reproduces honestly (lexical ran; provider arms `not_run`; `dark_opt_in`).
- Producer `write_collection_provenance` → gate `read_collection_provenance` → `verify_collection_provenance` round-trips **verified** against the frozen corpus on a **throwaway** Qdrant collection (production `code-embeddings` untouched), with every tamper case mapping to its exact reason code.

**Verification:** docs-only; `tests/docs/test_inference_rollout_report.py` green (8 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->