### PR TITLE
chore: add CODEOWNERS (lead dev @ViperJuice)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Lead developer — auto-requested as reviewer on all changes.
+# Managed via repo-state consolidation (Phase 2). Advisory, not a merge gate.
+* @ViperJuice


### PR DESCRIPTION
Phase 2 of the fleet consolidation: adds `.github/CODEOWNERS` designating @ViperJuice as lead developer / auto-requested reviewer. Advisory only — not a merge gate. Routed as a PR because `main` requires status checks (direct commit blocked, as expected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->