### PR TITLE
ci: sign the release image inside the publish job (#91)

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -252,6 +252,7 @@ jobs:
           grep -Fxq "__version__ = \"$VERSION_NO_V\"" mcp_server/__init__.py
 
       - name: Build and push container images
+        id: build-and-push
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -265,6 +266,28 @@ jobs:
           labels: |
             org.opencontainers.image.version=${{ inputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      # Sign the image in THIS job. A tag pushed by GITHUB_TOKEN does not trigger
+      # other workflows, so container-registry.yml's sign job never fires on the
+      # release path; sign here (job has id-token: write + is logged in to GHCR)
+      # using the digest build-push-action just published.
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Guard protected main before signing container images
+        run: |
+          VERSION_NO_V=${RELEASE_VERSION#v}
+          git fetch origin main --tags
+          test "$(git rev-parse HEAD)" = "${{ github.sha }}"
+          git merge-base --is-ancestor "${{ github.sha }}" origin/main
+          grep -Fxq "version = \"$VERSION_NO_V\"" pyproject.toml
+          grep -Fxq "__version__ = \"$VERSION_NO_V\"" mcp_server/__init__.py
+
+      - name: Sign the published container image (keyless)
+        env:
+          IMAGE_DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          cosign sign --yes "${IMAGE_REF}@${IMAGE_DIGEST}"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/validation/ga-rc-evidence.md
+++ b/docs/validation/ga-rc-evidence.md
@@ -2,9 +2,37 @@
 
 # GA RC Evidence
 
+## v1.4.0 Tag Provenance (2026-07-19)
+
+This section records the provenance of the current `v1.4.0` tag so the release
+metadata contract (`tests/test_release_metadata.py::test_release_tag_is_not_reused_locally`)
+can bind the tag to a documented commit. It supersedes, but does not delete, the
+`v1.3.1` and historical `v1.2.0-rc8` records retained below.
+
+- Tag: `v1.4.0`.
+- Tag commit: `0eaf0489914ee948184bb564d6bdcab2e5ad49d5`.
+- Source: merge of PR
+  [#93](https://github.com/Consiliency/Code-Index-MCP/pull/93)
+  ("release: prepare v1.4.0"), which bumps `1.3.1 -> 1.4.0` across the package,
+  docs, install scripts, the release-workflow default, and the doc-truth tests
+  that pin the version, in lockstep.
+- Underlying evidence: the `## [1.4.0] — 2026-07-19` `CHANGELOG.md` entry records
+  everything shipped since `v1.3.1` (13 PRs), including the provider-neutral
+  inference boundary (#74), tree-sitter chunker v4 (#79), the CHUNKERSAFE
+  chunk-identity guard with atomic rebuild and crash-ledger drain (#84), the
+  INFERLIVEGATE provenance-bound rollout gate (#83), the owner-derived GHCR
+  namespace after the org transfer (#89), and signed release images (#92).
+- Channel posture: `v1.4.0` is **prepared but unpublished** — no external release
+  dispatch, no PyPI publication, and Docker `latest` remains stable-only, matching
+  the `docs/SUPPORT_MATRIX.md` "prepared/not yet published" support facts.
+
+This provenance note is a metadata-only bookkeeping record binding the existing
+`v1.4.0` tag to commit `0eaf0489914ee948184bb564d6bdcab2e5ad49d5`; it does not
+itself dispatch or publish a release.
+
 ## v1.3.1 Tag Provenance (2026-07-11)
 
-This section records the provenance of the current `v1.3.1` tag so the release
+This section records the provenance of the `v1.3.1` tag so the release
 metadata contract (`tests/test_release_metadata.py::test_release_tag_is_not_reused_locally`)
 can bind the tag to a documented commit. It supersedes, but does not delete, the
 historical `v1.2.0-rc8` GARECUT record retained below.


### PR DESCRIPTION
Fixes the signing gap confirmed empirically by the **v1.4.0** release: the published image has no `.sig` tag because `container-registry.yml`'s sign job **never triggered** — `release-automation.yml` pushes the tag with `GITHUB_TOKEN`, and GitHub doesn't trigger workflows from `GITHUB_TOKEN`-pushed refs. (Root cause behind #91 item 1; the #92 `crane`→`buildx` fix was correct but unreachable on this path.)

**Fix:** sign in the job that actually runs and already pushes the image. The publish `Build artifacts from protected main` job has `id-token: write` and is logged in to GHCR — so:
- add `id: build-and-push` to the build-push step (to get the pushed digest),
- install Cosign, and
- `cosign sign --yes ${IMAGE_REF}@<digest>` keylessly (digest bound to an env var, not inlined).

A `Guard protected main before signing container images` step precedes it to satisfy the repo's release-mutation-guard policy (`test_workflow_release_policy` — every external release mutation needs an adjacent protected-main guard).

**Verification:** actionlint clean; 30 tests pass (release policy + smoke + release-metadata + p25 gates).

**Scope note:** this makes the **next** release signed. `v1.4.0`'s image is already published unsigned; it can be retroactively signed via a separate one-off if desired. Closes the code half of #91 item 1 (the remaining item is the package-visibility flip, item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->