### PR TITLE
ci: sign release images without crane + fix ownerless install URLs (#91)

### DIFF
--- a/.github/workflows/container-registry.yml
+++ b/.github/workflows/container-registry.yml
@@ -222,6 +222,15 @@ jobs:
       - name: Sign container images
         env:
           COSIGN_EXPERIMENTAL: 1
+          # Bind the tag name to an env var rather than interpolating the
+          # ${{ github.ref_name }} context directly into the shell script.
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          IMAGE_DIGEST=$(crane digest "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}")
-          cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${IMAGE_DIGEST}"
+          # Resolve the manifest digest with docker buildx (preinstalled and
+          # already authenticated above); avoids a crane binary that is not on
+          # the runner and was never installed, which previously made this
+          # signing step fail after a successful push.
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          IMAGE_DIGEST=$(docker buildx imagetools inspect \
+            "${IMAGE}:${REF_NAME}" --format '{{.Manifest.Digest}}')
+          cosign sign --yes "${IMAGE}@${IMAGE_DIGEST}"

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,7 @@ docker run -it -v $(pwd):/workspace ghcr.io/consiliency/code-index-mcp:v1.3.1
 docker run -it -v $(pwd):/workspace -e SEMANTIC_SEARCH_ENABLED=true -e VOYAGE_API_KEY=your-key ghcr.io/consiliency/code-index-mcp:v1.3.1
 
 # Install helper script (recommended)
-curl -sSL https://raw.githubusercontent.com/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
+curl -sSL https://raw.githubusercontent.com/Consiliency/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
 mcp-index  # Now available as a command
 ```
 

--- a/docs/DOCKER_GUIDE.md
+++ b/docs/DOCKER_GUIDE.md
@@ -68,13 +68,13 @@ authentication and suitable repository permissions.
 ### Quick Install (Linux/macOS)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
+curl -sSL https://raw.githubusercontent.com/Consiliency/Code-Index-MCP/main/scripts/install-mcp-docker.sh | bash
 ```
 
 ### Quick Install (Windows PowerShell)
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/Code-Index-MCP/main/scripts/install-mcp-docker.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/Consiliency/Code-Index-MCP/main/scripts/install-mcp-docker.ps1 | iex
 ```
 
 ### Manual Installation


### PR DESCRIPTION
Addresses items **2** and **3** of Consiliency/Code-Index-MCP#91 (follow-ups from the #89 panel review). Empirically confirmed on the live registry: release images `v1.2.0`..`v1.3.1` are published but carry **no cosign signature tags** — the sign step was failing.

- **Signing no longer depends on `crane`.** The sign job ran `crane digest ...` but only Cosign was installed and `crane` isn't on `ubuntu-latest`, so the step failed *after* a successful push → unsigned images. Now the manifest digest is resolved with `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` (buildx is preinstalled and already authenticated). Same index digest cosign would have signed; no new action to SHA-pin. The tag name is bound to a `REF_NAME` env var instead of interpolating `${{ github.ref_name }}` into the shell.
- **Fixed the ownerless install URLs.** `raw.githubusercontent.com/Code-Index-MCP/main/...` was missing the owner segment (404s everywhere) → `raw.githubusercontent.com/Consiliency/Code-Index-MCP/main/...` in `docker/README.md` and `docs/DOCKER_GUIDE.md`.

**Verification:** `actionlint` clean on all workflows; 33 release/doc contract tests pass.

Leaves #91 item 1 (verify a signed release once this lands) and item 4 (GHCR package made public — admin, after the first release) open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->