### PR TITLE
chore(2b): standardize package author -> ViperJuice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
-    {name = "Jenner Torrence"}
+    { name = "ViperJuice", email = "viperjuice@users.noreply.github.com" }
 ]
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
Phase 2b: set published-package author to `ViperJuice <viperjuice@users.noreply.github.com>` for consistent lead-dev credit (was `Jenner Torrence`). Metadata-only; publishes on next release. PR because main is protected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->