### PR TITLE
ci: manual workflow to retroactively sign a published image

### DIFF
--- a/.github/workflows/sign-published-image.yml
+++ b/.github/workflows/sign-published-image.yml
@@ -1,0 +1,74 @@
+# localci-workflow-classification: manual-only
+name: Sign Published Image
+
+# Retroactively cosign-sign an already-published GHCR image (keyless, via the
+# Actions OIDC identity). Signing cannot be done off-CI because keyless cosign
+# needs the workflow's id-token. Used for images published before signing moved
+# into the release job; safe to re-run (cosign sign is idempotent per digest).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published tag to sign (e.g., v1.4.0). Must equal the current protected-main version.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  RELEASE_VERSION: ${{ inputs.version }}
+
+jobs:
+  sign-published-image:
+    name: Sign an already-published container image
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Derive lowercase GHCR image name (follows repo owner across transfers)
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "IMAGE_NAME=${owner}/code-index-mcp" >> "$GITHUB_ENV"
+          echo "IMAGE_REF=${REGISTRY}/${owner}/code-index-mcp" >> "$GITHUB_ENV"
+
+      - name: Check out exact protected-main commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Guard protected main before signing container images
+        run: |
+          VERSION_NO_V=${RELEASE_VERSION#v}
+          git fetch origin main --tags
+          test "$(git rev-parse HEAD)" = "${{ github.sha }}"
+          git merge-base --is-ancestor "${{ github.sha }}" origin/main
+          grep -Fxq "version = \"$VERSION_NO_V\"" pyproject.toml
+          grep -Fxq "__version__ = \"$VERSION_NO_V\"" mcp_server/__init__.py
+
+      - name: Sign the published container image (keyless)
+        env:
+          REF_NAME: ${{ inputs.version }}
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          IMAGE_DIGEST=$(docker buildx imagetools inspect \
+            "${IMAGE}:${REF_NAME}" --format '{{.Manifest.Digest}}')
+          cosign sign --yes "${IMAGE}@${IMAGE_DIGEST}"

--- a/tests/test_localci_workflow_posture.py
+++ b/tests/test_localci_workflow_posture.py
@@ -15,6 +15,7 @@ EXPECTED_CLASSIFICATIONS = {
     "maintenance.yml": "offloaded",
     "mcp-index.yml": "manual-only",
     "release-automation.yml": "manual-only",
+    "sign-published-image.yml": "manual-only",
 }
 
 


### PR DESCRIPTION
Leftover from the release: `v1.4.0`'s image published **before** signing moved into the release job (#94), so it has no cosign signature. Keyless cosign needs the Actions OIDC identity, so this can't be done off-CI — a `workflow_dispatch` job that signs an already-published tag.

- Resolves the tag's digest with `docker buildx imagetools inspect` and `cosign sign --yes` (keyless).
- Guarded by the same protected-main check the release mutations use (the exact-version `pyproject`/`__init__` assertions mean an arbitrary dispatch input fails closed) — satisfies `test_workflow_release_policy`.
- Classified `manual-only` + registered in `test_localci_workflow_posture`.
- Reusable for any future image needing (re-)signing.

**Verification:** actionlint clean; 26 workflow-policy/posture/contract tests pass. After merge I'll dispatch it for `v1.4.0` and confirm a `.sig` tag appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/Code-Index-MCP/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->